### PR TITLE
디저트 메이트 멤버 관련 로직 추가

### DIFF
--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -13,8 +13,10 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.mate.dto.request.MateCreateRequest;
 import org.swyp.dessertbee.mate.dto.response.MateDetailResponse;
+import org.swyp.dessertbee.mate.service.MateMemberService;
 import org.swyp.dessertbee.mate.service.MateService;
 import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "Mate", description = "디저트메이트 관련 API")
 @RestController
@@ -23,6 +25,7 @@ import java.util.List;
 public class MateController {
 
     private final MateService mateService;
+    private final MateMemberService mateMemberService;
 
     /**
      * 메이트 등록
@@ -35,6 +38,7 @@ public class MateController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<MateDetailResponse> createMate(@RequestPart("request") @Valid MateCreateRequest request,
                                                          @RequestPart(value = "mateImage", required = false) List<MultipartFile> mateImage) {
+
         return ResponseEntity.status(HttpStatus.CREATED).body(mateService.createMate(request, mateImage));
     }
 
@@ -42,35 +46,40 @@ public class MateController {
      * 메이트 상세 정보 조회
      */
     @Operation(summary = "메이트 상세 정보 조회", description = "디저트메이트 상세 정보 조회합니다.")
-    @GetMapping("/{mateId}/details")
-    public MateDetailResponse getMateDetails(@PathVariable Long mateId) {
-        return mateService.getMateDetails(mateId);
+    @GetMapping("/{mateUuid}/details")
+    public MateDetailResponse getMateDetails(@PathVariable UUID mateUuid) {
+
+
+        return mateService.getMateDetails(mateUuid);
     }
 
 
     /**
      * 메이트 삭제
      */
-    @DeleteMapping("/{mateId}")
+    @DeleteMapping("/{mateUuid}")
     @Operation(summary = "메이트 삭제", description = "디저트메이트 삭제합니다.")
-    public ResponseEntity<String> deleteMate(@PathVariable Long mateId) {
-        mateService.deleteMate(mateId);
+    public ResponseEntity<String> deleteMate(@PathVariable UUID mateUuid) {
+        //디저트메이트 삭제
+        mateService.deleteMate(mateUuid);
 
+        //디저트메이트 멤버 삭제
+        mateMemberService.deleteAllMember(mateUuid);
         return ResponseEntity.ok("디저트메이트가 성공적으로 삭제되었습니다.");
     }
 
     /**
      * 메이트 수정
      * */
-    @PatchMapping("/{mateId}")
+    @PatchMapping("/{mateUuid}")
     @Operation(summary = "메이트 수정", description = "디저트메이트 수정합니다.")
     public ResponseEntity<String> updateMate(
-            @PathVariable Long mateId,
+            @PathVariable UUID mateUuid,
             @RequestPart("request") MateCreateRequest request,
             @RequestPart(value = "mateImage", required = false) MultipartFile mateImage
     ){
 
-        mateService.updateMate(mateId, request, mateImage);
+        mateService.updateMate(mateUuid, request, mateImage);
         return ResponseEntity.ok("디저트메이트가 성공적으로 수정되었습니다.");
     }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
@@ -1,0 +1,30 @@
+package org.swyp.dessertbee.mate.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swyp.dessertbee.mate.dto.response.MateMemberResponse;
+import org.swyp.dessertbee.mate.service.MateMemberService;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "MateMember", description = "디저트메이트 멤버 관련 API")
+@RestController
+@RequestMapping("api/mates/{mateUuid}")
+@RequiredArgsConstructor
+public class MateMemberController {
+
+    private final MateMemberService memberService;
+
+//    @GetMapping
+//    public ResponseEntity<List<MateMemberResponse>> getMemberList(@PathVariable UUID mateUuid) {
+//
+//        return ResponseEntity.ok(memberService.getMemberList(mateUuid));
+//    }
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/dto/request/MateCreateRequest.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/request/MateCreateRequest.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 @Builder
 @Data
@@ -16,7 +17,7 @@ import java.util.List;
 public class MateCreateRequest {
 
     @NotNull
-    private Long userId;
+    private UUID userUuid;
 
     @NotNull
     private Long mateCategoryId;

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
@@ -6,34 +6,36 @@ import lombok.Data;
 import org.swyp.dessertbee.mate.entity.Mate;
 
 import java.util.List;
+import java.util.UUID;
 
 @Data
 @Builder
 @AllArgsConstructor
 public class MateDetailResponse {
 
-    private Long mateId;
-    private Long userId;
+    private UUID mateId;
+    private UUID userId;
     private String title;
     private String content;
     private Boolean recruitYn;
     private List<String> mateImage;
 
     //디저트메이트 카테고리명
-    private String mateCategoryId;
+    private String mateCategory;
 
     public static MateDetailResponse fromEntity(Mate mate,
                                                 List<String> mateImage,
-                                                String category){
+                                                String category,
+                                                UUID userUuid){
 
         return MateDetailResponse.builder()
-                .mateId(mate.getMateId())
-                .userId(mate.getUserId())
+                .mateId(mate.getMateUuid())
+                .userId(userUuid)
                 .title(mate.getTitle())
                 .content(mate.getContent())
                 .recruitYn(mate.getRecruitYn())
                 .mateImage(mateImage)
-                .mateCategoryId(category)
+                .mateCategory(category)
                 .build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
@@ -13,8 +13,8 @@ import java.util.UUID;
 @AllArgsConstructor
 public class MateDetailResponse {
 
-    private UUID mateId;
-    private UUID userId;
+    private UUID mateUuid;
+    private UUID userUuid;
     private String title;
     private String content;
     private Boolean recruitYn;
@@ -29,8 +29,8 @@ public class MateDetailResponse {
                                                 UUID userUuid){
 
         return MateDetailResponse.builder()
-                .mateId(mate.getMateUuid())
-                .userId(userUuid)
+                .mateUuid(mate.getMateUuid())
+                .userUuid(userUuid)
                 .title(mate.getTitle())
                 .content(mate.getContent())
                 .recruitYn(mate.getRecruitYn())

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateMemberResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateMemberResponse.java
@@ -1,0 +1,39 @@
+package org.swyp.dessertbee.mate.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.swyp.dessertbee.mate.entity.MateMember;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class MateMemberResponse {
+
+    private UUID mateId;
+    private UUID userId;
+    private String grade;
+    private Boolean approvalYn;
+    private List<String> userImage;
+    private String nickname;
+
+    public static MateMemberResponse fromEntity(MateMember member,
+                                                UUID mateId,
+                                                UUID userId,
+                                                List<String> userImage,
+                                                String nickname) {
+
+        return MateMemberResponse.builder()
+                .mateId(mateId)
+                .userId(userId)
+                .grade(member.getGrade().toString())
+                .approvalYn(member.getApprovalYn())
+                .userImage(userImage)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateMemberResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateMemberResponse.java
@@ -14,22 +14,22 @@ import java.util.UUID;
 @AllArgsConstructor
 public class MateMemberResponse {
 
-    private UUID mateId;
-    private UUID userId;
+    private UUID mateUuid;
+    private UUID userUUid;
     private String grade;
     private Boolean approvalYn;
     private List<String> userImage;
     private String nickname;
 
     public static MateMemberResponse fromEntity(MateMember member,
-                                                UUID mateId,
-                                                UUID userId,
+                                                UUID mateUuid,
+                                                UUID userUUid,
                                                 List<String> userImage,
                                                 String nickname) {
 
         return MateMemberResponse.builder()
-                .mateId(mateId)
-                .userId(userId)
+                .mateUuid(mateUuid)
+                .userUUid(userUUid)
                 .grade(member.getGrade().toString())
                 .approvalYn(member.getApprovalYn())
                 .userImage(userImage)

--- a/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
@@ -8,8 +8,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(name="mate")
@@ -23,6 +25,11 @@ public class Mate {
     @Column(name = "mate_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long mateId;    //메이트 고유 id
+
+    @Column(name = "mate_uuid", nullable = false, unique = true, updatable = false)
+    @UuidGenerator()
+    private UUID mateUuid;
+
 
     @Column(name = "user_id")
     private Long userId;

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateMember.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateMember.java
@@ -18,15 +18,24 @@ public class MateMember {
     @Column(name = "mate_member_id")
     private Long mateMemberId;  //메이트 멤버 고유 id
 
+    @Column(name = "mate_id")
+    private Long mateId;    //메이트 테이블 조인하기 위해 필요(mate 테이블 고유 id)
+
     @Column(name = "user_id")
     private Long userId;
 
-    @Column(nullable = false, length = 45)
-    private String grade;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MateMemberGrade grade;
 
     @Column(name = "approval_yn")
     private  Boolean approvalYn;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+
+    public void softDelete(){
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateMemberGrade.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateMemberGrade.java
@@ -1,0 +1,5 @@
+package org.swyp.dessertbee.mate.entity;
+
+public enum MateMemberGrade {
+    CREATOR, NORMAL
+}

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
@@ -1,0 +1,14 @@
+package org.swyp.dessertbee.mate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.mate.entity.MateMember;
+
+import java.util.List;
+
+@Repository
+public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
+
+
+    List<MateMember> findAllByMateId(Long mateId);
+}

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
@@ -2,14 +2,23 @@ package org.swyp.dessertbee.mate.repository;
 
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.mate.entity.Mate;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface MateRepository extends JpaRepository<Mate, Long> {
 
     @Transactional
     Optional<Mate> findByMateIdAndDeletedAtIsNull(Long mateId);
+
+    /**
+     * MateUuid로 MateId 조회
+     * */
+    @Query("SELECT m.mateId FROM Mate m where m.mateUuid = :mateUuid")
+    Long findMateIdByMateUuid(UUID mateUuid);
+
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -1,0 +1,51 @@
+package org.swyp.dessertbee.mate.service;
+
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.swyp.dessertbee.mate.entity.MateMember;
+import org.swyp.dessertbee.mate.entity.MateMemberGrade;
+import org.swyp.dessertbee.mate.repository.MateMemberRepository;
+import org.swyp.dessertbee.mate.repository.MateRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MateMemberService {
+
+
+    private final MateMemberRepository mateMemberRepository;
+    private final MateRepository mateRepository;
+    private MateMember mateMember;
+    /**
+     * 디저트 메이트 생성 시 생성자 등록
+     * */
+    public void addCreatorAsMember(UUID mateUuid, Long userId) {
+
+        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+        //mateMember 테이블에 생성자 등록
+        mateMemberRepository.save(
+                MateMember.builder()
+                        .mateId(mateId)
+                        .userId(userId)
+                        .grade(MateMemberGrade.CREATOR)
+                        .approvalYn(true)
+                        .build()
+        );
+    }
+
+
+
+//    public List<MateMemberResponse> getMemberList(UUID mateUuid) {
+//
+//        //프론트에서 받아온 mateUuid로 mateId 조회
+//        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+//
+//
+//         return mateMemberRepository.findMateMemberByMateId()
+//    }
+}

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -37,7 +37,36 @@ public class MateMemberService {
                         .build()
         );
     }
+    /**
+     * 디저트메이트 삭제 시 멤버 삭제
+     * */
+    public void deleteAllMember(UUID mateUuid) {
 
+        //mateUuid로 mateId 조회
+        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+
+        try {
+
+
+            // mateId로 모든 멤버 조회
+            List<MateMember> members = mateMemberRepository.findAllByMateId(mateId);
+
+            // 각 멤버에 대해 softDelete 처리
+            for (MateMember member : members) {
+                member.softDelete();  // 개별 멤버에 softDelete 적용
+            }
+
+            // 변경된 모든 멤버 저장
+            mateMemberRepository.saveAll(members);
+
+
+
+        }catch (Exception e){
+            System.out.println("❌ 디저트메이트 멤버 삭제 중 오류 발생: " + e.getMessage());
+            throw new RuntimeException("디저트메이트 멤버 삭제 실패: " + e.getMessage(), e);
+        }
+
+    }
 
 
 //    public List<MateMemberResponse> getMemberList(UUID mateUuid) {

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -9,10 +9,15 @@ import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.mate.dto.request.MateCreateRequest;
 import org.swyp.dessertbee.mate.dto.response.MateDetailResponse;
 import org.swyp.dessertbee.mate.entity.Mate;
+import org.swyp.dessertbee.mate.entity.MateMember;
+import org.swyp.dessertbee.mate.entity.MateMemberGrade;
 import org.swyp.dessertbee.mate.repository.MateCategoryRepository;
+import org.swyp.dessertbee.mate.repository.MateMemberRepository;
 import org.swyp.dessertbee.mate.repository.MateRepository;
+import org.swyp.dessertbee.user.repository.UserRepository;
 
 import java.util.List;
+import java.util.UUID;
 
 
 @Service
@@ -20,17 +25,27 @@ import java.util.List;
 @Transactional
 public class MateService {
 
+    private final UserRepository userRepository;
     private final MateRepository mateRepository;
+    private final MateMemberRepository mateMemberRepository;
     private final MateCategoryRepository mateCategoryRepository;
+    private final MateMemberService mateMemberService;
     private final ImageService imageService;
 
 
-    /** 가게 등록 */
+    /** 메이트 등록 */
     public MateDetailResponse createMate(MateCreateRequest request, List<MultipartFile> mateImage) {
+
+        Long userId = userRepository.findIdByUserUuid(request.getUserUuid());
+
+        //userId 존재 여부 확인
+        if (userId == null) {
+            throw new IllegalArgumentException("존재하지 않는 유저입니다.");
+        }
 
         Mate mate = mateRepository.save(
                 Mate.builder()
-                        .userId(request.getUserId())
+                        .userId(userId)
                         .mateCategoryId(request.getMateCategoryId())
                         .title(request.getTitle())
                         .content(request.getContent())
@@ -38,19 +53,30 @@ public class MateService {
                         .build()
         );
 
-        // 가게 대표 사진 S3 업로드 및 저장
+
+        // 메이트 대표 사진 S3 업로드 및 저장
         if (mateImage != null && !mateImage.isEmpty()) {
             String folder = "mate/" + mate.getMateId();
             imageService.uploadAndSaveImages(mateImage, ImageType.MATE, mate.getMateId(), folder);
         }
-        return getMateDetails(mate.getMateId());
+
+        //디저트 메이트 mateId를 가진 member 데이터 생성
+        mateMemberService.addCreatorAsMember(mate.getMateUuid(), userId);
+
+        return getMateDetails(mate.getMateUuid());
     }
 
 
     /** 메이트 상세 정보 */
-    public MateDetailResponse getMateDetails(Long mateId) {
+    public MateDetailResponse getMateDetails(UUID mateUuid) {
+
+        //mateUuid로 mateId 조회
+        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+
+        //mateId로 디저트메이트 여부 확인
         Mate mate = mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 디저트메이트입니다."));
+
 
         //디저트메이트 사진 조회
         List<String> mateImage = imageService.getImagesByTypeAndId(ImageType.MATE, mateId);
@@ -58,34 +84,44 @@ public class MateService {
         //mateCategoryId로 name 조회
         String mateCategory = String.valueOf(mateCategoryRepository.findCategoryNameById( mate.getMateCategoryId()));
 
-        return MateDetailResponse.fromEntity(mate, mateImage, mateCategory);
+        //userId로 userUuid 조회
+        UUID userUuid = userRepository.findUserUuidById(mate.getUserId());
+
+        return MateDetailResponse.fromEntity(mate, mateImage, mateCategory, userUuid);
 
     }
 
     /** 메이트 삭제 */
+    @Transactional
+    public void deleteMate(UUID mateUuid) {
 
-        @Transactional
-        public void deleteMate(Long mateId) {
-            Mate mate = mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 디저트메이트입니다."));
+        //mateUuid로 mateId 조회
+        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
 
+        //mateId 존재 여부 확인
+        Mate mate = mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 디저트메이트입니다."));
 
-            try {
+        try {
                 mate.softDelete();
                 mateRepository.save(mate);
 
                 imageService.deleteImagesByRefId(ImageType.MATE, mateId);
 
-            } catch (Exception e) {
+        } catch (Exception e) {
                 System.out.println("❌ S3 이미지 삭제 중 오류 발생: " + e.getMessage());
                 throw new RuntimeException("S3 이미지 삭제 실패: " + e.getMessage(), e);
-            }
         }
+    }
 
     /**
      * 메이트 수정
      * */
-    public void updateMate(Long mateId, MateCreateRequest request, MultipartFile mateImage) {
+    public void updateMate(UUID mateUuid, MateCreateRequest request, MultipartFile mateImage) {
+        //mateUuid로 mateId 조회
+        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+
+        //mateId 존재 여부 확인
         Mate mate = mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 디저트메이트입니다."));
 

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -1,10 +1,12 @@
 package org.swyp.dessertbee.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
@@ -28,4 +30,16 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
      * @return boolean
      */
     boolean existsByNickname(String nickname);
+
+    /**
+     * Uuid로 userId 조회
+     * */
+    @Query("SELECT u.id FROM UserEntity u where u.userUuid = :userUuid")
+    Long findIdByUserUuid(UUID userUuid);
+
+    /**
+     * userId로 userUuid 조회
+     * */
+    @Query("SELECT u.userUuid FROM UserEntity u where u.id = :userId")
+    UUID findUserUuidById(Long userId);
 }


### PR DESCRIPTION
## :hash: 연관된 이슈

> 28

## :memo: 작업 내용

> 디저트 메이트 생성 시 메이트 멤버 테이블에 생성자 등록
> 디저트 메이트 삭제 시 해당 메이트 멤버 데이터 삭제(soft delete 적용)

## :speech_balloon: 리뷰 요구사항(선택)

> 현재 uuid를 통해 프론트와 데이터 주고 받고 있는데 괜찮게 짜여진건지 확인 후 피드백 부탁드립니다!
