### PR TITLE
디저트메이트 생성, 상세 조회 api 구현

### DIFF
--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.mate.dto.request.MateCreateRequest;
 import org.swyp.dessertbee.mate.dto.response.MateDetailResponse;
 import org.swyp.dessertbee.mate.service.MateService;
+import org.swyp.dessertbee.store.dto.response.StoreDetailResponse;
 
 import java.util.List;
 
@@ -28,4 +29,9 @@ public class MateController {
          return ResponseEntity.status(HttpStatus.CREATED).body(mateService.createMate(request, mateImageFiles));
      }
 
+     /** 메이트 상세 정보 조회 */
+     @GetMapping("/{mateId}/details")
+    public MateDetailResponse getMateDetails(@PathVariable Long mateId){
+         return mateService.getMateDetails(mateId);
+     }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -1,0 +1,31 @@
+package org.swyp.dessertbee.mate.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.mate.dto.request.MateCreateRequest;
+import org.swyp.dessertbee.mate.dto.response.MateDetailResponse;
+import org.swyp.dessertbee.mate.service.MateService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/mates")
+@RequiredArgsConstructor
+public class MateController {
+
+    private final MateService mateService;
+
+    /** 메이트 등록 */
+     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<MateDetailResponse> createMate(@RequestPart("request") @Valid MateCreateRequest request,
+                                                         @RequestPart(value = "mateImageFiles", required = false) List<MultipartFile> mateImageFiles){
+         return ResponseEntity.status(HttpStatus.CREATED).body(mateService.createMate(request, mateImageFiles));
+     }
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/dto/request/MateCreateRequest.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/request/MateCreateRequest.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class MateCreateRequest {
     private Boolean recruitYn;
 
 
-    private List<String> mateImage; //모임 대표 이미지
+    private List<MultipartFile> mateImage; //모임 대표 이미지
 
 
 }

--- a/src/main/java/org/swyp/dessertbee/mate/dto/request/MateCreateRequest.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/request/MateCreateRequest.java
@@ -1,0 +1,35 @@
+package org.swyp.dessertbee.mate.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MateCreateRequest {
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    private Long mateCategoryId;
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String content;
+
+    private Boolean recruitYn;
+
+
+    private List<String> mateImage; //모임 대표 이미지
+
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
@@ -1,0 +1,40 @@
+package org.swyp.dessertbee.mate.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.swyp.dessertbee.mate.entity.Mate;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class MateDetailResponse {
+
+    private Long mateId;
+    private Long userId;
+    private String title;
+    private String content;
+    private Boolean recruitYn;
+    private List<String> mateImage;
+
+    //디저트메이트 카테고리명
+    private String mateCategoryId;
+
+    public static MateDetailResponse fromEntity(Mate mate,
+                                                List<String> mateImage,
+                                                String category){
+
+        return MateDetailResponse.builder()
+                .mateId(mate.getMateId())
+                .userId(mate.getUserId())
+                .title(mate.getTitle())
+                .content(mate.getContent())
+                .recruitYn(mate.getRecruitYn())
+                .mateImage(mateImage)
+                .mateCategoryId(category)
+                .build();
+    }
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
@@ -1,0 +1,54 @@
+package org.swyp.dessertbee.mate.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="mate")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Mate {
+
+    @Id
+    @Column(name = "mate_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long mateId;    //메이트 고유 id
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "mate_category_id")
+    private Long mateCategoryId; //메이트 카테고리(ex:친목,빵지순례 등등)
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "recruit_yn")
+    private Boolean recruitYn;  //메이트 현재 모집 여부
+
+    @Column(nullable = true, length = 255)
+    private String report;
+
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateCategory.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateCategory.java
@@ -1,0 +1,22 @@
+package org.swyp.dessertbee.mate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "mate_category")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MateCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mate_category_id")
+    private Long mateCategoryId; // 카테고리 고유번호
+
+
+    @Column(nullable = false, length = 100)
+    private String name; //카테고리 이름
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateMember.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateMember.java
@@ -1,0 +1,32 @@
+package org.swyp.dessertbee.mate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mate_member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MateMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mate_member_id")
+    private Long mateMemberId;  //메이트 멤버 고유 id
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(nullable = false, length = 45)
+    private String grade;
+
+    @Column(name = "approval_yn")
+    private  Boolean approvalYn;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateStatistics.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateStatistics.java
@@ -1,0 +1,34 @@
+package org.swyp.dessertbee.mate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "mate_statistics")
+public class MateStatistics {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mate_statistics_id")
+    private Long mateStatisticsId;
+
+    @Column(name = "mate_id")
+    private Long mateId;
+    private Integer views;
+    private Integer saves;
+    private Integer reviews;
+    private LocalDate createDate;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/SavedMate.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/SavedMate.java
@@ -1,0 +1,33 @@
+package org.swyp.dessertbee.mate.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "saved_mate")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavedMate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mate_id")
+    private Long mateId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateCategoryRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateCategoryRepository.java
@@ -1,12 +1,17 @@
 package org.swyp.dessertbee.mate.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.swyp.dessertbee.mate.entity.MateCategory;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MateCategoryRepository extends JpaRepository<MateCategory, Long> {
 
     //주어진 카테고리 ID로 해당 카테고리 이름 조회
-    Optional<MateCategory> findById(Long mateCategoryid);
+    @Query("SELECT DISTINCT mc.name FROM MateCategory mc JOIN Mate m ON mc.mateCategoryId = m.mateCategoryId WHERE mc.mateCategoryId = :mateCategoryId" )
+    String findCategoryNameById(@Param("mateCategoryId") Long mateCategoryId);
 }
+

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateCategoryRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateCategoryRepository.java
@@ -1,0 +1,12 @@
+package org.swyp.dessertbee.mate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swyp.dessertbee.mate.entity.MateCategory;
+
+import java.util.Optional;
+
+public interface MateCategoryRepository extends JpaRepository<MateCategory, Long> {
+
+    //주어진 카테고리 ID로 해당 카테고리 이름 조회
+    Optional<MateCategory> findById(Long mateCategoryid);
+}

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
@@ -1,0 +1,9 @@
+package org.swyp.dessertbee.mate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swyp.dessertbee.mate.entity.Mate;
+
+public interface MateRepository extends JpaRepository<Mate, Long> {
+
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -52,24 +52,22 @@ public class MateService {
     public MateDetailResponse getMateDetails(Long mateId) {
         Mate mate;
 
-
         Optional<Mate> optionalMate = mateRepository.findById(mateId);
+
 
         if(optionalMate.isPresent()) {
             mate =  optionalMate.get();
         }else {
             throw new IllegalArgumentException("존재하지 않는 디저트메이트입니다.");
-
         }
-
 
         //디저트메이트 사진 조회
         List<String> mateImage = imageService.getImagesByTypeAndId(ImageType.MATE, mateId);
 
+        //mateCategoryId로 name 조회
+        String mateCategory = String.valueOf(mateCategoryRepository.findCategoryNameById( mate.getMateCategoryId()));
 
-        String mateCategory = String.valueOf(mateCategoryRepository.findById( mate.getMateCategoryId()));
-
-        return MateDetailResponse.fromEntity(mate,mateImage, mateCategory);
+        return MateDetailResponse.fromEntity(mate, mateImage, mateCategory);
 
     }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -1,0 +1,75 @@
+package org.swyp.dessertbee.mate.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.common.entity.ImageType;
+import org.swyp.dessertbee.common.service.ImageService;
+import org.swyp.dessertbee.mate.dto.request.MateCreateRequest;
+import org.swyp.dessertbee.mate.dto.response.MateDetailResponse;
+import org.swyp.dessertbee.mate.entity.Mate;
+import org.swyp.dessertbee.mate.repository.MateCategoryRepository;
+import org.swyp.dessertbee.mate.repository.MateRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MateService {
+
+    private final MateRepository mateRepository;
+    private final MateCategoryRepository mateCategoryRepository;
+    private final ImageService imageService;
+
+
+    /** 가게 등록 */
+    public MateDetailResponse createMate(MateCreateRequest request, List<MultipartFile> mateImageFiles) {
+
+        Mate mate = mateRepository.save(
+                Mate.builder()
+                        .userId(request.getUserId())
+                        .mateCategoryId(request.getMateCategoryId())
+                        .title(request.getTitle())
+                        .content(request.getContent())
+                        .recruitYn(Boolean.TRUE.equals(request.getRecruitYn()))
+                        .build()
+        );
+
+        // 가게 대표 사진 S3 업로드 및 저장
+        if (mateImageFiles != null && !mateImageFiles.isEmpty()) {
+            String folder = "mate/" + mate.getMateId();
+            imageService.uploadAndSaveImages(mateImageFiles, ImageType.MATE, mate.getMateId(), folder);
+        }
+        return getMateDetails(mate.getMateId());
+    }
+
+
+    /** 메이트 상세 정보 */
+    public MateDetailResponse getMateDetails(Long mateId) {
+        Mate mate;
+
+
+        Optional<Mate> optionalMate = mateRepository.findById(mateId);
+
+        if(optionalMate.isPresent()) {
+            mate =  optionalMate.get();
+        }else {
+            throw new IllegalArgumentException("존재하지 않는 디저트메이트입니다.");
+
+        }
+
+
+        //디저트메이트 사진 조회
+        List<String> mateImage = imageService.getImagesByTypeAndId(ImageType.MATE, mateId);
+
+
+        String mateCategory = String.valueOf(mateCategoryRepository.findById( mate.getMateCategoryId()));
+
+        return MateDetailResponse.fromEntity(mate,mateImage, mateCategory);
+
+    }
+}


### PR DESCRIPTION
## :hash: 연관된 이슈

> 8

## :memo: 작업 내용

> 디저트메이트 엔터디,dto 구현
> 디저트메이트 생성 api 구현 (아직 멤버 신청 부분 만들지 않아서 인원 제한 로직 없음 추후 만들 예정)
> 디저트메이트 상세 조회 api 구현

## :speech_balloon: 리뷰 요구사항(선택)

> 테스트코드를 작성하다가 테스트 코드에서 버그가 나서 빼고 postman으로 테스트 했습니다.
> 확인 후 피드백 부탁드립니다!