### PR TITLE
[Feature] 유저 프로필 이미지

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -42,11 +42,10 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
     })
-    @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping("/signup")
     public ResponseEntity<SignUpResponse> signup(
             @RequestHeader("X-Email-Verification-Token") String verificationToken,
-            @Valid @RequestPart(value = "data") SignUpRequest request,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+            @Valid @RequestBody SignUpRequest request
     ) throws BadRequestException {
         log.debug("회원가입 요청: {}", request.getEmail());
 
@@ -55,10 +54,11 @@ public class AuthController {
             throw new BadRequestException("비밀번호가 일치하지 않습니다.");
         }
 
-        // 회원가입 처리 (프로필 이미지 포함)
-        SignUpResponse response = authService.signup(request, profileImage, verificationToken);
+        // 회원가입 처리
+        SignUpResponse response = authService.signup(request, verificationToken);
         return ResponseEntity.ok(response);
     }
+
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @ApiResponses({

--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -11,8 +11,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
@@ -40,10 +42,11 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
     })
-    @PostMapping("/signup")
+    @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SignUpResponse> signup(
             @RequestHeader("X-Email-Verification-Token") String verificationToken,
-            @Valid @RequestBody SignUpRequest request
+            @Valid @RequestPart(value = "data") SignUpRequest request,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) throws BadRequestException {
         log.debug("회원가입 요청: {}", request.getEmail());
 
@@ -52,8 +55,8 @@ public class AuthController {
             throw new BadRequestException("비밀번호가 일치하지 않습니다.");
         }
 
-        // 회원가입 처리
-        SignUpResponse response = authService.signup(request, verificationToken);
+        // 회원가입 처리 (프로필 이미지 포함)
+        SignUpResponse response = authService.signup(request, profileImage, verificationToken);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
@@ -21,6 +21,7 @@ public class LoginResponse {
     private UUID userUuid;          // 사용자 UUID
     private String email;           // 사용자 이메일
     private String nickname;        // 사용자 닉네임
+    private String profileImageUrl; // 프로필 이미지
 
     /**
      * 로그인 성공 응답 생성
@@ -28,12 +29,13 @@ public class LoginResponse {
      * @param user 사용자 엔티티
      * @return 로그인 응답 객체
      */
-    public static LoginResponse success(String token, UserEntity user) {
+    public static LoginResponse success(String token, UserEntity user, String profileImageUrl) {
         return LoginResponse.builder()
                 .accessToken(token)
                 .userUuid(user.getUserUuid())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
+                .profileImageUrl(profileImageUrl)
                 .build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package org.swyp.dessertbee.auth.service;
 
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
@@ -41,7 +42,7 @@ public interface AuthService {
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
      * @throws DuplicateEmailException 이메일 중복
      */
-    SignUpResponse signup(SignUpRequest request, String verificationToken);
+    SignUpResponse signup(SignUpRequest request, MultipartFile profileImage, String verificationToken);
 
 
     /**
@@ -57,7 +58,6 @@ public interface AuthService {
      * @param request 비밀번호 재설정 요청
      * @param verificationToken 이메일 인증 토큰
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
-     * @throws InvalidPasswordException 유효하지 않은 비밀번호
      */
     void resetPassword(PasswordResetRequest request, String verificationToken);
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -42,7 +42,7 @@ public interface AuthService {
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
      * @throws DuplicateEmailException 이메일 중복
      */
-    SignUpResponse signup(SignUpRequest request, MultipartFile profileImage, String verificationToken);
+    SignUpResponse signup(SignUpRequest request, String verificationToken);
 
 
     /**

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -65,7 +65,7 @@ public class AuthServiceImpl implements AuthService {
      */
     @Override
     @Transactional
-    public SignUpResponse signup(SignUpRequest request, MultipartFile profileImage, String verificationToken) {
+    public SignUpResponse signup(SignUpRequest request, String verificationToken) {
         try {
             // 메일 인증 토큰 검증
             validateEmailVerificationToken(verificationToken, request.getEmail(), EmailVerificationPurpose.SIGNUP);
@@ -102,16 +102,7 @@ public class AuthServiceImpl implements AuthService {
             user.addRole(userRole);
 
             // 사용자 정보 저장
-            UserEntity savedUser = userRepository.save(user);
-
-            if (profileImage != null && !profileImage.isEmpty()) {
-                imageService.uploadAndSaveImage(
-                        profileImage,
-                        ImageType.PROFILE,
-                        savedUser.getId(),
-                        "profile/" + savedUser.getId()
-                );
-            }
+            userRepository.save(user);
 
             log.info("회원가입 완료 - 이메일: {}", request.getEmail());
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -3,7 +3,6 @@ package org.swyp.dessertbee.auth.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +20,6 @@ import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
-import org.swyp.dessertbee.common.exception.GlobalExceptionHandler;
 import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
 import org.swyp.dessertbee.role.entity.RoleEntity;
@@ -29,8 +27,6 @@ import org.swyp.dessertbee.role.repository.RoleRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -164,8 +160,12 @@ public class AuthServiceImpl implements AuthService {
             // 5. Refresh Token 저장
             saveRefreshToken(user.getEmail(), refreshToken);
 
+            // 6. 프로필 이미지
+            List<String> profileImages = imageService.getImagesByTypeAndId(ImageType.PROFILE, user.getId());
+            String profileImageUrl = profileImages.isEmpty() ? null : profileImages.get(0);
+
             // 7. 로그인 응답 생성
-            return LoginResponse.success(accessToken, user);
+            return LoginResponse.success(accessToken, user, profileImageUrl);
 
         } catch (InvalidCredentialsException e) {
             log.warn("로그인 실패 - 이메일: {}, 사유: {}", request.getEmail(), e.getMessage());

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -34,12 +34,19 @@ public enum ErrorCode {
     USER_DELETED(HttpStatus.GONE, "U002", "탈퇴한 사용자입니다."),
     INVALID_USER_STATUS(HttpStatus.BAD_REQUEST, "U003", "유효하지 않은 사용자 상태입니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "U004", "해당 정보에 대한 접근 권한이 없습니다."),
-    INVALID_USER_UUID(HttpStatus.BAD_REQUEST, "U005", "유효하지 않은 사용자 식별자입니다.");
+    INVALID_USER_UUID(HttpStatus.BAD_REQUEST, "U005", "유효하지 않은 사용자 식별자입니다."),
 
     // 사장님 권한
     /**
      * 필요한 에러코드에 대하 추가적으로 더 적으시면 됩니다. - 영민 -
      */
+    // File
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드에 실패했습니다."),
+    FILE_UPDATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F002", "파일 업데이트에 실패했습니다."),
+    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "파일 삭제에 실패했습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "F004", "지원하지 않는 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F005", "파일 크기가 제한을 초과했습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/swyp/dessertbee/config/CorsMvcConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/CorsMvcConfig.java
@@ -1,4 +1,0 @@
-package org.swyp.dessertbee.config;
-
-public class CorsMvcConfig {
-}

--- a/src/main/java/org/swyp/dessertbee/config/CorsMvcConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/CorsMvcConfig.java
@@ -1,0 +1,4 @@
+package org.swyp.dessertbee.config;
+
+public class CorsMvcConfig {
+}

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.swyp.dessertbee.auth.service.AuthService;
 import org.swyp.dessertbee.auth.service.CustomOAuth2UserService;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -88,12 +89,17 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        List<String> allowedOrigins = Arrays.asList(corsAllowedOrigins.split(","));
-        configuration.setAllowedOrigins(allowedOrigins);
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
+        // allowedOrigins를 yml 설정값에서 가져와서 설정
+        String[] origins = corsAllowedOrigins.split(",");
+        configuration.setAllowedOrigins(Arrays.asList(origins));
+
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowCredentials(true);
-        configuration.setExposedHeaders(Arrays.asList("Authorization"));
+        configuration.setAllowedHeaders(Arrays.asList("Origin", "Content-Type", "Accept", "Authorization"));
+        configuration.setMaxAge(3600L);
+
+        // 노출할 헤더 설정 - Set-Cookie도 포함
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
@@ -54,21 +54,10 @@ public class UserController {
      * 현재 인증된 사용자의 정보를 수정합니다.
      * @return 사용자 상세 정보
      */
-    @PatchMapping(value="/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<UserDetailResponseDto> updateMyInfo(@Valid @RequestPart(value = "data", required = false) UserUpdateRequestDto updateRequest,
-                                                              @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+    @PatchMapping(value="/me")
+    public ResponseEntity<UserDetailResponseDto> updateMyInfo(@RequestBody @Valid UserUpdateRequestDto updateRequest) {
 
-        // 최소한 하나의 업데이트 데이터가 있는지 검증
-        if (updateRequest == null && (profileImage == null || profileImage.isEmpty())) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "업데이트할 정보가 없습니다.");
-        }
-
-        // null인 경우 빈 DTO 생성
-        if (updateRequest == null) {
-            updateRequest = UserUpdateRequestDto.builder().build();
-        }
-
-        UserDetailResponseDto response = userService.updateMyInfo(updateRequest, profileImage);
+        UserDetailResponseDto response = userService.updateMyInfo(updateRequest);
         return ResponseEntity.ok(response);
     }
 
@@ -93,6 +82,22 @@ public class UserController {
         Map<String, Boolean> response = new HashMap<>();
         response.put("available", isAvailable);
 
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 프로필 이미지 업데이트
+     * @param image 업로드할 프로필 이미지 파일
+     * @return 업데이트된 사용자 정보
+     */
+    @PostMapping(
+            value = "/me/profile-image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<UserDetailResponseDto> updateProfileImage(
+            @RequestPart("image") MultipartFile image) {
+        log.info("프로필 이미지 업데이트 요청 - 파일명: {}", image.getOriginalFilename());
+        UserDetailResponseDto response = userService.updateProfileImage(image);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/user/dto/ProfileImageUpdateRequestDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/ProfileImageUpdateRequestDto.java
@@ -1,4 +1,13 @@
 package org.swyp.dessertbee.user.dto;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class ProfileImageUpdateRequestDto {
+    private MultipartFile image;
 }

--- a/src/main/java/org/swyp/dessertbee/user/dto/ProfileImageUpdateRequestDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/ProfileImageUpdateRequestDto.java
@@ -1,0 +1,4 @@
+package org.swyp.dessertbee.user.dto;
+
+public class ProfileImageUpdateRequestDto {
+}

--- a/src/main/java/org/swyp/dessertbee/user/dto/UserDetailResponseDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/UserDetailResponseDto.java
@@ -18,9 +18,9 @@ public class UserDetailResponseDto extends UserResponseDto {
 
     @Builder(builderMethodName = "detailBuilder")
     public UserDetailResponseDto(String userUuid, String nickname, UserEntity.Gender gender,
-                                 Long imageId, List<Long> preferences, String mbti,
+                                 String profileImage, List<Long> preferences, String mbti,
                                  String email, String name, String phoneNumber, String address) {
-        super(userUuid, nickname, gender, imageId, preferences, mbti);
+        super(userUuid, nickname, gender, profileImage, preferences, mbti);
         this.email = email;
         this.name = name;
         this.phoneNumber = phoneNumber;

--- a/src/main/java/org/swyp/dessertbee/user/dto/UserOAuthDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/UserOAuthDto.java
@@ -31,7 +31,6 @@ public class UserOAuthDto {
     public static UserOAuthDto fromEntity(UserEntity entity, List<String> roles) {
         return UserOAuthDto.builder()
                 .id(entity.getId())
-                .imageId(entity.getImageId())
                 .userUuid(entity.getUserUuid())
                 .email(entity.getEmail())
                 .nickname(entity.getNickname())

--- a/src/main/java/org/swyp/dessertbee/user/dto/UserResponseDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/UserResponseDto.java
@@ -14,17 +14,17 @@ public class UserResponseDto {
     private String userUuid;  // 필수
     private String nickname;  // 필수
     private UserEntity.Gender gender;    // 선택
-    private Long imageId;     // 선택
+    private String profileImageUrl;  // 선택
     private List<Long> preferences;  // 선택
     private String mbti;     // 선택
 
     @Builder
     public UserResponseDto(String userUuid, String nickname, UserEntity.Gender gender,
-                           Long imageId, List<Long> preferences, String mbti) {
+                           String profileImageUrl, List<Long> preferences, String mbti) {
         this.userUuid = userUuid;
         this.nickname = nickname;
         this.gender = gender;
-        this.imageId = imageId;
+        this.profileImageUrl = profileImageUrl;
         this.preferences = preferences;
         this.mbti = mbti;
     }

--- a/src/main/java/org/swyp/dessertbee/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/UserUpdateRequestDto.java
@@ -21,12 +21,12 @@ public class UserUpdateRequestDto {
     private String address;
     private UserEntity.Gender gender;
     private String mbti;
-    private Long imageId;
+    private Boolean removeProfileImage;  // 프로필 이미지 제거 플래그 추가
 
     @Builder
     public UserUpdateRequestDto(String nickname, List<Long> preferences, String name,
                                 String phoneNumber, String address, UserEntity.Gender gender,
-                                String mbti, Long imageId) {
+                                String mbti, Boolean removeProfileImage) {
         this.nickname = nickname;
         this.preferences = preferences;
         this.name = name;
@@ -34,6 +34,6 @@ public class UserUpdateRequestDto {
         this.address = address;
         this.gender = gender;
         this.mbti = mbti;
-        this.imageId = imageId;
+        this.removeProfileImage = removeProfileImage;
     }
 }

--- a/src/main/java/org/swyp/dessertbee/user/entity/MbtiEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/MbtiEntity.java
@@ -23,8 +23,4 @@ public class MbtiEntity {
 
     @Column(name = "mbti_desc", length = 200)
     private String mbtiDesc;
-
-    @OneToOne(mappedBy = "mbti")
-    private UserEntity user;
-
 }

--- a/src/main/java/org/swyp/dessertbee/user/entity/NicknameValidationPurpose.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/NicknameValidationPurpose.java
@@ -1,5 +1,8 @@
 package org.swyp.dessertbee.user.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum NicknameValidationPurpose {
     SIGNUP("회원가입"),
     PROFILE_UPDATE("프로필 수정");
@@ -10,7 +13,4 @@ public enum NicknameValidationPurpose {
         this.description = description;
     }
 
-    public String getDescription() {
-        return description;
-    }
 }

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -34,9 +34,6 @@ public class UserEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "image_id")
-    private Long imageId;
-
     @Column(name = "user_uuid", nullable = false, unique = true, updatable = false)
     @UuidGenerator
     private UUID userUuid;

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -81,8 +81,8 @@ public class UserEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<UserPreferenceEntity> userPreferences = new HashSet<>();
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mbti_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mbti_id", nullable = true)
     private MbtiEntity mbti;
 
     public void addRole(RoleEntity role) {

--- a/src/main/java/org/swyp/dessertbee/user/service/UserService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserService.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.user.service;
 
+import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.user.dto.UserDetailResponseDto;
 import org.swyp.dessertbee.user.dto.UserResponseDto;
 import org.swyp.dessertbee.user.dto.UserUpdateRequestDto;
@@ -24,7 +25,7 @@ public interface UserService {
      * 현재 인증된 사용자의 정보를 수정합니다.
      * @return 사용자 상세 정보 DTO
      */
-    UserDetailResponseDto updateMyInfo(UserUpdateRequestDto updateRequest);
+    UserDetailResponseDto updateMyInfo(UserUpdateRequestDto updateRequest, MultipartFile profileImage);
 
     /**
      * 현재 인증된 사용자의 계정을 비활성화(소프트 삭제)합니다.

--- a/src/main/java/org/swyp/dessertbee/user/service/UserService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserService.java
@@ -25,7 +25,7 @@ public interface UserService {
      * 현재 인증된 사용자의 정보를 수정합니다.
      * @return 사용자 상세 정보 DTO
      */
-    UserDetailResponseDto updateMyInfo(UserUpdateRequestDto updateRequest, MultipartFile profileImage);
+    UserDetailResponseDto updateMyInfo(UserUpdateRequestDto updateRequest);
 
     /**
      * 현재 인증된 사용자의 계정을 비활성화(소프트 삭제)합니다.
@@ -38,4 +38,11 @@ public interface UserService {
      * @return 사용 가능 여부
      */
     boolean checkNicknameAvailability(String nickname, NicknameValidationPurpose purpose);
+
+    /**
+     * @param image 새로운 프로필 이미지 파일
+     * @return 업데이트된 사용자 정보
+     */
+    UserDetailResponseDto updateProfileImage(MultipartFile image);
+
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,3 +16,6 @@ spring:
   graphql:
     cors:
       allowed-origins: "http://localhost:3000"
+app:
+  client:
+    redirect-url: "http://localhost:3000"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,4 +12,7 @@ spring:
             redirect-uri: "http://${SERVER_HOST}:8080/${KAKAO_REDIRECT_URI}"
   graphql:
     cors:
-      allowed-origins: "https://desserbee.com,https://www.desserbee.com,http://desserbee.com,http://www.desserbee.com"
+      allowed-origins: "https://desserbee.com,https://www.desserbee.com,http://desserbee.com,http://www.desserbee.com,https://api.desserbee.com"
+app:    # 추가
+  client:    # 추가
+    redirect-url: "https://desserbee.com"    # 추가


### PR DESCRIPTION
## :hash: 연관된 이슈
#42 

## :memo: 작업 내용
- 유저 회원가입 시 프로필 이미지 multipart/form-data로 받기 -> 따로 프로필만 수정하는 것으로 변경
- 유저 회원 정보 업데이트 시 이미지 multipart/form-data로 받기 -> 따로 프로필만 수정하는 것으로 변경
- uploadAndSaveImage 에 에러 핸들링 추가
- OAuth 로그인 후 리다이렉트 하도록 설정(쿠키 포함)
- CORS 설정 추가
### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2252abb5-ccc7-4081-b36d-b328fb9297b7)
