### PR TITLE
[Fix] 리스트에 가게 추가 시 api 요청형식 및 응답값 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
@@ -50,8 +50,8 @@ public class UserStoreController {
 
     /** 리스트에 가게 추가 */
     @PostMapping("/lists/{listId}/stores/{storeUuid}")
-    public ResponseEntity<SavedStoreResponse> addStoreToList(@PathVariable Long listId, @PathVariable UUID storeUuid) {
-        return ResponseEntity.ok(userStoreService.addStoreToList(listId, storeUuid));
+    public ResponseEntity<SavedStoreResponse> addStoreToList(@PathVariable Long listId, @PathVariable UUID storeUuid, @RequestBody List<String> userPreferences) {
+        return ResponseEntity.ok(userStoreService.addStoreToList(listId, storeUuid, userPreferences));
     }
 
     /** 리스트별 저장된 가게 조회 */

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/SavedStoreResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/SavedStoreResponse.java
@@ -17,4 +17,5 @@ public class SavedStoreResponse {
     private String storeName;
     private String storeAddress;
     private List<String> imageUrls;
+    private List<String> userPreferences;
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/entity/SavedStore.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/entity/SavedStore.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "saved_store")
@@ -26,6 +27,11 @@ public class SavedStore {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
+
+    @ElementCollection
+    @CollectionTable(name = "saved_store_preferences", joinColumns = @JoinColumn(name = "saved_store_id"))
+    @Column(name = "preference", nullable = false)
+    private List<String> userPreferences;
 
     @CreationTimestamp
     private LocalDateTime createdAt;

--- a/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
@@ -108,7 +108,7 @@ public class UserStoreService {
     }
 
     /** 리스트에 가게 추가 */
-    public SavedStoreResponse addStoreToList(Long listId, UUID storeUuid) {
+    public SavedStoreResponse addStoreToList(Long listId, UUID storeUuid, List<String> userPreferences) {
         UserStoreList list = userStoreListRepository.findById(listId)
                 .orElseThrow(() -> new IllegalArgumentException("저장 리스트를 찾을 수 없습니다."));
 
@@ -124,6 +124,7 @@ public class UserStoreService {
                 SavedStore.builder()
                         .userStoreList(list)
                         .store(store)
+                        .userPreferences(userPreferences)
                         .build()
         );
 
@@ -133,7 +134,8 @@ public class UserStoreService {
                 list.getListName(),
                 store.getName(),
                 store.getAddress(),
-                imageService.getImagesByTypeAndId(ImageType.STORE, store.getStoreId())
+                imageService.getImagesByTypeAndId(ImageType.STORE, store.getStoreId()),
+                savedStore.getUserPreferences()
         );
     }
 
@@ -149,7 +151,8 @@ public class UserStoreService {
                         list.getListName(),
                         savedStore.getStore().getName(),
                         savedStore.getStore().getAddress(),
-                        imageService.getImagesByTypeAndId(ImageType.STORE, savedStore.getStore().getStoreId())
+                        imageService.getImagesByTypeAndId(ImageType.STORE, savedStore.getStore().getStoreId()),
+                        savedStore.getUserPreferences()
                 ))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## :hash: 연관된 이슈

> #61 

## :memo: 작업 내용

> 저장 리스트에 가게 추가 시 요청값(@RequestBody)에 문자열 배열의 사용자 취향 값 포함
> 리스트에 가게 추가 시 응답값에 사용자 취향 데이터 포함
> 리스트에 가게 조회 시 응답값에 사용자 취향 데이터 포함
> saved_store_preference 테이블에 저장된 가게의 사용자 취향 값 저장 (saved_store_id로 연결)