### PR TITLE
[Refactor] 디저트메이트 에러 핸들링 추가

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -45,7 +45,13 @@ public enum ErrorCode {
     FILE_UPDATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F002", "파일 업데이트에 실패했습니다."),
     FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "파일 삭제에 실패했습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "F004", "지원하지 않는 파일 형식입니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F005", "파일 크기가 제한을 초과했습니다.");
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F005", "파일 크기가 제한을 초과했습니다."),
+
+
+    MATE_NOT_FOUND(HttpStatus.NOT_FOUND,"M001" ,"존재하지 않는 디저트메이트입니다." ),
+    DUPLICATE_APPLY(HttpStatus.CONFLICT, "MOO2", "이미 신청된 아이디입니다."),
+    MATES_NOT_FOUND(HttpStatus.NOT_FOUND, "M003", "해당 범위에서 메이트 데이터를 찾을 수 없습니다."),
+    INVALID_RANGE(HttpStatus.BAD_REQUEST, "M004", "잘못된 범위 요청입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -49,9 +49,13 @@ public enum ErrorCode {
 
 
     MATE_NOT_FOUND(HttpStatus.NOT_FOUND,"M001" ,"존재하지 않는 디저트메이트입니다." ),
-    DUPLICATE_APPLY(HttpStatus.CONFLICT, "MOO2", "이미 신청된 아이디입니다."),
-    MATES_NOT_FOUND(HttpStatus.NOT_FOUND, "M003", "해당 범위에서 메이트 데이터를 찾을 수 없습니다."),
-    INVALID_RANGE(HttpStatus.BAD_REQUEST, "M004", "잘못된 범위 요청입니다.");
+    MATES_NOT_FOUND(HttpStatus.NOT_FOUND, "M002", "해당 범위에서 메이트 데이터를 찾을 수 없습니다."),
+    INVALID_RANGE(HttpStatus.BAD_REQUEST, "M003", "잘못된 범위 요청입니다."),
+    MATE_APPLY_WAIT(HttpStatus.CONFLICT, "M004", "메이트 신청 대기 중입니다."),
+    MATE_APPLY_BANNED(HttpStatus.FORBIDDEN, "M005" , "디저트메이트 강퇴 당한 사람입니다. 신청 불가능합니다."),
+    MATE_APPLY_REJECT(HttpStatus.FORBIDDEN, "M006" , "거절 된 메이트입니다. 신청 불가능합니다."),
+    ALREADY_TEAM_MEMBER(HttpStatus.CONFLICT,"M007" , "해당 사용자는 이미 팀원입니다."),
+    MATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "M008","메이트 관리자 권한이 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.swyp.dessertbee.mate.exception.MateExceptions.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -63,8 +64,6 @@ public class MateController {
         //디저트메이트 삭제
         mateService.deleteMate(mateUuid);
 
-        //디저트메이트 멤버 삭제
-        mateMemberService.deleteAllMember(mateUuid);
         return ResponseEntity.ok("디저트메이트가 성공적으로 삭제되었습니다.");
     }
 
@@ -76,8 +75,7 @@ public class MateController {
     public ResponseEntity<String> updateMate(
             @PathVariable UUID mateUuid,
             @RequestPart("request") MateCreateRequest request,
-            @RequestPart(value = "mateImage", required = false) MultipartFile mateImage
-    ){
+            @RequestPart(value = "mateImage", required = false) MultipartFile mateImage ){
 
         mateService.updateMate(mateUuid, request, mateImage);
         return ResponseEntity.ok("디저트메이트가 성공적으로 수정되었습니다.");
@@ -93,11 +91,6 @@ public class MateController {
             @RequestParam int from,
             @RequestParam int to
     ) {
-
-        if (from >= to) {
-            throw new IllegalArgumentException("잘못된 범위 설정");
-        }
-
 
         return ResponseEntity.ok(mateService.getMates(from, to));
     }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
@@ -2,6 +2,7 @@ package org.swyp.dessertbee.mate.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.mate.dto.response.MateMemberResponse;
@@ -22,7 +23,7 @@ public class MateMemberController {
      * 디저트 메이트 멤버 전체 조회
      * */
     @GetMapping("/members")
-    public ResponseEntity<List<MateMemberResponse>> getMembers(@PathVariable UUID mateUuid) {
+    public ResponseEntity<List<MateMemberResponse>> getMembers(@PathVariable UUID mateUuid) throws BadRequestException {
 
         return ResponseEntity.ok(memberService.getMembers(mateUuid));
     }
@@ -31,7 +32,7 @@ public class MateMemberController {
      * 디저트 메이트 멤버 신청 api
      * */
     @PostMapping("/apply")
-    public ResponseEntity<String> applyMate(@PathVariable UUID mateUuid, UUID userUuid) {
+    public ResponseEntity<String> applyMate(@PathVariable UUID mateUuid, UUID userUuid) throws BadRequestException {
 
         memberService.applyMate(mateUuid,userUuid);
         return ResponseEntity.ok("디저트메이트에 성공적으로 신청되었습니다.");
@@ -41,7 +42,7 @@ public class MateMemberController {
      * 디저트 메이트 멤버 신청 수락 api
      * */
     @PatchMapping("/apply")
-    public ResponseEntity<String> acceptMemeber(@PathVariable UUID mateUuid, UUID userUuid) {
+    public ResponseEntity<String> acceptMemeber(@PathVariable UUID mateUuid, UUID userUuid) throws BadRequestException {
 
         memberService.acceptMember(mateUuid, userUuid);
         return ResponseEntity.ok("팀원이 되었습니다~!");
@@ -51,7 +52,7 @@ public class MateMemberController {
      * 디저트 메이트 멤버 신청 거절 api
      * */
     @DeleteMapping("/apply")
-    public ResponseEntity<String> rejectMemeber(@PathVariable UUID mateUuid, UUID userUuid) {
+    public ResponseEntity<String> rejectMemeber(@PathVariable UUID mateUuid, UUID userUuid) throws BadRequestException {
 
         memberService.rejectMember(mateUuid, userUuid);
 

--- a/src/main/java/org/swyp/dessertbee/mate/dto/MateUserIds.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/MateUserIds.java
@@ -1,0 +1,11 @@
+package org.swyp.dessertbee.mate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MateUserIds {
+    private final Long mateId;
+    private final Long userId;
+}

--- a/src/main/java/org/swyp/dessertbee/mate/exception/MateExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/mate/exception/MateExceptions.java
@@ -25,17 +25,6 @@ public class MateExceptions {
         }
     }
 
-    /**
-     * 디저트메이트 신청 중복
-     * */
-    public static class DuplicateApplyException extends BusinessException {
-        public DuplicateApplyException(){super(ErrorCode.DUPLICATE_APPLY);}
-
-        public DuplicateApplyException(String message) {
-            super(ErrorCode.USER_NOT_FOUND,message );
-        }
-
-    }
 
     /**
      * 디저트메이트 목록 조회 예외(잘못된 범위 설정)
@@ -47,4 +36,64 @@ public class MateExceptions {
             super(ErrorCode.INVALID_RANGE, message);
         }
     }
+
+    /**
+     * 디저트메이트 신청 대기 예외
+     * */
+    public static class MateApplyWaitException extends BusinessException {
+        public MateApplyWaitException(){super(ErrorCode.MATE_APPLY_WAIT);}
+
+        public MateApplyWaitException(String message) {
+            super(ErrorCode.MATE_APPLY_WAIT, message);
+        }
+    }
+
+    /**
+     * 디저트메이트 신청 강퇴 예외
+     * */
+    public static class MateApplyBannedException extends BusinessException {
+
+        public MateApplyBannedException(){super(ErrorCode.MATE_APPLY_REJECT);}
+
+        public MateApplyBannedException(String message) {
+            super(ErrorCode.MATE_APPLY_BANNED, message);
+        }
+    }
+
+    /**
+     * 디저트메이트 신청 거절 예외
+     * */
+    public static class MateApplyRejectException extends BusinessException {
+        public MateApplyRejectException(){super(ErrorCode.MATE_APPLY_REJECT);}
+        public MateApplyRejectException(String message) {
+            super(ErrorCode.MATE_APPLY_REJECT, message);
+        }
+    }
+
+    /**
+     * 디저트메이트 신청자가 기존 팀원일 때 예외
+     * */
+    public static class AlreadyTeamMemberException extends BusinessException {
+        public AlreadyTeamMemberException() {
+            super(ErrorCode.ALREADY_TEAM_MEMBER);
+        }
+        public AlreadyTeamMemberException(String message) {
+            super(ErrorCode.ALREADY_TEAM_MEMBER, message);
+        }
+    }
+
+    /**
+     * 관리자 권한 예외
+     * */
+    public static class PermissionDeniedException extends BusinessException {
+        public PermissionDeniedException(){
+            super(ErrorCode.MATE_PERMISSION_DENIED);
+        }
+        public PermissionDeniedException(String message) {
+            super(ErrorCode.MATE_PERMISSION_DENIED,message);
+        }
+    }
+
+
+
 }

--- a/src/main/java/org/swyp/dessertbee/mate/exception/MateExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/mate/exception/MateExceptions.java
@@ -1,0 +1,50 @@
+package org.swyp.dessertbee.mate.exception;
+
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+
+public class MateExceptions {
+
+
+    /**
+     * 디저트메이트 없을 때 예외
+     * */
+    public static class MateNotFoundException extends BusinessException {
+        public MateNotFoundException(){super(ErrorCode.MATE_NOT_FOUND);}
+
+        public  MateNotFoundException(String message) {
+            super(ErrorCode.MATE_NOT_FOUND, message);
+        }
+    }
+
+    public static class UserNotFoundExcption extends BusinessException {
+        public UserNotFoundExcption(){super(ErrorCode.USER_NOT_FOUND);}
+
+        public UserNotFoundExcption(String message) {
+            super(ErrorCode.USER_NOT_FOUND,message );
+        }
+    }
+
+    /**
+     * 디저트메이트 신청 중복
+     * */
+    public static class DuplicateApplyException extends BusinessException {
+        public DuplicateApplyException(){super(ErrorCode.DUPLICATE_APPLY);}
+
+        public DuplicateApplyException(String message) {
+            super(ErrorCode.USER_NOT_FOUND,message );
+        }
+
+    }
+
+    /**
+     * 디저트메이트 목록 조회 예외(잘못된 범위 설정)
+     * */
+    public static class FromToMateException extends BusinessException {
+        public FromToMateException(){super(ErrorCode.INVALID_RANGE);}
+
+        public FromToMateException(String message) {
+            super(ErrorCode.INVALID_RANGE, message);
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -3,22 +3,22 @@ package org.swyp.dessertbee.mate.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
 import org.springframework.stereotype.Service;
 import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.service.ImageService;
+import org.swyp.dessertbee.mate.dto.MateUserIds;
 import org.swyp.dessertbee.mate.dto.response.MateMemberResponse;
-import org.swyp.dessertbee.mate.entity.Mate;
 import org.swyp.dessertbee.mate.entity.MateMember;
 import org.swyp.dessertbee.mate.entity.MateMemberGrade;
 import org.swyp.dessertbee.mate.repository.MateMemberRepository;
 import org.swyp.dessertbee.mate.repository.MateRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
+import org.swyp.dessertbee.mate.exception.MateExceptions.*;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +40,7 @@ public class MateMemberService {
     public void addCreatorAsMember(UUID mateUuid, Long userId) {
 
         Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+
         //mateMember 테이블에 생성자 등록
         mateMemberRepository.save(
                 MateMember.builder()
@@ -53,10 +54,7 @@ public class MateMemberService {
     /**
      * 디저트메이트 삭제 시 멤버 삭제
      * */
-    public void deleteAllMember(UUID mateUuid) {
-
-        //mateUuid로 mateId 조회
-        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+    public void deleteAllMember(Long mateId) {
 
         try {
 
@@ -87,14 +85,10 @@ public class MateMemberService {
      * */
     public List<MateMemberResponse> getMembers(UUID mateUuid) {
 
-        //mateUuid로 mateId 조회
-        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+        //mateId 유효성 검사
+        MateUserIds validateMate = validateMate(mateUuid);
 
-        //mateId 존재 여부 확인
-        mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 디저트메이트입니다."));
-
-        List<MateMember> mateMembers = mateMemberRepository.findByMateIdAndDeletedAtIsNullAndApprovalYnTrue(mateId);
+        List<MateMember> mateMembers = mateMemberRepository.findByMateIdAndDeletedAtIsNullAndApprovalYnTrue(validateMate.getMateId());
 
         //userId로 userUuid 조회
         List<UserEntity> users = mateMembers.stream()
@@ -108,10 +102,15 @@ public class MateMemberService {
         return mateMembers.stream()
                 .map(mateMember -> {
                     // 사용자 정보 찾기
-                    UserEntity user = users.stream()
-                            .filter(u -> u.getId().equals(mateMember.getUserId()))
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+                    UserEntity user = null;
+                    try {
+                        user = users.stream()
+                                .filter(u -> u.getId().equals(mateMember.getUserId()))
+                                .findFirst()
+                                .orElseThrow(() -> new UserNotFoundExcption("사용자 정보를 찾을 수 없습니다."));
+                    } catch (UserNotFoundExcption e) {
+                        throw new RuntimeException(e);
+                    }
 
                     // 사용자별 프로필 이미지 조회
                     List<String> userImages = imageService.getImagesByTypeAndId(ImageType.PROFILE, user.getId());
@@ -125,26 +124,16 @@ public class MateMemberService {
     /**
      * 디저트메이트 신청 api
      * */
-    public void applyMate(UUID mateUuid, UUID userUuid) {
-        //mateUuid로 mateId 조회
-        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
-
-        //mateId 존재 여부 확인
-        mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 디저트메이트입니다."));
-
-        //userUuid로 userId 조회
-        Long userId = userRepository.findIdByUserUuid(userUuid);
-
-        //userId 존재 여부 확인
-        if (userId == null) {
-            throw new IllegalArgumentException("존재하지 않는 유저입니다.");
-        }
+    public void applyMate(UUID mateUuid, UUID userUuid) throws BadRequestException {
+        //mateId,userId  유효성 검사
+        MateUserIds validate = validateMateAndUser(mateUuid, userUuid);
+        Long mateId = validate.getMateId();
+        Long userId = validate.getUserId();
 
         MateMember mateMember = mateMemberRepository.findByMateIdAndUserId(mateId, userId);
 
         if(mateMember != null) {
-            throw new IllegalArgumentException("신청한 유저입니다. 신청 불가능합니다.");
+            throw new DuplicateApplyException("신청한 유저입니다. 신청 불가능합니다.");
         }
 
         //mateMember 테이블에 신청자 등록
@@ -161,16 +150,11 @@ public class MateMemberService {
     /**
      * 디저트 메이트 멤버 신청 수락 api
      * */
-    public void acceptMember(UUID mateUuid, UUID userUuid) {
-        //mateUuid로 mateId 조회
-        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
-
-        //mateId 존재 여부 확인
-        mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 디저트메이트입니다."));
-
-        //userUuid로 userId 조회
-        Long userId = userRepository.findIdByUserUuid(userUuid);
+    public void acceptMember(UUID mateUuid, UUID userUuid){
+        //mateId,userId  유효성 검사
+        MateUserIds validate = validateMateAndUser(mateUuid, userUuid);
+        Long mateId = validate.getMateId();
+        Long userId = validate.getUserId();
 
         mateMemberRepository.updateApprovalYn(mateId, userId);
     }
@@ -180,23 +164,14 @@ public class MateMemberService {
      * */
     public void rejectMember(UUID mateUuid, UUID userUuid) {
 
-        //mateUuid로 mateId 조회
-        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
-
-
-        //mateId 존재 여부 확인
-        mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 디저트메이트입니다."));
-
-        //userUuid로 userId 조회
-        Long userId = userRepository.findIdByUserUuid(userUuid);
-        if (userId == null) {
-            throw new IllegalArgumentException("해당하는 사용자를 찾을 수 없습니다.");
-        }
+        //mateId,userId  유효성 검사
+        MateUserIds validate = validateMateAndUser(mateUuid, userUuid);
+        Long mateId = validate.getMateId();
+        Long userId = validate.getUserId();
 
         MateMember mateMember = mateMemberRepository.findByMateIdAndUserId(mateId, userId);
         if (mateMember == null) {
-            throw new IllegalArgumentException("해당하는 멤버가 존재하지 않습니다.");
+            throw new UserNotFoundExcption("디저트메이트 멤버로 존재하지 않는 유저입니다.");
         }
 
         try {
@@ -210,4 +185,58 @@ public class MateMemberService {
             throw new RuntimeException("디저트메이트 멤버 삭제 실패: " + e.getMessage(), e);
         }
     }
+
+    /**
+     * Mate와 User 한번에 유효성 검사
+     * */
+    public MateUserIds validateMateAndUser(UUID mateUuid, UUID userUuid) {
+        // mateUuid로 mateId 조회
+        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+
+        mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
+                .orElseThrow(() -> new MateNotFoundException("존재하지 않는 디저트메이트입니다."));
+
+        // userUuid로 userId 조회
+        Long userId = userRepository.findIdByUserUuid(userUuid);
+        if (userId == null) {
+            throw new UserNotFoundExcption("존재하지 않는 유저입니다.");
+        }
+        return new MateUserIds(mateId, userId);
+
+    }
+
+    /**
+     * Mate만 유효성 검사
+     * */
+    public MateUserIds validateMate(UUID mateUuid) {
+
+
+
+        // mateUuid로 mateId 조회
+        Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
+
+
+
+        mateRepository.findByMateIdAndDeletedAtIsNull(mateId)
+                .orElseThrow(() -> new MateNotFoundException("존재하지 않는 디저트메이트입니다."));
+
+
+        return new MateUserIds(mateId,null);
+    }
+
+
+    /**
+     * User만 유효성 검사
+     * */
+    public MateUserIds validateUser(UUID userUuid) {
+
+        // userUuid로 userId 조회
+        Long userId = userRepository.findIdByUserUuid(userUuid);
+
+        if (userId == null) {
+            throw new UserNotFoundExcption("존재하지 않는 유저입니다.");
+        }
+        return new MateUserIds(null,userId);
+    }
+
 }


### PR DESCRIPTION
## :hash: 연관된 이슈

> 46

## :memo: 작업 내용

> 디저트 메이트 기능(댓글, saved 기능 제외) 현재까지 나온 api 들 에러 핸들링

### 스크린샷 (선택)

<img width="524" alt="스크린샷 2025-02-19 오전 6 13 42" src="https://github.com/user-attachments/assets/a7b23efe-13d0-4d4e-9e3c-ce03ca4260b4" />

## :speech_balloon: 리뷰 요구사항(선택)

> 더 추가해야할 예외들이 있을까요?
