### PR TITLE
[Feature] JWT관련 로그인, 회원가입, 로그아웃, 비밀번호 변경 구현 #21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ src/main/resources/.env*
 
 ### application-test.yml ###
 src/test/resources/application-test.yml
+**/.DS_Store
+.DS_Store

--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -9,16 +9,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.swyp.dessertbee.auth.dto.TokenRequest;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
+import org.swyp.dessertbee.auth.dto.login.LoginRequest;
+import org.swyp.dessertbee.auth.dto.login.LoginResponse;
+import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
+import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
+import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
+import org.swyp.dessertbee.auth.dto.signup.SignUpResponse;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.swyp.dessertbee.auth.service.AuthService;
-import org.swyp.dessertbee.user.dto.UserDTO;
-
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 @Tag(name = "Authentication", description = "인증 관련 API")
@@ -38,49 +41,68 @@ public class AuthController {
             @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
     })
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(
-            @Valid @RequestBody UserDTO.SignUpRequest request) {
-        //return authService.signup(request);
-        return null;
+    public ResponseEntity<SignUpResponse> signup(
+            @RequestHeader("X-Email-Verification-Token") String verificationToken,
+            @Valid @RequestBody SignUpRequest request
+    ) throws BadRequestException {
+        log.debug("회원가입 요청: {}", request.getEmail());
+
+        // 비밀번호 일치 여부 확인
+        if (!request.getPassword().equals(request.getConfirmPassword())) {
+            throw new BadRequestException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 회원가입 처리
+        SignUpResponse response = authService.signup(request, verificationToken);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공",
-                    content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = LoginResponse.class))
+            ),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(
-            @Valid @RequestBody UserDTO.LoginRequest request,
-            HttpServletResponse response) {
-        // return authService.login(request, response);
-        return null;
+    public ResponseEntity<LoginResponse> login(
+            @Parameter(description = "로그인 정보", required = true)
+            @Valid @RequestBody LoginRequest request
+    ) {
+        return ResponseEntity.ok(authService.login(request));
     }
 
-    @Operation(summary = "로그아웃", description = "현재 사용자를 로그아웃합니다.")
+    @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(
-            @RequestHeader("Authorization") String token) {
-        // return authService.logout(token);
-        return null;
+    public ResponseEntity<LogoutResponse> logout(
+            @Parameter(description = "JWT 액세스 토큰", required = true)
+            @RequestHeader("Authorization") String token
+    ) {
+        String accessToken = token.substring(7);
+        return ResponseEntity.ok(authService.logout(accessToken));
     }
 
     @Operation(summary = "비밀번호 재설정", description = "이메일 인증 후 비밀번호를 재설정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "비밀번호 재설정 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+            @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PostMapping("/password/reset")
     public ResponseEntity<?> resetPassword(
-            @Valid @RequestBody UserDTO.PasswordChangeRequest request) {
-        // return authService.resetPassword(request);
-        return null;
+            @Parameter(description = "이메일 인증 토큰", required = true)
+            @RequestHeader("X-Email-Verification-Token") String verificationToken,
+            @Parameter(description = "비밀번호 재설정 정보", required = true)
+            @Valid @RequestBody PasswordResetRequest request
+    ) {
+        authService.resetPassword(request, verificationToken);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "토큰 재발급", description = "Refresh 토큰을 사용하여 새로운 Access 토큰을 발급받습니다.")

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuth2Controller.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuth2Controller.java
@@ -1,8 +1,5 @@
 package org.swyp.dessertbee.auth.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +8,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.swyp.dessertbee.auth.dto.LoginResponse;
 import org.swyp.dessertbee.auth.dto.OAuth2AuthorizationRequest;
-import org.swyp.dessertbee.auth.dto.OAuth2CallbackRequest;
 
 /**
  * OAuth2 인증 프로세스를 처리하는 컨트롤러

--- a/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginRequest.java
@@ -1,0 +1,16 @@
+package org.swyp.dessertbee.auth.dto.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    private String email;           // 사용자 이메일
+    private String password;        // 비밀번호
+    private boolean keepLoggedIn;   // 로그인 상태 유지 여부
+}

--- a/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
@@ -1,0 +1,51 @@
+package org.swyp.dessertbee.auth.dto.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.swyp.dessertbee.user.entity.UserEntity;
+
+import java.util.UUID;
+
+/**
+ * 로그인 응답을 위한 DTO 클래스
+ * 로그인 성공 시 JWT 토큰과 사용자 정보를 담아 반환
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;     // JWT 액세스 토큰
+    private UUID userUuid;          // 사용자 UUID
+    private String email;           // 사용자 이메일
+    private String nickname;        // 사용자 닉네임
+
+    /**
+     * 로그인 성공 응답 생성
+     * @param token JWT 액세스 토큰
+     * @param user 사용자 엔티티
+     * @return 로그인 응답 객체
+     */
+    public static LoginResponse success(String token, UserEntity user) {
+        return LoginResponse.builder()
+                .accessToken(token)
+                .userUuid(user.getUserUuid())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+
+    /**
+     * 토큰만 포함된 응답 생성
+     * 토큰 갱신 시 사용
+     * @param token JWT 액세스 토큰
+     * @return 로그인 응답 객체
+     */
+    public static LoginResponse withToken(String token) {
+        return LoginResponse.builder()
+                .accessToken(token)
+                .build();
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/dto/logout/LogoutRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/logout/LogoutRequest.java
@@ -1,0 +1,16 @@
+package org.swyp.dessertbee.auth.dto.logout;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogoutRequest {
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+}

--- a/src/main/java/org/swyp/dessertbee/auth/dto/logout/LogoutResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/logout/LogoutResponse.java
@@ -1,0 +1,20 @@
+package org.swyp.dessertbee.auth.dto.logout;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogoutResponse {
+    private String message;
+
+    public static LogoutResponse success() {
+        return LogoutResponse.builder()
+                .message("로그아웃이 완료되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/dto/passwordreset/PasswordResetRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/passwordreset/PasswordResetRequest.java
@@ -1,0 +1,31 @@
+package org.swyp.dessertbee.auth.dto.passwordreset;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 비밀번호 재설정 요청을 위한 DTO 클래스
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequest {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;            // 사용자 이메일
+
+    @NotBlank(message = "현재 비밀번호는 필수 입력값입니다.")
+    private String currentPassword;  // 현재 비밀번호
+
+    @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+            message = "비밀번호는 8자 이상, 영문자, 숫자, 특수문자를 포함해야 합니다."
+    )
+    private String newPassword;      // 새로운 비밀번호
+}

--- a/src/main/java/org/swyp/dessertbee/auth/dto/signup/SignUpRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/signup/SignUpRequest.java
@@ -1,0 +1,54 @@
+package org.swyp.dessertbee.auth.dto.signup;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.swyp.dessertbee.user.entity.UserEntity;
+
+import java.util.List;
+
+/**
+ * 회원가입 요청을 위한 DTO 클래스
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpRequest {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;           // 사용자 이메일
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+            message = "비밀번호는 8자 이상, 영문자, 숫자, 특수문자를 포함해야 합니다."
+    )
+    private String password;        // 비밀번호
+
+    @NotBlank(message = "비밀번호 확인은 필수 입력값입니다.")
+    private String confirmPassword; // 비밀번호 확인
+
+    @NotBlank(message = "닉네임은 필수 입력값입니다.")
+    @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
+    private String nickname;        // 닉네임
+
+    @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
+    private String name;            // 이름
+
+    @Pattern(
+            regexp = "^\\d{3}-\\d{3,4}-\\d{4}$",
+            message = "올바른 전화번호 형식이 아닙니다."
+    )
+    private String phoneNumber;     // 전화번호
+
+    @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다.")
+    private String address;         // 주소
+
+    private UserEntity.Gender gender; // 성별
+
+    private List<Long> preferenceIds; // 선호도 ID 목록
+}

--- a/src/main/java/org/swyp/dessertbee/auth/dto/signup/SignUpResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/signup/SignUpResponse.java
@@ -1,0 +1,23 @@
+package org.swyp.dessertbee.auth.dto.signup;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpResponse {
+    private String message;         // 결과 메시지
+    private String email;           // 가입된 이메일
+
+
+    public static SignUpResponse success(String email) {
+        return SignUpResponse.builder()
+                .message("회원가입이 완료되었습니다.")
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
@@ -1,0 +1,40 @@
+package org.swyp.dessertbee.auth.exception;
+
+public class AuthExceptions {
+
+    /**
+     * 인증 토큰 검증 실패시 발생하는 예외
+     */
+    public static class InvalidVerificationTokenException extends RuntimeException {
+        public InvalidVerificationTokenException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * 비밀번호 검증 실패시 발생하는 예외
+     */
+    public static class InvalidPasswordException extends RuntimeException {
+        public InvalidPasswordException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * 이메일 중복시 발생하는 예외
+     */
+    public static class DuplicateEmailException extends RuntimeException {
+        public DuplicateEmailException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * 잘못된 인증 정보 제공시 발생하는 예외
+     */
+    public static class InvalidCredentialsException extends RuntimeException {
+        public InvalidCredentialsException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 public class JWTFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
-    private final AuthService authService;
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";

--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JWTUtil.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JWTUtil.java
@@ -26,9 +26,13 @@ public class JWTUtil {
     private final SecretKey accessTokenSecretKey;
     private final SecretKey refreshTokenSecretKey;
 
-    private final long ACCESS_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L;       // 30분
-    private final long REFRESH_TOKEN_EXPIRE_TIME = 14 * 24 * 60 * 60 * 1000L;  // 14일
     private final long EMAIL_VERIFICATION_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L;
+
+    private final long SHORT_ACCESS_TOKEN_EXPIRE = 24 * 30 * 60 * 1000L;       // 1일
+    private final long LONG_ACCESS_TOKEN_EXPIRE = 3 * 24 * 60 * 60 * 1000L;   // 3일
+
+    private final long SHORT_REFRESH_TOKEN_EXPIRE = 10 * 24 * 60 * 60 * 1000L;   // 10일
+    private final long LONG_REFRESH_TOKEN_EXPIRE = 30 * 24 * 60 * 60 * 1000L;   // 30일
 
 
     public JWTUtil(
@@ -48,15 +52,17 @@ public class JWTUtil {
     /**
      * Access Token 생성
      */
-    public String createAccessToken(String email, List<String> roles) {
-        return createToken(email, roles, accessTokenSecretKey, ACCESS_TOKEN_EXPIRE_TIME);
+    public String createAccessToken(String email, List<String> roles, boolean keepLoggedIn) {
+        long expireTime = keepLoggedIn ? LONG_ACCESS_TOKEN_EXPIRE : SHORT_ACCESS_TOKEN_EXPIRE;
+        return createToken(email, roles, accessTokenSecretKey, expireTime);
     }
 
     /**
      * Refresh Token 생성
      */
-    public String createRefreshToken(String email, List<String> roles) {
-        return createToken(email, roles, refreshTokenSecretKey, REFRESH_TOKEN_EXPIRE_TIME);
+    public String createRefreshToken(String email, List<String> roles, boolean keepLoggedIn) {
+        long expireTime = keepLoggedIn ? LONG_REFRESH_TOKEN_EXPIRE : SHORT_REFRESH_TOKEN_EXPIRE;
+        return createToken(email, roles, refreshTokenSecretKey, expireTime);
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/org/swyp/dessertbee/auth/oauth2/CustomSuccessHandler.java
@@ -1,8 +1,6 @@
 package org.swyp.dessertbee.auth.oauth2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +12,10 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.swyp.dessertbee.auth.dto.CustomOAuth2User;
-import org.swyp.dessertbee.auth.dto.LoginResponse;
+import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.swyp.dessertbee.auth.service.AuthService;
+import org.swyp.dessertbee.auth.service.TokenService;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -36,7 +35,7 @@ import java.util.stream.Collectors;
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JWTUtil jwtUtil;
-    private final AuthService authService;
+    private final TokenService tokenService;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -73,11 +72,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .collect(Collectors.toList());
 
         // JWT 액세스 토큰 생성
-        String accessToken = jwtUtil.createAccessToken(email, roles);
+        String accessToken = jwtUtil.createAccessToken(email, roles, false);
 
         // 리프레시 토큰 생성 및 저장
-        String refreshToken = jwtUtil.createRefreshToken(email, roles);
-        authService.saveRefreshToken(email, refreshToken);
+        String refreshToken = jwtUtil.createRefreshToken(email, roles, false);
+        tokenService.saveRefreshToken(email, refreshToken);
 
         return LoginResponse.builder()
                 .accessToken(accessToken)

--- a/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
+++ b/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
@@ -7,5 +7,5 @@ import org.swyp.dessertbee.user.entity.UserEntity;
 import java.util.Optional;
 
 public interface AuthRepository extends JpaRepository<AuthEntity, Integer> {
-    Optional<AuthEntity> findByUserAndProvider(UserEntity user, String provider);
+    Optional<AuthEntity> findByUserAndProvider(Optional<UserEntity> user, String provider);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -1,7 +1,14 @@
 package org.swyp.dessertbee.auth.service;
 
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.auth.dto.login.LoginRequest;
+import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
-
+import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
+import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
+import org.swyp.dessertbee.auth.dto.signup.SignUpResponse;
+import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
+import org.swyp.dessertbee.auth.exception.AuthExceptions.*;
 /**
  * 인증 관련 서비스 인터페이스
  */
@@ -25,4 +32,40 @@ public interface AuthService {
      * @param email 사용자 이메일
      */
     void revokeRefreshToken(String email);
+
+    /**
+     * 회원가입 처리
+     * @param request 회원가입 요청 정보
+     * @param verificationToken 이메일 인증 토큰
+     * @return 회원가입 결과
+     * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
+     * @throws DuplicateEmailException 이메일 중복
+     */
+    SignUpResponse signup(SignUpRequest request, String verificationToken);
+
+
+    /**
+     * 로그인 처리
+     * @param request 로그인 요청 정보
+     * @return 로그인 응답 정보
+     * @throws InvalidCredentialsException 잘못된 인증 정보
+     */
+    LoginResponse login(LoginRequest request);
+
+    /**
+     * 비밀번호 재설정
+     * @param request 비밀번호 재설정 요청
+     * @param verificationToken 이메일 인증 토큰
+     * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
+     * @throws InvalidPasswordException 유효하지 않은 비밀번호
+     */
+    void resetPassword(PasswordResetRequest request, String verificationToken);
+
+    /**
+     * 로그아웃 처리
+     * @param token 로그인 요청 정보
+     * @return 로그인 응답 정보
+     * @throws InvalidCredentialsException 잘못된 인증 정보
+     */
+    LogoutResponse logout(String token);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -2,107 +2,209 @@ package org.swyp.dessertbee.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import org.swyp.dessertbee.auth.dto.TokenResponse;
-import org.swyp.dessertbee.auth.entity.AuthEntity;
+import org.swyp.dessertbee.auth.dto.login.LoginRequest;
+import org.swyp.dessertbee.auth.dto.login.LoginResponse;
+import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
+import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
+import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
+import org.swyp.dessertbee.auth.dto.signup.SignUpResponse;
+import org.swyp.dessertbee.auth.exception.AuthExceptions.*;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
-import org.swyp.dessertbee.auth.repository.AuthRepository;
+import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
+import org.swyp.dessertbee.role.entity.RoleEntity;
+import org.swyp.dessertbee.role.repository.RoleRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- * 인증 관련 서비스 구현체
- */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AuthServiceImpl implements AuthService {
 
-    private final AuthRepository authRepository;
     private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
     private final JWTUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private TokenService tokenService;
 
     @Override
-    @Transactional
-    public void saveRefreshToken(String email, String refreshToken) {
-        UserEntity user = userRepository.findByEmail(email);
-        if (user == null) {
-            throw new UsernameNotFoundException("User not found with email: " + email);
-        }
-
-        AuthEntity auth = authRepository.findByUserAndProvider(user, "local")
-                .orElse(AuthEntity.builder()
-                        .user(user)
-                        .provider("local")
-                        .build());
-
-        // 리프레시 토큰 만료 시간 설정 (14일)
-        LocalDateTime expiresAt = LocalDateTime.now().plusDays(14);
-
-        auth.updateRefreshToken(refreshToken, expiresAt);
-        authRepository.save(auth);
-
-        log.info("Refresh token saved for user: {}", email);
-    }
-
-    @Override
-    @Transactional
     public TokenResponse refreshAccessToken(String email) {
-        UserEntity user = userRepository.findByEmail(email);
-        if (user == null) {
-            throw new UsernameNotFoundException("User not found with email: " + email);
-        }
-
-        // DB에서 해당 유저의 리프레시 토큰 조회
-        AuthEntity auth = authRepository.findByUserAndProvider(user, "local")
-                .orElseThrow(() -> new InvalidTokenException("Refresh token not found"));
-
-        // 리프레시 토큰 유효성 검사
-        if (!auth.isActive() ||
-                auth.getRefreshToken() == null ||
-                auth.getRefreshTokenExpiresAt().isBefore(LocalDateTime.now())) {
-            throw new InvalidTokenException("Refresh token is expired or invalid");
-        }
-
-        // 새로운 액세스 토큰 발급
-        List<String> roles = user.getUserRoles().stream()
-                .map(userRole -> userRole.getRole().getName())
-                .collect(Collectors.toList());
-
-        String newAccessToken = jwtUtil.createAccessToken(email, roles);
-
-        return TokenResponse.builder()
-                .accessToken(newAccessToken)
-                .tokenType("Bearer")
-                .expiresIn(1800) // 30분
-                .build();
+        return tokenService.refreshAccessToken(email);
     }
-
 
     @Override
-    @Transactional
+    public void saveRefreshToken(String email, String refreshToken) {
+        tokenService.saveRefreshToken(email, refreshToken);
+    }
+
+    @Override
     public void revokeRefreshToken(String email) {
-        UserEntity user = userRepository.findByEmail(email);
-        if (user != null) {
-            authRepository.findByUserAndProvider(user, "local")
-                    .ifPresent(auth -> {
-                        auth.deactivate();
-                        authRepository.save(auth);
-                        log.info("Refresh token revoked for user: {}", email);
-                    });
+        tokenService.revokeRefreshToken(email);
+    }
+
+    /**
+     * 회원가입 처리
+     */
+    @Override
+    @Transactional
+    public SignUpResponse signup(SignUpRequest request, String verificationToken) {
+        try {
+            // 메일 인증 토큰 검증
+            validateEmailVerificationToken(verificationToken, request.getEmail(), EmailVerificationPurpose.SIGNUP);
+
+            // 이메일 중복 검사
+            if (userRepository.existsByEmail(request.getEmail())) {
+                throw new DuplicateEmailException("이미 등록된 이메일입니다.");
+            }
+
+            // 비밀번호 일치 여부 확인
+            if (!request.getPassword().equals(request.getConfirmPassword())) {
+                throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
+            }
+
+            // UserEntity 생성
+            UserEntity user = UserEntity.builder()
+                    .email(request.getEmail())
+                    .password(passwordEncoder.encode(request.getPassword()))
+                    .nickname(request.getNickname())
+                    .name(request.getName())
+                    .phoneNumber(request.getPhoneNumber())
+                    .address(request.getAddress())
+                    .gender(request.getGender())
+                    .build();
+
+            // 기본 사용자 권한(ROLE_USER) 설정
+            RoleEntity userRole = roleRepository.findByName("ROLE_USER")
+                    .orElseThrow(() -> new RuntimeException("기본 권한이 설정되어 있지 않습니다."));
+            user.addRole(userRole);
+
+            // 사용자 정보 저장
+            userRepository.save(user);
+            log.info("회원가입 완료 - 이메일: {}", request.getEmail());
+
+            return SignUpResponse.success(request.getEmail());
+
+        } catch (Exception e) {
+            log.error("회원가입 실패 - 이메일: {}, 에러: {}", request.getEmail(), e.getMessage());
+            throw e;
         }
     }
 
-    public static class InvalidTokenException extends RuntimeException {
-        public InvalidTokenException(String message) {
-            super(message);
+    /**
+     * 로그인 처리
+     * 1. 사용자 인증
+     * 2. JWT 토큰 생성
+     */
+    @Override
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        try {
+            // 1. 사용자 조회
+            UserEntity user = userRepository.findByEmail(request.getEmail())
+                    .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
+
+            // 2. 비밀번호 검증
+            if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+                throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
+            }
+
+            // 3. 사용자 권한 조회
+            List<String> roles = user.getUserRoles().stream()
+                    .map(userRole -> userRole.getRole().getName())
+                    .collect(Collectors.toList());
+
+            // 4. Access Token, Refresh Token 생성
+            String accessToken = jwtUtil.createAccessToken(user.getEmail(), roles, request.isKeepLoggedIn());
+            String refreshToken = jwtUtil.createRefreshToken(user.getEmail(), roles, request.isKeepLoggedIn());
+
+            // 5. Refresh Token 저장
+            saveRefreshToken(user.getEmail(), refreshToken);
+
+            // 7. 로그인 응답 생성
+            return LoginResponse.success(accessToken, user);
+
+        } catch (InvalidCredentialsException e) {
+            log.warn("로그인 실패 - 이메일: {}, 사유: {}", request.getEmail(), e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            log.error("로그인 처리 중 오류 발생 - 이메일: {}", request.getEmail(), e);
+            throw new RuntimeException("로그인 처리 중 오류가 발생했습니다.", e);
         }
     }
 
+    /**
+     * 비밀번호 재설정
+     * 이메일 인증이 완료된 사용자의 비밀번호 변경
+     *
+     * 1. 이메일 검증 토큰에서 사용자 이메일 추출
+     * 2. 사용자 존재 확인
+     * 3. 새 비밀번호 암호화 및 업데이트
+     * 4. 기존 토큰 무효화 (로그아웃)
+     */
+    @Override
+    @Transactional
+    public void resetPassword(PasswordResetRequest request, String verificationToken) {
+        // 토큰 유효성 검사
+        validateEmailVerificationToken(verificationToken, request.getEmail(), EmailVerificationPurpose.PASSWORD_RESET);
+
+        // 사용자 조회
+        UserEntity user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 새 비밀번호 암호화 및 저장
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        userRepository.save(user);
+
+        // 로그아웃 처리 (기존 토큰 무효화)
+        revokeRefreshToken(request.getEmail());
+
+        log.info("비밀번호 재설정 완료 - 이메일: {}", request.getEmail());
+    }
+
+    /**
+     * 로그아웃 처리
+     * 사용자의 리프레시 토큰을 무효화
+     *
+     * 1. 액세스 토큰에서 이메일 추출
+     * 2. 리프레시 토큰 무효화
+     *
+     * @param token 액세스 토큰
+     * @return 로그아웃 응답
+     */
+    @Transactional
+    @Override
+    public LogoutResponse logout(String token) {
+        String email = jwtUtil.getEmail(token, true);
+        revokeRefreshToken(email);
+        return LogoutResponse.success();
+    }
+
+    private void validateEmailVerificationToken(String token, String requestEmail, EmailVerificationPurpose expectedPurpose) {
+        if (!jwtUtil.validateToken(token, true)) {
+            throw new InvalidVerificationTokenException("만료되거나 유효하지 않은 인증 토큰입니다.");
+        }
+
+        String verifiedEmail = jwtUtil.getEmail(token, true);
+        EmailVerificationPurpose purpose = jwtUtil.getVerificationPurpose(token);
+
+        if (!verifiedEmail.equals(requestEmail)) {
+            throw new InvalidVerificationTokenException("인증된 이메일과 요청한 이메일이 일치하지 않습니다.");
+        }
+
+        if (purpose != expectedPurpose) {
+            throw new InvalidVerificationTokenException("유효하지 않은 인증 토큰입니다.");
+        }
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/CustomOAuth2UserService.java
@@ -23,6 +23,7 @@ import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -38,7 +39,6 @@ import java.util.stream.Collectors;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
-    private final AuthRepository authRepository;
 
     @Override
     @Transactional
@@ -81,18 +81,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     @Transactional
     protected UserEntity saveOrUpdateUser(OAuth2Response oauth2Response) {
-        UserEntity user = userRepository.findByEmail(oauth2Response.getEmail());
-
-        if (user == null) {
-            // 새 사용자 생성
-            user = UserEntity.builder()
-                    .email(oauth2Response.getEmail())
-                    .nickname(oauth2Response.getNickname())
-                    .build();
-            log.info("새로운 OAuth2 사용자 생성: {}", oauth2Response.getEmail());
-        }
-
-        return userRepository.save(user);
+        return userRepository.findByEmail(oauth2Response.getEmail())
+                .orElseGet(() -> {
+                    UserEntity newUser = UserEntity.builder()
+                            .email(oauth2Response.getEmail())
+                            .nickname(oauth2Response.getNickname())
+                            .build();
+                    log.info("새로운 OAuth2 사용자 생성: {}", oauth2Response.getEmail());
+                    return userRepository.save(newUser);
+                });
     }
 
     private CustomOAuth2User createCustomOAuth2User(UserEntity user, Map<String, Object> attributes) {

--- a/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
@@ -1,0 +1,89 @@
+package org.swyp.dessertbee.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.auth.dto.TokenResponse;
+import org.swyp.dessertbee.auth.entity.AuthEntity;
+import org.swyp.dessertbee.auth.jwt.JWTUtil;
+import org.swyp.dessertbee.auth.repository.AuthRepository;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final AuthRepository authRepository;
+    private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
+
+    /**
+     * 리프레시 토큰을 저장하거나 업데이트
+     */
+    @Transactional
+    public void saveRefreshToken(String email, String refreshToken) {
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        AuthEntity auth = authRepository.findByUserAndProvider(Optional.of(user), "local")
+                .orElse(AuthEntity.builder()
+                        .user(user)
+                        .provider("local")
+                        .build());
+
+        auth.updateRefreshToken(refreshToken, LocalDateTime.now().plusDays(14));
+        authRepository.save(auth);
+    }
+
+    /**
+     * 리프레시 토큰 무효화 (로그아웃)
+     */
+    @Transactional
+    public void revokeRefreshToken(String email) {
+        userRepository.findByEmail(email)
+                .flatMap(user -> authRepository.findByUserAndProvider(Optional.of(user), "local"))
+                .ifPresent(auth -> {
+                    auth.deactivate();
+                    authRepository.save(auth);
+                });
+    }
+
+    @Transactional
+    public TokenResponse refreshAccessToken(String email) {
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        AuthEntity auth = authRepository.findByUserAndProvider(Optional.of(user), "local")
+                .orElseThrow(() -> new InvalidTokenException("Refresh token not found"));
+
+        if (!auth.isActive() ||
+                auth.getRefreshToken() == null ||
+                auth.getRefreshTokenExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new InvalidTokenException("Refresh token is expired or invalid");
+        }
+
+        List<String> roles = user.getUserRoles().stream()
+                .map(userRole -> userRole.getRole().getName())
+                .collect(Collectors.toList());
+
+        String newAccessToken = jwtUtil.createAccessToken(email, roles, false);
+
+        return TokenResponse.builder()
+                .accessToken(newAccessToken)
+                .tokenType("Bearer")
+                .expiresIn(1800)
+                .build();
+    }
+
+    public static class InvalidTokenException extends RuntimeException {
+        public InvalidTokenException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/dto/UserDTO.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/UserDTO.java
@@ -47,32 +47,6 @@ public class UserDTO {
                 .build();
     }
 
-    // 회원가입용 DTO
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class SignUpRequest {
-        private String email;
-        private String password;
-        private String nickname;
-        private String name;
-        private String phoneNumber;
-        private String address;
-        private UserEntity.Gender gender;
-    }
-
-    // 로그인용 DTO
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class LoginRequest {
-        private String email;
-        private String password;
-        private boolean rememberMe;
-    }
-
     // 프로필 수정용 DTO
     @Data
     @Builder
@@ -85,15 +59,5 @@ public class UserDTO {
         private String address;
         private String preferences;
         private UserEntity.Gender gender;
-    }
-
-    // 비밀번호 변경용 DTO
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class PasswordChangeRequest {
-        private String currentPassword;
-        private String newPassword;
     }
 }

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -77,6 +77,7 @@ public class UserEntity {
     @Column(name = "gender", length = 6)
     private Gender gender;
 
+    @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<UserRoleEntity> userRoles = new HashSet<>();
 

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -4,10 +4,28 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
-    // UserEntity findByNickname(String nickname);
-    UserEntity findByEmail(String email);
-    Boolean existsByEmail(String email);
+    /**
+     * 이메일로 사용자 조회
+     * @param email 사용자 이메일
+     * @return UserEntity
+     */
+    Optional<UserEntity> findByEmail(String email);
+    /**
+     * 이메일 존재 여부 확인
+     * @param email 사용자 이메일
+     * @return boolean
+     */
+    boolean existsByEmail(String email);
+
+    /**
+     * 닉네임 존재 여부 확인
+     * @param nickname 사용자 닉네임
+     * @return boolean
+     */
+    boolean existsByNickname(String nickname);
 }


### PR DESCRIPTION
## :hash: 연관된 이슈
#17 
## :memo: 작업 내용
- JWT 로그인 구현
  - KeepLoggedIn True일 시, (액세스 토큰 기본 1일 -> 3일, 리프레시 토큰 기본 10일 -> 30일)
- JWT 회원가입 구현
- 로그아웃 구현
  - 액세스 토큰은 프론트에서 무효화
  - 리프레시 토큰 무효화는 DB에서 진행