### PR TITLE
Feat/14 email verify api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'jakarta.mail:jakarta.mail-api'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,12 +45,19 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'jakarta.mail:jakarta.mail-api'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'io.github.cdimascio:dotenv-java:3.1.0'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/swyp/dessertbee/config/EmailConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/EmailConfig.java
@@ -1,0 +1,48 @@
+package org.swyp.dessertbee.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+/**
+ * 이메일 설정을 위한 Configuration 클래스
+ * JavaMailSender를 설정하고 SMTP 속성을 정의
+ */
+@Configuration
+public class EmailConfig {
+
+    /**
+     * JavaMailSender Bean 설정
+     * @param host SMTP 서버 호스트
+     * @param port SMTP 서버 포트
+     * @param username 이메일 계정
+     * @param password 앱 비밀번호
+     * @return 설정된 JavaMailSender 인스턴스
+     */
+    @Bean
+    public JavaMailSender javaMailSender(
+            @Value("${spring.mail.host}") String host,
+            @Value("${spring.mail.port}") int port,
+            @Value("${spring.mail.username}") String username,
+            @Value("${spring.mail.password}") String password
+    ) {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        // SMTP 프로토콜 설정
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");  // 디버깅 활성화
+
+        return mailSender;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/config/ThymeleafConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/ThymeleafConfig.java
@@ -1,0 +1,40 @@
+package org.swyp.dessertbee.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
+import org.thymeleaf.templatemode.TemplateMode;
+
+/**
+ * 이메일 템플릿 엔진 설정을 위한 Configuration
+ */
+@Configuration
+public class ThymeleafConfig {
+
+    /**
+     * Thymeleaf 템플릿 엔진 Bean 생성
+     * HTML 이메일 템플릿을 처리하기 위한 설정
+     */
+    @Bean
+    public SpringTemplateEngine springTemplateEngine() {
+        SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(htmlTemplateResolver());
+        return templateEngine;
+    }
+
+    /**
+     * HTML 템플릿 리졸버 설정
+     * 템플릿 파일의 위치, 형식, 캐시 설정 등을 정의
+     */
+    @Bean
+    public SpringResourceTemplateResolver htmlTemplateResolver() {
+        SpringResourceTemplateResolver resolver = new SpringResourceTemplateResolver();
+        resolver.setPrefix("classpath:/templates/mail/");  // 템플릿 파일 위치
+        resolver.setSuffix(".html");  // 템플릿 파일 확장자
+        resolver.setTemplateMode(TemplateMode.HTML);  // HTML 모드로 설정
+        resolver.setCharacterEncoding("UTF-8");  // 인코딩 설정
+        resolver.setCacheable(false);  // 개발 환경에서는 캐시 비활성화
+        return resolver;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/email/controller/EmailVerificationController.java
+++ b/src/main/java/org/swyp/dessertbee/email/controller/EmailVerificationController.java
@@ -1,0 +1,63 @@
+package org.swyp.dessertbee.email.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.swyp.dessertbee.email.dto.EmailVerificationRequestDto;
+import org.swyp.dessertbee.email.dto.EmailVerificationResponseDto;
+import org.swyp.dessertbee.email.dto.EmailVerifyRequestDto;
+import org.swyp.dessertbee.email.dto.EmailVerifyResponseDto;
+import org.swyp.dessertbee.email.service.EmailVerificationService;
+import org.swyp.dessertbee.email.service.EmailVerificationServiceImpl;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * 이메일 인증 관련 API Controller
+ */
+@RestController
+@RequestMapping("/api/auth/email")
+@RequiredArgsConstructor
+@Slf4j
+public class EmailVerificationController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    /**
+     * 이메일 인증 코드 발송 API
+     */
+    @PostMapping("/verification-request")
+    public ResponseEntity<EmailVerificationResponseDto> requestVerification(
+            @Valid @RequestBody EmailVerificationRequestDto request
+    ) {
+        EmailVerificationResponseDto response =
+                emailVerificationService.sendVerificationEmail(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 이메일 인증 코드 확인 API
+     */
+    @PostMapping("/verify")
+    public ResponseEntity<EmailVerifyResponseDto> verifyEmail(
+            @Valid @RequestBody EmailVerifyRequestDto request
+    ) {
+        EmailVerifyResponseDto response =
+                emailVerificationService.verifyEmail(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 이메일 인증 관련 예외 처리
+     */
+    @ExceptionHandler(EmailVerificationServiceImpl.InvalidVerificationException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidVerification(EmailVerificationServiceImpl.InvalidVerificationException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Collections.singletonMap("message", e.getMessage()));
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/email/dto/EmailVerificationRequestDto.java
+++ b/src/main/java/org/swyp/dessertbee/email/dto/EmailVerificationRequestDto.java
@@ -1,0 +1,30 @@
+package org.swyp.dessertbee.email.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
+
+/**
+ * 이메일 검증 요청을 위한 DTO
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerificationRequestDto {
+
+    /**
+     * 검증할 이메일 주소
+     */
+    @Email(message = "유효한 이메일 주소를 입력해주세요.")
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    private String email;
+
+    /**
+     * 이메일 검증 목적 (SIGNUP 또는 PASSWORD_RESET)
+     */
+    @NotNull(message = "검증 목적은 필수 입력값입니다.")
+    private EmailVerificationPurpose purpose;
+}

--- a/src/main/java/org/swyp/dessertbee/email/dto/EmailVerificationResponseDto.java
+++ b/src/main/java/org/swyp/dessertbee/email/dto/EmailVerificationResponseDto.java
@@ -1,0 +1,24 @@
+package org.swyp.dessertbee.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 이메일 검증 요청에 대한 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class EmailVerificationResponseDto {
+
+    /**
+     * 사용자에게 보여줄 메시지
+     */
+    private String message;
+
+    /**
+     * 인증 코드 만료 시간 (분)
+     */
+    private int expirationMinutes;
+}

--- a/src/main/java/org/swyp/dessertbee/email/dto/EmailVerifyRequestDto.java
+++ b/src/main/java/org/swyp/dessertbee/email/dto/EmailVerifyRequestDto.java
@@ -1,0 +1,35 @@
+package org.swyp.dessertbee.email.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerifyRequestDto {
+
+    /**
+     * 검증할 이메일 주소
+     */
+    @Email(message = "유효한 이메일 주소를 입력해주세요.")
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    private String email;
+
+    /**
+     * 사용자가 입력한 인증 코드
+     */
+    @NotBlank(message = "인증 코드는 필수 입력값입니다.")
+    @Size(min = 6, max = 6, message = "인증 코드는 6자리여야 합니다.")
+    private String code;
+
+    /**
+     * 이메일 검증 목적
+     */
+    @NotNull(message = "검증 목적은 필수 입력값입니다.")
+    private EmailVerificationPurpose purpose;
+}

--- a/src/main/java/org/swyp/dessertbee/email/dto/EmailVerifyResponseDto.java
+++ b/src/main/java/org/swyp/dessertbee/email/dto/EmailVerifyResponseDto.java
@@ -1,0 +1,22 @@
+package org.swyp.dessertbee.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class EmailVerifyResponseDto {
+
+    /**
+     * 이메일 검증 성공 여부
+     */
+    private boolean isVerified;
+
+    /**
+     * 검증 완료 시 발급되는 JWT 토큰 (30분 유효)
+     */
+    private String verificationToken;
+}
+

--- a/src/main/java/org/swyp/dessertbee/email/entity/EmailVerificationEntity.java
+++ b/src/main/java/org/swyp/dessertbee/email/entity/EmailVerificationEntity.java
@@ -34,11 +34,14 @@ public class EmailVerificationEntity {
     private boolean verified;
 
     @CreatedDate
-    @Column(nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false, name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "expires_at")
     private LocalDateTime expiresAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;  // soft delete 컬럼 추가
 
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(expiresAt);

--- a/src/main/java/org/swyp/dessertbee/email/entity/EmailVerificationEntity.java
+++ b/src/main/java/org/swyp/dessertbee/email/entity/EmailVerificationEntity.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.auth.entity;
+package org.swyp.dessertbee.email.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/org/swyp/dessertbee/email/entity/EmailVerificationPurpose.java
+++ b/src/main/java/org/swyp/dessertbee/email/entity/EmailVerificationPurpose.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.auth.entity;
+package org.swyp.dessertbee.email.entity;
 
 public enum EmailVerificationPurpose {
     SIGNUP("회원가입"),

--- a/src/main/java/org/swyp/dessertbee/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/org/swyp/dessertbee/email/repository/EmailVerificationRepository.java
@@ -1,10 +1,14 @@
 package org.swyp.dessertbee.email.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.email.entity.EmailVerificationEntity;
 import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -26,4 +30,28 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
             String code,
             EmailVerificationPurpose purpose
     );
+
+    /**
+     * 특정 이메일의 최근 인증 요청 횟수를 조회
+     * soft delete되지 않은 레코드만 계산
+     * @param email 조회할 이메일 주소
+     * @param since 조회 시작 시간
+     * @return 해당 기간 동안의 인증 요청 횟수
+     */
+    @Query("SELECT COUNT(e) FROM EmailVerificationEntity e WHERE e.email = :email " +
+            "AND e.createdAt > :since AND e.deletedAt IS NULL")
+    long countRecentVerificationRequests(
+            @Param("email") String email,
+            @Param("since") LocalDateTime since
+    );
+
+    /**
+     * 지정된 시간 이전의 레코드들을 soft delete 처리
+     * 이미 soft delete된 레코드는 제외
+     * @param before 이 시간 이전의 레코드들이 soft delete 처리되는 겁니다
+     */
+    @Modifying
+    @Query("UPDATE EmailVerificationEntity e SET e.deletedAt = CURRENT_TIMESTAMP " +
+            "WHERE e.createdAt < :before AND e.deletedAt IS NULL")
+    void softDeleteOldRecords(@Param("before") LocalDateTime before);
 }

--- a/src/main/java/org/swyp/dessertbee/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/org/swyp/dessertbee/email/repository/EmailVerificationRepository.java
@@ -1,0 +1,29 @@
+package org.swyp.dessertbee.email.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.email.entity.EmailVerificationEntity;
+import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailVerificationRepository extends JpaRepository<EmailVerificationEntity, Long> {
+
+    /**
+     * 이메일, 목적으로 가장 최근 검증 정보 조회
+     */
+    Optional<EmailVerificationEntity> findFirstByEmailAndPurposeOrderByCreatedAtDesc(
+            String email,
+            EmailVerificationPurpose purpose
+    );
+
+    /**
+     * 이메일, 코드, 목적으로 검증 정보 조회
+     */
+    Optional<EmailVerificationEntity> findByEmailAndCodeAndPurpose(
+            String email,
+            String code,
+            EmailVerificationPurpose purpose
+    );
+}

--- a/src/main/java/org/swyp/dessertbee/email/service/EmailVerificationService.java
+++ b/src/main/java/org/swyp/dessertbee/email/service/EmailVerificationService.java
@@ -1,0 +1,18 @@
+package org.swyp.dessertbee.email.service;
+
+import org.swyp.dessertbee.email.dto.EmailVerificationRequestDto;
+import org.swyp.dessertbee.email.dto.EmailVerificationResponseDto;
+import org.swyp.dessertbee.email.dto.EmailVerifyRequestDto;
+import org.swyp.dessertbee.email.dto.EmailVerifyResponseDto;
+
+public interface EmailVerificationService {
+    /**
+     * 이메일 인증 코드 생성 및 발송
+     */
+    EmailVerificationResponseDto sendVerificationEmail(EmailVerificationRequestDto request);
+
+    /**
+     * 이메일 인증 코드 확인
+     */
+    EmailVerifyResponseDto verifyEmail(EmailVerifyRequestDto request);
+}

--- a/src/main/java/org/swyp/dessertbee/email/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/email/service/EmailVerificationServiceImpl.java
@@ -1,0 +1,122 @@
+package org.swyp.dessertbee.email.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.auth.jwt.JWTUtil;
+import org.swyp.dessertbee.email.dto.EmailVerificationRequestDto;
+import org.swyp.dessertbee.email.dto.EmailVerificationResponseDto;
+import org.swyp.dessertbee.email.dto.EmailVerifyRequestDto;
+import org.swyp.dessertbee.email.dto.EmailVerifyResponseDto;
+import org.swyp.dessertbee.email.entity.EmailVerificationEntity;
+import org.swyp.dessertbee.email.repository.EmailVerificationRepository;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailVerificationServiceImpl implements EmailVerificationService {
+
+    private final JavaMailSender emailSender;
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final JWTUtil jwtUtil;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    // 인증 코드 만료 시간 (분)
+    private static final int VERIFICATION_CODE_EXPIRY_MINUTES = 5;
+
+    @Override
+    @Transactional
+    public EmailVerificationResponseDto sendVerificationEmail(EmailVerificationRequestDto request) {
+        String verificationCode = generateVerificationCode();
+
+        // 이메일 인증 정보 저장
+        EmailVerificationEntity verification = EmailVerificationEntity.builder()
+                .email(request.getEmail())
+                .code(verificationCode)
+                .purpose(request.getPurpose())
+                .verified(false)
+                .expiresAt(LocalDateTime.now().plusMinutes(5))
+                .build();
+
+        emailVerificationRepository.save(verification);
+
+        // 이메일 발송
+        sendEmail(request.getEmail(), verificationCode);
+
+        return EmailVerificationResponseDto.builder()
+                .message("인증 코드가 발송되었습니다.")
+                .expirationMinutes(5)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public EmailVerifyResponseDto verifyEmail(EmailVerifyRequestDto request) {
+        // 이메일 검증 정보 조회
+        EmailVerificationEntity verification = emailVerificationRepository
+                .findByEmailAndCodeAndPurpose(request.getEmail(), request.getCode(), request.getPurpose())
+                .orElseThrow(() -> new InvalidVerificationException("유효하지 않은 인증 코드입니다."));
+
+        // 만료 여부 확인
+        if (verification.isExpired()) {
+            throw new InvalidVerificationException("만료된 인증 코드입니다.");
+        }
+
+        // 이미 검증된 코드인지 확인
+        if (verification.isVerified()) {
+            throw new InvalidVerificationException("이미 사용된 인증 코드입니다.");
+        }
+
+        // 검증 완료 처리
+        verification.verify();
+
+        // 인증 토큰 생성
+        String verificationToken = jwtUtil.createEmailVerificationToken(
+                request.getEmail(),
+                request.getPurpose()
+        );
+
+        return EmailVerifyResponseDto.builder()
+                .isVerified(true)
+                .verificationToken(verificationToken)
+                .build();
+    }
+
+
+    /**
+     * 6자리 랜덤 인증 코드 생성
+     */
+    private String generateVerificationCode() {
+        Random random = new Random();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+
+    /**
+     * 인증 이메일 발송
+     */
+    private void sendEmail(String toEmail, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromEmail);
+        message.setTo(toEmail);
+        message.setSubject("이메일 인증 코드");
+        message.setText("인증 코드: " + code + "\n" +
+                "유효시간은 5분입니다.");
+
+        emailSender.send(message);
+    }
+
+    public static class InvalidVerificationException extends RuntimeException {
+        public InvalidVerificationException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/preference/entity/PreferenceEntity.java
+++ b/src/main/java/org/swyp/dessertbee/preference/entity/PreferenceEntity.java
@@ -1,0 +1,30 @@
+package org.swyp.dessertbee.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "preference")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PreferenceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "preference_name", length = 50, nullable = false)
+    private String preferenceName;
+
+    @Column(name = "preference_desc", length = 200)
+    private String preferenceDesc;
+
+    @OneToMany(mappedBy = "preference", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UserPreferenceEntity> userPreferences = new HashSet<>();
+}
+

--- a/src/main/java/org/swyp/dessertbee/preference/entity/UserPreferenceEntity.java
+++ b/src/main/java/org/swyp/dessertbee/preference/entity/UserPreferenceEntity.java
@@ -1,0 +1,27 @@
+package org.swyp.dessertbee.preference.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.swyp.dessertbee.user.entity.UserEntity;
+
+@Entity
+@Table(name = "user_preference")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserPreferenceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "preference_id", nullable = false)
+    private PreferenceEntity preference;
+}

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.swyp.dessertbee.auth.entity.AuthEntity;
+import org.swyp.dessertbee.preference.entity.UserPreferenceEntity;
 import org.swyp.dessertbee.role.entity.RoleEntity;
 import org.swyp.dessertbee.role.entity.UserRoleEntity;
 
@@ -81,6 +82,9 @@ public class UserEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AuthEntity> auths = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UserPreferenceEntity> userPreferences = new HashSet<>();
 
     public void addRole(RoleEntity role) {
         UserRoleEntity userRole = UserRoleEntity.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,17 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GOOGLE_MAIL_USERNAME}
+    password: ${GOOGLE_MAIL_APP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 logging:
   level:
     org:

--- a/src/main/resources/templates/mail/verification-email.html
+++ b/src/main/resources/templates/mail/verification-email.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${serviceName} + ' 이메일 인증'">DessertBee 이메일 인증</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+<!-- 전체 컨테이너 -->
+<div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+    <!-- 헤더 영역: FFB6C1 -> FFD700 (골드 색상) -->
+    <div style="background-color: #FFD700; padding: 20px; text-align: center; border-radius: 10px;">
+        <h1 style="color: #333333; margin: 0;" th:text="${serviceName}">DessertBee</h1>
+    </div>
+
+    <!-- 본문 영역 -->
+    <div style="background-color: #ffffff; padding: 20px; margin-top: 20px; border: 1px solid #dee2e6; border-radius: 10px;">
+        <h2 style="color: #333333;">이메일 인증 코드</h2>
+        <p>안녕하세요. <span th:text="${serviceName}">DessertBee</span>입니다.</p>
+        <p>아래의 인증 코드를 입력해주세요.</p>
+
+        <!-- 인증 코드: FF69B4 -> DAA520 (골든로드 색상) -->
+        <div style="background-color: #FFF8DC; padding: 15px; text-align: center; margin: 20px 0; border-radius: 5px;">
+                <span style="font-size: 32px; font-weight: bold; letter-spacing: 3px; color: #DAA520;"
+                      th:text="${code}">123456</span>
+        </div>
+
+        <!-- 주의사항 -->
+        <p style="color: #666666; font-size: 14px;">
+            인증 코드는 <span th:text="${expirationMinutes}">5</span>분 동안 유효합니다.<br>
+            본인이 요청하지 않은 경우 이 메일을 무시하셔도 됩니다.
+        </p>
+    </div>
+
+    <!-- 푸터 영역 -->
+    <div style="margin-top: 20px; text-align: center; color: #999999; font-size: 12px;">
+        <p>본 메일은 발신전용입니다. 문의사항은 고객센터를 이용해주세요.</p>
+        <p>&copy; 2024 <span th:text="${serviceName}">DessertBee</span>. All rights reserved.</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## :hash: 연관된 이슈
#14 
## :memo: 작업 내용
이메일 검증 및 이메일 검증 요청 관련 API 를 작성하였습니다.
목적은 2가지 입니다.
- 비밀번호 초기화(PASSWORD_RESET)
- 회원가입(SIGN_UP)
검증 후 토큰이 발급 되는 것은 해당 토큰의 유효 기간(30분) 동안 회원가입 및 비밀번호 변경을 진행하라는 의미입니다.

### 스크린샷 (선택)
![스크린샷 2025-02-05 오전 2 02 12](https://github.com/user-attachments/assets/065eb1b9-32eb-4b9a-b148-4ac1ce9b4746)
<img width="828" alt="스크린샷 2025-02-05 오전 1 59 56" src="https://github.com/user-attachments/assets/70c2dd24-aee4-4d0f-a5db-335e55fb600e" />
![스크린샷 2025-02-05 오전 2 01 58](https://github.com/user-attachments/assets/2dd973a0-6994-4c21-a707-76ee61a6c950)

## :speech_balloon: 리뷰 요구사항(선택)
- 이메일이 수신 및 검증이 되는지 확인해주세요.
- 테스트 코드는 로그인까지 구현 후에 작성하겠습니다.. 로그인 구현이 시급하여서
- 사실 디렉토리 구조에 대한 고민을 좀 했습니다. auth 안에 넣을지, email을 새로만들지에 대해서.. 어떻게 하는 것이 좋을까요 api 엔드포인트 경로 상 auth 가 붙어있기는 합니다
