### PR TITLE
[Feature] 디저트 메이트 전체 조회 api 구현

### DIFF
--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -82,4 +82,23 @@ public class MateController {
         mateService.updateMate(mateUuid, request, mateImage);
         return ResponseEntity.ok("디저트메이트가 성공적으로 수정되었습니다.");
     }
+
+
+    /**
+     * 디저트메이트 전체 조회
+     * */
+    @GetMapping
+    @Operation(summary = "메이트 전체 조회", description = "디저트메이트 전체 조회합니다.")
+    public ResponseEntity<List<MateDetailResponse>> getMates(
+            @RequestParam int from,
+            @RequestParam int to
+    ) {
+
+        if (from >= to) {
+            throw new IllegalArgumentException("잘못된 범위 설정");
+        }
+
+
+        return ResponseEntity.ok(mateService.getMates(from, to));
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
@@ -22,9 +22,9 @@ public class MateMemberController {
      * 디저트 메이트 멤버 전체 조회
      * */
     @GetMapping("/members")
-    public ResponseEntity<List<MateMemberResponse>> getMemberList(@PathVariable UUID mateUuid) {
+    public ResponseEntity<List<MateMemberResponse>> getMembers(@PathVariable UUID mateUuid) {
 
-        return ResponseEntity.ok(memberService.getMemberList(mateUuid));
+        return ResponseEntity.ok(memberService.getMembers(mateUuid));
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import org.swyp.dessertbee.mate.entity.Mate;
+import org.swyp.dessertbee.user.entity.UserEntity;
 
 import java.util.List;
 import java.util.UUID;
@@ -15,6 +16,7 @@ public class MateDetailResponse {
 
     private UUID mateUuid;
     private UUID userUuid;
+    private String nickname;
     private String title;
     private String content;
     private Boolean recruitYn;
@@ -26,11 +28,12 @@ public class MateDetailResponse {
     public static MateDetailResponse fromEntity(Mate mate,
                                                 List<String> mateImage,
                                                 String category,
-                                                UUID userUuid){
+                                                UserEntity creator){
 
         return MateDetailResponse.builder()
                 .mateUuid(mate.getMateUuid())
-                .userUuid(userUuid)
+                .userUuid(creator.getUserUuid())
+                .nickname(creator.getNickname())
                 .title(mate.getTitle())
                 .content(mate.getContent())
                 .recruitYn(mate.getRecruitYn())

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
@@ -2,9 +2,11 @@ package org.swyp.dessertbee.mate.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.mate.dto.response.MateMemberResponse;
 import org.swyp.dessertbee.mate.entity.MateMember;
+import org.swyp.dessertbee.user.entity.UserEntity;
 
 import java.util.List;
 
@@ -12,5 +14,10 @@ import java.util.List;
 public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
 
     List<MateMember> findByMateIdAndDeletedAtIsNullAndApprovalYnTrue(Long mateId);
+
+    @Query("SELECT u FROM UserEntity u " +
+            "JOIN MateMember m ON u.id = m.userId " +
+            "WHERE m.mateId = :mateId AND m.grade = 'CREATOR'")
+    UserEntity findByMateId(@Param("mateId") Long mateId);
 
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.mate.entity.Mate;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,5 +21,13 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
      * */
     @Query("SELECT m.mateId FROM Mate m where m.mateUuid = :mateUuid")
     Long findMateIdByMateUuid(UUID mateUuid);
+
+    /**
+     *
+     * */
+    @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL ORDER BY m.mateId ASC LIMIT :limit OFFSET :from")
+    List<Mate> findAllByDeletedAtIsNull(int from, int limit);
+
+
 
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -86,7 +86,7 @@ public class MateMemberService {
     /**
      * 디저트 메이트 멤버 전체 조회
      * */
-    public List<MateMemberResponse> getMemberList(UUID mateUuid) {
+    public List<MateMemberResponse> getMembers(UUID mateUuid) {
 
         //mateUuid로 mateId 조회
         Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);


### PR DESCRIPTION
## :hash: 연관된 이슈

> 32

## :memo: 작업 내용

> 디저트 메이트 리스트 전체 조회
> 디저트 메이트 상세 보기 데이터 닉네임 추가

### 스크린샷 (선택)
> 범위 설정 잘못하면 예외처리 뜨게 만들었습니다.

<img width="949" alt="스크린샷 2025-02-13 오후 9 40 41" src="https://github.com/user-attachments/assets/f9b8c1ea-9f3f-4304-9b1f-0068f297be97" />


## :speech_balloon: 리뷰 요구사항(선택)

> 혹시 더 예외처리 해야할 부분들이 있는지 한번만 봐주실 수 있나용?
