### PR TITLE
Feature/36 user auth email validaton

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -26,6 +26,8 @@ import org.swyp.dessertbee.role.repository.RoleRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     EXPIRED_VERIFICATION_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "만료된 인증 토큰입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "A005", "비밀번호가 일치하지 않습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A006", "잘못된 인증 정보입니다."),
+    SIGNUP_RESTRICTED_DELETED_ACCOUNT(HttpStatus.FORBIDDEN, "A007", "탈퇴한 계정은 30일 이후에 재가입이 가능합니다."),
 
     // Email
     EMAIL_SENDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E005", "이메일 발송에 실패했습니다."),

--- a/src/main/java/org/swyp/dessertbee/email/entity/EmailVerificationEntity.java
+++ b/src/main/java/org/swyp/dessertbee/email/entity/EmailVerificationEntity.java
@@ -50,4 +50,18 @@ public class EmailVerificationEntity {
     public void verify() {
         this.verified = true;
     }
+
+    /**
+     * 만료 시간을 설정
+     */
+    public void updateExpiresAt(LocalDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    /**
+     * 삭제 시간을 설정
+     */
+    public void updateDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/org/swyp/dessertbee/email/repository/EmailVerificationRepository.java
@@ -9,6 +9,7 @@ import org.swyp.dessertbee.email.entity.EmailVerificationEntity;
 import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -54,4 +55,13 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
     @Query("UPDATE EmailVerificationEntity e SET e.deletedAt = CURRENT_TIMESTAMP " +
             "WHERE e.createdAt < :before AND e.deletedAt IS NULL")
     void softDeleteOldRecords(@Param("before") LocalDateTime before);
+
+    /**
+     * 인증되지 않고 삭제되지 않은 이메일 인증 정보 조회
+     */
+    List<EmailVerificationEntity> findByEmailAndPurposeAndVerifiedFalseAndDeletedAtIsNull(
+            String email,
+            EmailVerificationPurpose purpose
+    );
+
 }

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
@@ -5,10 +5,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.swyp.dessertbee.user.dto.NicknameValidationRequestDto;
 import org.swyp.dessertbee.user.dto.UserDetailResponseDto;
 import org.swyp.dessertbee.user.dto.UserResponseDto;
 import org.swyp.dessertbee.user.dto.UserUpdateRequestDto;
 import org.swyp.dessertbee.user.service.UserService;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 사용자 정보 조회 관련 컨트롤러
@@ -60,5 +64,19 @@ public class UserController {
         log.debug("유저 소프트 삭제를 진행합니다.");
         userService.deleteMyAccount();
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 닉네임 중복 검사
+     * @return 사용 가능 여부
+     */
+    @PostMapping("/validate/nickname")
+    public ResponseEntity<Map<String, Boolean>> checkNickname(@Valid @RequestBody NicknameValidationRequestDto request) {
+        boolean isAvailable = userService.checkNicknameAvailability(request.getNickname(), request.getPurpose());
+
+        Map<String, Boolean> response = new HashMap<>();
+        response.put("available", isAvailable);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/user/dto/NicknameValidationRequestDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/NicknameValidationRequestDto.java
@@ -1,0 +1,21 @@
+package org.swyp.dessertbee.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import org.swyp.dessertbee.user.entity.NicknameValidationPurpose;
+
+@Getter
+public class NicknameValidationRequestDto {
+    @NotNull(message = "닉네임은 필수 입력값입니다.")
+    private final String nickname;
+
+    @NotNull(message = "용도는 필수 입력값입니다.")
+    private final NicknameValidationPurpose purpose;
+
+    @Builder
+    public NicknameValidationRequestDto(String nickname, NicknameValidationPurpose purpose) {
+        this.nickname = nickname;
+        this.purpose = purpose;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/entity/NicknameValidationPurpose.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/NicknameValidationPurpose.java
@@ -1,0 +1,16 @@
+package org.swyp.dessertbee.user.entity;
+
+public enum NicknameValidationPurpose {
+    SIGNUP("회원가입"),
+    PROFILE_UPDATE("프로필 수정");
+
+    private final String description;
+
+    NicknameValidationPurpose(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -45,4 +45,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
      * */
     @Query("SELECT u.userUuid FROM UserEntity u WHERE u.id = :userId AND u.deletedAt IS NULL")
     UUID findUserUuidById(Long userId);
+
+    /**
+     * 삭제된 계정 중 이메일로 조회
+     */
+    @Query("SELECT u FROM UserEntity u WHERE u.email = :email AND u.deletedAt IS NOT NULL")
+    Optional<UserEntity> findDeletedAccountByEmail(String email);
 }

--- a/src/main/java/org/swyp/dessertbee/user/service/UserService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserService.java
@@ -3,6 +3,7 @@ package org.swyp.dessertbee.user.service;
 import org.swyp.dessertbee.user.dto.UserDetailResponseDto;
 import org.swyp.dessertbee.user.dto.UserResponseDto;
 import org.swyp.dessertbee.user.dto.UserUpdateRequestDto;
+import org.swyp.dessertbee.user.entity.NicknameValidationPurpose;
 
 public interface UserService {
     /**
@@ -30,5 +31,10 @@ public interface UserService {
      */
     void deleteMyAccount();
 
+    /**
+     * 닉네임 중복 여부를 확인합니다.
+     * @param nickname 검사할 닉네임
+     * @return 사용 가능 여부
+     */
+    boolean checkNicknameAvailability(String nickname, NicknameValidationPurpose purpose);
 }
-

--- a/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
@@ -16,6 +16,7 @@ import org.swyp.dessertbee.user.dto.UserDetailResponseDto;
 import org.swyp.dessertbee.user.dto.UserResponseDto;
 import org.swyp.dessertbee.user.dto.UserUpdateRequestDto;
 import org.swyp.dessertbee.user.entity.MbtiEntity;
+import org.swyp.dessertbee.user.entity.NicknameValidationPurpose;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.MbtiRepository;
 import org.swyp.dessertbee.user.repository.UserRepository;
@@ -264,4 +265,17 @@ public class UserServiceImpl implements UserService {
         log.info("해당 유저의 계정이 비활성화 처리 되었습니다 : {}", user.getEmail());
     }
 
+    @Override
+    public boolean checkNicknameAvailability(String nickname, NicknameValidationPurpose purpose) {
+        // 프로필 수정의 경우 인증 확인
+        if (purpose == NicknameValidationPurpose.PROFILE_UPDATE) {
+            UserEntity currentUser = getCurrentUser();
+            // 현재 사용자의 닉네임과 동일한 경우 true 반환
+            if (currentUser.getNickname().equals(nickname)) {
+                return true;
+            }
+        }
+
+        return !userRepository.existsByNickname(nickname);
+    }
 }


### PR DESCRIPTION
## :hash: 연관된 이슈
#36 
## :memo: 작업 내용
- 회원가입 시 탈퇴한 유저인지 체크
  -  일단 한 달 뒤 가입 가능하도록 처리
- 이메일 인증 코드 여러 번 요청 시 기존 인증 코드들은 만료 처리
- 닉네임 중복 검사 API 추가
  -  purpose를 통해 용도 구분
### 스크린샷 (선택)
<img width="1058" alt="스크린샷 2025-02-13 오전 12 39 49" src="https://github.com/user-attachments/assets/e7005f61-e047-40d9-88ce-891dfb3dcfb8" />
<img width="1002" alt="스크린샷 2025-02-13 오전 12 40 57" src="https://github.com/user-attachments/assets/5165466e-5dd7-442c-9b24-a29f61e3ba72" />
<img width="776" alt="image" src="https://github.com/user-attachments/assets/224f3001-fb2e-4faf-ae9e-39ac0b4c341b" />
