### PR TITLE
[FIX] 리프레시 토큰 만료시간 설정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/dto/signup/SignUpRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/signup/SignUpRequest.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.swyp.dessertbee.role.entity.RoleType;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
 import java.util.List;
@@ -51,4 +52,8 @@ public class SignUpRequest {
     private UserEntity.Gender gender; // 성별
 
     private List<Long> preferenceIds; // 선호도 ID 목록
+
+    @Builder.Default
+    private RoleType role = RoleType.ROLE_USER; // 기본값 ROLE_USER 설정
+
 }

--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
@@ -66,8 +66,15 @@ public class JWTFilter extends OncePerRequestFilter {
      * Request Header에서 토큰 추출
      */
     private String extractTokenFromHeader(HttpServletRequest request) {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+        // 대소문자 구분 없이 모든 헤더를 확인
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER.toLowerCase());
+        if (bearerToken == null) {
+            // 첫 번째 시도가 실패하면 원래 대문자 버전으로 시도
+            bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        }
+
+        if (StringUtils.hasText(bearerToken) &&
+                bearerToken.toLowerCase().startsWith(BEARER_PREFIX.toLowerCase())) {
             return bearerToken.substring(BEARER_PREFIX.length());
         }
         return null;

--- a/src/main/java/org/swyp/dessertbee/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/CustomOAuth2UserService.java
@@ -91,7 +91,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .nickname(user.getNickname())
                 .userUuid(user.getUserUuid())
                 .roles(user.getUserRoles().stream()
-                        .map(userRole -> userRole.getRole().getName())
+                        .map(userRole -> userRole.getRole().getName().getRoleName())
                         .collect(Collectors.toList()))
                 .build();
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
@@ -122,7 +122,7 @@ public class TokenService {
 
             // 새로운 Access Token 생성
             List<String> roles = user.getUserRoles().stream()
-                    .map(userRole -> userRole.getRole().getName())
+                    .map(userRole -> userRole.getRole().getName().getRoleName())
                     .collect(Collectors.toList());
 
             boolean keepLoggedIn = false; // 로그인 유지 여부 (프론트엔드에서 전달받을 수도 있음)

--- a/src/main/java/org/swyp/dessertbee/role/entity/RoleEntity.java
+++ b/src/main/java/org/swyp/dessertbee/role/entity/RoleEntity.java
@@ -18,7 +18,8 @@ public class RoleEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, unique = true, length = 50)
-    private String name;
+    private RoleType name;
 
 }

--- a/src/main/java/org/swyp/dessertbee/role/entity/RoleType.java
+++ b/src/main/java/org/swyp/dessertbee/role/entity/RoleType.java
@@ -1,0 +1,31 @@
+package org.swyp.dessertbee.role.entity;
+
+public enum RoleType {
+    ROLE_USER("ROLE_USER", "일반 사용자"),
+    ROLE_OWNER("ROLE_OWNER", "사업자"),
+    ROLE_ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String roleName;
+    private final String description;
+
+    RoleType(String roleName, String description) {
+        this.roleName = roleName;
+        this.description = description;
+    }
+
+    public String getRoleName() {
+        return roleName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static RoleType fromString(String role) {
+        try {
+            return valueOf(role);
+        } catch (IllegalArgumentException e) {
+            return ROLE_USER; // 기본값
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/role/repository/RoleRepository.java
+++ b/src/main/java/org/swyp/dessertbee/role/repository/RoleRepository.java
@@ -2,9 +2,11 @@ package org.swyp.dessertbee.role.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.swyp.dessertbee.role.entity.RoleEntity;
+import org.swyp.dessertbee.role.entity.RoleType;
 
 import java.util.Optional;
 
 public interface RoleRepository extends JpaRepository<RoleEntity, Long> {
-    Optional<RoleEntity> findByName(String name);
+    Optional<RoleEntity> findByName(RoleType name);
+    boolean existsByName(RoleType name);
 }

--- a/src/main/java/org/swyp/dessertbee/role/service/RoleService.java
+++ b/src/main/java/org/swyp/dessertbee/role/service/RoleService.java
@@ -3,6 +3,7 @@ package org.swyp.dessertbee.role.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.swyp.dessertbee.role.entity.RoleEntity;
+import org.swyp.dessertbee.role.entity.RoleType;
 import org.swyp.dessertbee.role.repository.RoleRepository;
 
 @Service
@@ -10,8 +11,8 @@ import org.swyp.dessertbee.role.repository.RoleRepository;
 public class RoleService {
     private final RoleRepository roleRepository;
 
-    public RoleEntity findRoleByName(String roleName) {
-        return roleRepository.findByName(roleName)
-                .orElseThrow(() -> new RuntimeException("Role not found: " + roleName));
+    public RoleEntity findRoleByName(RoleType roleType) {
+        return roleRepository.findByName(roleType)
+                .orElseThrow(() -> new RuntimeException("Role not found: " + roleType));
     }
 }

--- a/src/main/java/org/swyp/dessertbee/role/service/UserRoleService.java
+++ b/src/main/java/org/swyp/dessertbee/role/service/UserRoleService.java
@@ -19,7 +19,7 @@ public class UserRoleService {
     // 유저의 역할 목록을 리스트로 가져옴
     public List<String> getUserRoles(UserEntity user) {
         return userRoleRepository.findByUserId(user.getId()).stream()
-                .map(userRole -> userRole.getRole().getName())
+                .map(userRole -> userRole.getRole().getName().getRoleName())
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/swyp/dessertbee/seeder/RoleSeeder.java
+++ b/src/main/java/org/swyp/dessertbee/seeder/RoleSeeder.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 import org.swyp.dessertbee.role.entity.RoleEntity;
+import org.swyp.dessertbee.role.entity.RoleType;
 import org.swyp.dessertbee.role.repository.RoleRepository;
 
 import java.util.List;
@@ -16,12 +17,13 @@ public class RoleSeeder implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        List<String> roles = List.of("ROLE_USER", "ROLE_ADMIN", "ROLE_OWNER");
-
-        for (String roleName : roles) {
-            if (roleRepository.findByName(roleName).isEmpty()) { // 없다면 추가, 있다면 추가하지 않음
-                roleRepository.save(RoleEntity.builder().name(roleName).build());
-                System.out.println("Seeded Role: " + roleName);
+        // RoleType enum의 모든 값을 순회
+        for (RoleType roleType : RoleType.values()) {
+            if (roleRepository.findByName(roleType).isEmpty()) {
+                roleRepository.save(RoleEntity.builder()
+                        .name(roleType)
+                        .build());
+                System.out.println("Seeded Role: " + roleType.getRoleName());
             }
         }
     }

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
@@ -7,8 +7,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.swyp.dessertbee.common.exception.BusinessException;
-import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.user.dto.NicknameValidationRequestDto;
 import org.swyp.dessertbee.user.dto.UserDetailResponseDto;
 import org.swyp.dessertbee.user.dto.UserResponseDto;

--- a/src/main/java/org/swyp/dessertbee/user/dto/UserDetailResponseDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/UserDetailResponseDto.java
@@ -15,6 +15,7 @@ public class UserDetailResponseDto extends UserResponseDto {
     private String name;     // 선택
     private String phoneNumber;  // 선택
     private String address;      // 선택
+    private Boolean isPreferencesSet;
 
     @Builder(builderMethodName = "detailBuilder")
     public UserDetailResponseDto(String userUuid, String nickname, UserEntity.Gender gender,
@@ -25,5 +26,7 @@ public class UserDetailResponseDto extends UserResponseDto {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.address = address;
+        this.isPreferencesSet = preferences != null && !preferences.isEmpty();
+
     }
 }


### PR DESCRIPTION
## :hash: 연관된 이슈
#49 

## :memo: 작업 내용
- 토큰 만료 및 생성 관련 시간대를 한국 서울 기준으로 수정함.
- Authorization Bearer 토큰 request Header 대문자 소문자 처리하도록 수정
- ROLE 역할에 따른 다른 ROLE의 부여 (기본은 ROLE_USER) 바디값을 통해 받도록 수정
- isPreferencesSet = true or false 로 바디값을 통해서 보내서 취향 설정 여부를 손쉽게 파악 가능

### 스크린샷 (선택)
<img width="746" alt="image" src="https://github.com/user-attachments/assets/f6a814c4-0d98-4656-a8b4-dd352ff6e16c" />