### PR TITLE
[Feature] 디저트 메이트 댓글 API 구현

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -55,7 +55,9 @@ public enum ErrorCode {
     MATE_APPLY_BANNED(HttpStatus.FORBIDDEN, "M005" , "디저트메이트 강퇴 당한 사람입니다. 신청 불가능합니다."),
     MATE_APPLY_REJECT(HttpStatus.FORBIDDEN, "M006" , "거절 된 메이트입니다. 신청 불가능합니다."),
     ALREADY_TEAM_MEMBER(HttpStatus.CONFLICT,"M007" , "해당 사용자는 이미 팀원입니다."),
-    MATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "M008","메이트 관리자 권한이 없습니다.");
+    MATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "M008","메이트 관리자 권한이 없습니다."),
+    MATE_REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "M009" , "존재하지 않는 댓글입니다."),
+    MATE_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M010", "디저트메이트 멤버가 아닙니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -63,10 +63,10 @@ public class MateController {
      * 메이트 상세 정보 조회
      */
     @Operation(summary = "메이트 상세 정보 조회", description = "디저트메이트 상세 정보 조회합니다.")
-    @GetMapping("/{mateUuid}/details")
-    public ResponseEntity<MateDetailResponse> getMateDetails(@PathVariable UUID mateUuid) {
+    @GetMapping("/{mateUuid}")
+    public ResponseEntity<MateDetailResponse> getMateDetail(@PathVariable UUID mateUuid) {
 
-        MateDetailResponse mate = mateService.getMateDetails(mateUuid);
+        MateDetailResponse mate = mateService.getMateDetail(mateUuid);
         return ResponseEntity.ok(mate);
     }
 

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
@@ -13,9 +13,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.mate.dto.request.MateReplyCreateRequest;
+import org.swyp.dessertbee.mate.dto.response.MateReplyPageResponse;
 import org.swyp.dessertbee.mate.dto.response.MateReplyResponse;
 import org.swyp.dessertbee.mate.service.MateReplyService;
 
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "MateReply", description = "디저트메이트 댓글 관련 API")
@@ -70,4 +72,15 @@ public class MateReplyController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 디저트메이트 댓글 전체 조회
+     * */
+    @GetMapping
+    public ResponseEntity<MateReplyPageResponse> getReplies(@PathVariable UUID mateUuid,
+                                                           @RequestParam int from,
+                                                           @RequestParam int to) {
+
+
+        return ResponseEntity.ok(mateReplyService.getReplies(mateUuid, from, to));
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
@@ -1,0 +1,73 @@
+package org.swyp.dessertbee.mate.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.*;
+import org.swyp.dessertbee.mate.dto.request.MateReplyCreateRequest;
+import org.swyp.dessertbee.mate.dto.response.MateReplyResponse;
+import org.swyp.dessertbee.mate.service.MateReplyService;
+
+import java.util.UUID;
+
+@Tag(name = "MateReply", description = "디저트메이트 댓글 관련 API")
+@RestController
+@RequestMapping("api/mates/{mateUuid}/reply")
+@RequiredArgsConstructor
+public class MateReplyController {
+
+    private final MateReplyService mateReplyService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 디저트메이트 댓글 생성
+     * */
+    @Operation(summary = "메이트 댓글 생성", description = "디저트메이트를 댓글을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "디저트메이트 댓글 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @PostMapping
+    public ResponseEntity<MateReplyResponse> createReply(@RequestPart("request")  String requestJson,
+                                                         @PathVariable UUID mateUuid) {
+
+
+        MateReplyCreateRequest request;
+
+
+        try {
+
+            request = objectMapper.readValue(requestJson, MateReplyCreateRequest.class);
+
+        } catch (JsonProcessingException e) {
+
+            throw new RuntimeException(e);
+        }
+
+        MateReplyResponse response = mateReplyService.createReply(mateUuid, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+
+
+    /**
+     * 디저트메이트 댓글 조회(한개만)
+     * */
+    @GetMapping("/{replyId}")
+    public ResponseEntity<MateReplyResponse> getReplyDetail(@PathVariable UUID mateUuid, @PathVariable Long replyId) {
+
+        MateReplyResponse response = mateReplyService.getReplyDetail(mateUuid, replyId);
+
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
@@ -111,4 +111,14 @@ public class MateReplyController {
 
     }
 
+    /**
+     * 디저트메이트 댓글 삭제
+     * */
+    @DeleteMapping("{replyId}")
+    public ResponseEntity<String> deleteReply(@PathVariable UUID mateUuid, @PathVariable Long replyId) {
+
+        mateReplyService.deleteReply(mateUuid, replyId);
+
+        return ResponseEntity.ok("댓글이 성공적으로 삭제되었습니다.");
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
+import org.swyp.dessertbee.mate.dto.request.MateCreateRequest;
 import org.swyp.dessertbee.mate.dto.request.MateReplyCreateRequest;
 import org.swyp.dessertbee.mate.dto.response.MateReplyPageResponse;
 import org.swyp.dessertbee.mate.dto.response.MateReplyResponse;
@@ -83,4 +84,31 @@ public class MateReplyController {
 
         return ResponseEntity.ok(mateReplyService.getReplies(mateUuid, from, to));
     }
+
+    /**
+     * 디저트메이트 댓글 수정
+     * */
+    @PatchMapping("/{replyId}")
+    public ResponseEntity<String> updateMate(
+            @PathVariable UUID mateUuid,
+            @PathVariable Long replyId,
+            @RequestPart(value = "request") String requestJson
+    ){
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        MateReplyCreateRequest request;
+
+            //JSON 문자열을 MateCreateRequest 객체로 변환
+        try {
+            request = objectMapper.readValue(requestJson, MateReplyCreateRequest.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return ResponseEntity.badRequest().body(null);
+        }
+
+        mateReplyService.updateReply(mateUuid, replyId, request);
+        return ResponseEntity.ok("댓글이 성공적으로 수정되었습니다.");
+
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
@@ -8,6 +8,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
@@ -16,6 +19,7 @@ import org.swyp.dessertbee.mate.dto.request.MateCreateRequest;
 import org.swyp.dessertbee.mate.dto.request.MateReplyCreateRequest;
 import org.swyp.dessertbee.mate.dto.response.MateReplyPageResponse;
 import org.swyp.dessertbee.mate.dto.response.MateReplyResponse;
+import org.swyp.dessertbee.mate.exception.MateExceptions;
 import org.swyp.dessertbee.mate.service.MateReplyService;
 
 import java.util.List;
@@ -81,15 +85,20 @@ public class MateReplyController {
                                                            @RequestParam int from,
                                                            @RequestParam int to) {
 
+        if (from >= to) {
+            throw new MateExceptions.FromToMateException("잘못된 범위 요청입니다.");
+        }
 
-        return ResponseEntity.ok(mateReplyService.getReplies(mateUuid, from, to));
+        Pageable pageable = PageRequest.of(from, to, Sort.by("mateReplyId").ascending());
+
+        return ResponseEntity.ok(mateReplyService.getReplies(mateUuid, pageable));
     }
 
     /**
      * 디저트메이트 댓글 수정
      * */
     @PatchMapping("/{replyId}")
-    public ResponseEntity<String> updateMate(
+    public ResponseEntity<String> updateReply(
             @PathVariable UUID mateUuid,
             @PathVariable Long replyId,
             @RequestPart(value = "request") String requestJson

--- a/src/main/java/org/swyp/dessertbee/mate/dto/request/MateReplyCreateRequest.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/request/MateReplyCreateRequest.java
@@ -1,0 +1,32 @@
+package org.swyp.dessertbee.mate.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MateReplyCreateRequest {
+
+    @NotNull
+    private Long mateId;
+
+    @NotNull
+    private UUID userUuid;
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    private String content;
+
+    private String report;
+
+
+}

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
@@ -34,6 +34,7 @@ public class MateDetailResponse {
 
         return MateDetailResponse.builder()
                 .mateUuid(mate.getMateUuid())
+                .mateId(mate.getMateId())
                 .userId(mate.getUserId())
                 .userUuid(creator.getUserUuid())
                 .nickname(creator.getNickname())

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateReplyPageResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateReplyPageResponse.java
@@ -1,0 +1,16 @@
+package org.swyp.dessertbee.mate.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class MateReplyPageResponse {
+
+    private List<MateReplyResponse> mates;
+    private boolean isLast;
+}

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateReplyResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateReplyResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import org.swyp.dessertbee.mate.entity.MateMember;
 import org.swyp.dessertbee.mate.entity.MateReply;
+import org.swyp.dessertbee.user.entity.UserEntity;
 
 import java.util.UUID;
 
@@ -19,13 +20,14 @@ public class MateReplyResponse {
     private Long mateId;
     private UUID mateUuid;
     private Long userId;
+    private String nickname;
     private UUID userUuid;
     private String content;
 
 
     public static MateReplyResponse fromEntity(MateReply reply,
                                                UUID mateUuid,
-                                               UUID userUuid
+                                               UserEntity user
                                                ) {
 
         return MateReplyResponse.builder()
@@ -33,7 +35,8 @@ public class MateReplyResponse {
                 .mateId(reply.getMateId())
                 .mateUuid(mateUuid)
                 .userId(reply.getUserId())
-                .userUuid(userUuid)
+                .nickname(user.getNickname())
+                .userUuid(user.getUserUuid())
                 .content(reply.getContent())
                 .build();
 

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateReplyResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateReplyResponse.java
@@ -1,0 +1,41 @@
+package org.swyp.dessertbee.mate.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.swyp.dessertbee.mate.entity.MateMember;
+import org.swyp.dessertbee.mate.entity.MateReply;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class MateReplyResponse {
+
+
+    private Long mateReplyId;
+    private Long mateId;
+    private UUID mateUuid;
+    private Long userId;
+    private UUID userUuid;
+    private String content;
+
+
+    public static MateReplyResponse fromEntity(MateReply reply,
+                                               UUID mateUuid,
+                                               UUID userUuid
+                                               ) {
+
+        return MateReplyResponse.builder()
+                .mateReplyId(reply.getMateReplyId())
+                .mateId(reply.getMateId())
+                .mateUuid(mateUuid)
+                .userId(reply.getUserId())
+                .userUuid(userUuid)
+                .content(reply.getContent())
+                .build();
+
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateReply.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateReply.java
@@ -1,0 +1,41 @@
+package org.swyp.dessertbee.mate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mate_reply")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MateReply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mate_reply_id")
+    private Long mateReplyId;
+
+    @Column(name = "mate_id")
+    private Long mateId;    //메이트 테이블 조인하기 위해 필요(mate 테이블 고유 id)
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column
+    private String content;
+
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column
+    private String report;
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateReply.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateReply.java
@@ -3,6 +3,7 @@ package org.swyp.dessertbee.mate.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -33,9 +34,23 @@ public class MateReply {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @Column
     private String report;
+
+    public void update(String content){
+        this.content = content;
+    }
+
+
+    public void softDelete(){
+        this.deletedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateStatistics.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateStatistics.java
@@ -26,7 +26,7 @@ public class MateStatistics {
     private Integer views;
     private Integer saves;
     private Integer reviews;
-    private LocalDate createDate;
+
 
     @CreationTimestamp
     @Column(name = "created_at")

--- a/src/main/java/org/swyp/dessertbee/mate/exception/MateExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/mate/exception/MateExceptions.java
@@ -17,6 +17,9 @@ public class MateExceptions {
         }
     }
 
+    /**
+     * 유저 예외
+     * */
     public static class UserNotFoundExcption extends BusinessException {
         public UserNotFoundExcption(){super(ErrorCode.USER_NOT_FOUND);}
 
@@ -25,6 +28,13 @@ public class MateExceptions {
         }
     }
 
+    /**
+     * 디저트 메이트 멤버 예외
+     * */
+    public static class MateMemberNotFoundExcption extends BusinessException {
+        public MateMemberNotFoundExcption(){super(ErrorCode.MATE_MEMBER_NOT_FOUND);}
+        public MateMemberNotFoundExcption(String message) {super(ErrorCode.MATE_MEMBER_NOT_FOUND, message);}
+    }
 
     /**
      * 디저트메이트 목록 조회 예외(잘못된 범위 설정)
@@ -83,7 +93,7 @@ public class MateExceptions {
     }
 
     /**
-     * 관리자 권한 예외
+     * 디저트 메이트 멤버 관리자 권한 예외
      * */
     public static class PermissionDeniedException extends BusinessException {
         public PermissionDeniedException(){
@@ -95,5 +105,14 @@ public class MateExceptions {
     }
 
 
+    /**
+     *  디저트 메이트 댓글 예외
+     * */
+    public static class MateReplyNotFoundException extends BusinessException {
+        public MateReplyNotFoundException(){super(ErrorCode.MATE_REPLY_NOT_FOUND);}
 
+        public MateReplyNotFoundException(String message) {
+            super(ErrorCode.MATE_REPLY_NOT_FOUND, message);
+        }
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
@@ -1,9 +1,19 @@
 package org.swyp.dessertbee.mate.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.mate.entity.Mate;
 import org.swyp.dessertbee.mate.entity.MateReply;
+
+import java.util.List;
 
 @Repository
 public interface MateReplyRepository extends JpaRepository<MateReply, Long> {
+
+    /**
+     * 디저트메이트 댓글 전체 조회(삭제된 댓글 제외)
+     * */
+    @Query("SELECT m FROM MateReply m WHERE m.deletedAt IS NULL AND m.mateId = :mateId ORDER BY m.mateReplyId ASC LIMIT :limit OFFSET :from")
+    List<MateReply> findAllByDeletedAtIsNull(Long mateId, int from, int limit);
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
@@ -1,0 +1,9 @@
+package org.swyp.dessertbee.mate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.mate.entity.MateReply;
+
+@Repository
+public interface MateReplyRepository extends JpaRepository<MateReply, Long> {
+}

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
@@ -7,6 +7,7 @@ import org.swyp.dessertbee.mate.entity.Mate;
 import org.swyp.dessertbee.mate.entity.MateReply;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MateReplyRepository extends JpaRepository<MateReply, Long> {
@@ -16,4 +17,6 @@ public interface MateReplyRepository extends JpaRepository<MateReply, Long> {
      * */
     @Query("SELECT m FROM MateReply m WHERE m.deletedAt IS NULL AND m.mateId = :mateId ORDER BY m.mateReplyId ASC LIMIT :limit OFFSET :from")
     List<MateReply> findAllByDeletedAtIsNull(Long mateId, int from, int limit);
+
+    Optional<MateReply> findByMateIdAndDeletedAtIsNull(Long replyId);
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
@@ -19,4 +19,6 @@ public interface MateReplyRepository extends JpaRepository<MateReply, Long> {
     List<MateReply> findAllByDeletedAtIsNull(Long mateId, int from, int limit);
 
     Optional<MateReply> findByMateIdAndDeletedAtIsNull(Long replyId);
+
+    Optional<MateReply> findByMateIdAndMateReplyId(Long mateId, Long replyId);
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateReplyRepository.java
@@ -1,7 +1,10 @@
 package org.swyp.dessertbee.mate.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.mate.entity.Mate;
 import org.swyp.dessertbee.mate.entity.MateReply;
@@ -15,8 +18,8 @@ public interface MateReplyRepository extends JpaRepository<MateReply, Long> {
     /**
      * 디저트메이트 댓글 전체 조회(삭제된 댓글 제외)
      * */
-    @Query("SELECT m FROM MateReply m WHERE m.deletedAt IS NULL AND m.mateId = :mateId ORDER BY m.mateReplyId ASC LIMIT :limit OFFSET :from")
-    List<MateReply> findAllByDeletedAtIsNull(Long mateId, int from, int limit);
+    @Query("SELECT m FROM MateReply m WHERE m.deletedAt IS NULL AND m.mateId = :mateId")
+    Page<MateReply> findAllByDeletedAtIsNull(@Param("mateId") Long mateId, Pageable pageable);
 
     Optional<MateReply> findByMateIdAndDeletedAtIsNull(Long replyId);
 

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MateMemberService {
 
 
@@ -36,6 +35,7 @@ public class MateMemberService {
     /**
      * 디저트 메이트 생성 시 생성자 등록
      */
+    @Transactional
     public void addCreatorAsMember(UUID mateUuid, Long userId) {
 
         Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
@@ -54,6 +54,7 @@ public class MateMemberService {
     /**
      * 디저트메이트 삭제 시 멤버 삭제
      */
+    @Transactional
     public void deleteAllMember(Long mateId) {
 
         try {
@@ -82,6 +83,7 @@ public class MateMemberService {
     /**
      * 디저트 메이트 멤버 전체 조회
      */
+    @Transactional
     public List<MateMemberResponse> getMembers(UUID mateUuid) {
 
         //mateId 유효성 검사
@@ -125,6 +127,7 @@ public class MateMemberService {
      *
      * @return
      */
+    @Transactional
     public void applyMate(UUID mateUuid, UUID userUuid) {
         //mateId,userId  유효성 검사
         MateUserIds validate = validateMateAndUser(mateUuid, userUuid);
@@ -189,6 +192,7 @@ public class MateMemberService {
     /**
      * 디저트 메이트 멤버 신청 수락 api
      * */
+    @Transactional
     public void acceptMember (UUID mateUuid, UUID userUuid){
         //mateId,userId  유효성 검사
         MateUserIds validate = validateMateAndUser(mateUuid, userUuid);

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -283,7 +283,7 @@ public class MateMemberService {
         Long userId = validate.getUserId();
 
         MateMember mateMember = mateMemberRepository.findByMateIdAndUserId(mateId, userId)
-                .orElseThrow(() -> new UserNotFoundExcption("존재하지 않는 멤버입니다."));
+                .orElseThrow(() -> new MateMemberNotFoundExcption("존재하지 않는 멤버입니다."));
         try {
             mateMember.softDelete();
 
@@ -347,6 +347,11 @@ public class MateMemberService {
         if (userId == null) {
             throw new UserNotFoundExcption("존재하지 않는 유저입니다.");
         }
+
+        //디저트 메이트 멤버인지 확인
+        mateMemberRepository.findByMateIdAndUserId(mateId, userId)
+                .orElseThrow(() -> new MateMemberNotFoundExcption("디저트메이트 멤버가 아닙니다."));
+
         return new MateUserIds(mateId, userId);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateReplyService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateReplyService.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MateReplyService {
 
     private final MateReplyRepository replyRepository;
@@ -37,6 +36,7 @@ public class MateReplyService {
     /**
      * 디저트메이트 댓글 생성
      * */
+    @Transactional
     public MateReplyResponse createReply(UUID mateUuid, MateReplyCreateRequest request) {
 
         //디저트 메이트 유효성 검사

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateReplyService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateReplyService.java
@@ -7,6 +7,7 @@ import org.swyp.dessertbee.mate.dto.MateUserIds;
 import org.swyp.dessertbee.mate.dto.request.MateReplyCreateRequest;
 import org.swyp.dessertbee.mate.dto.response.MateReplyPageResponse;
 import org.swyp.dessertbee.mate.dto.response.MateReplyResponse;
+import org.swyp.dessertbee.mate.entity.Mate;
 import org.swyp.dessertbee.mate.entity.MateMember;
 import org.swyp.dessertbee.mate.entity.MateReply;
 import org.swyp.dessertbee.mate.repository.MateMemberRepository;
@@ -105,6 +106,23 @@ public class MateReplyService {
 
 
     /**
+     * 디저트메이트 댓글 수정
+     * */
+    public void updateReply(UUID mateUuid, Long replyId, MateReplyCreateRequest request) {
+
+        MateUserIds mateUserIds = validateMate(mateUuid);
+        Long mateId = mateUserIds.getMateId();
+
+        //replyId 존재 여부 확인
+        MateReply reply = mateReplyRepository.findByMateIdAndDeletedAtIsNull(replyId)
+                .orElseThrow(() -> new MateReplyNotFoundException("존재하지 않는 댓글입니다."));
+
+
+        reply.update(request.getContent());
+
+    }
+
+    /**
      * Mate와 User 한번에 유효성 검사
      * */
     private MateUserIds validateMateAndUser(UUID mateUuid, UUID userUuid) {
@@ -145,5 +163,4 @@ public class MateReplyService {
 
         return new MateUserIds(mateId, null);
     }
-
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateReplyService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateReplyService.java
@@ -76,6 +76,7 @@ public class MateReplyService {
     /**
      * 디저트메이트 댓글 전체 조회
      * */
+    @Transactional
     public MateReplyPageResponse getReplies(UUID mateUuid, int from, int to) {
 
         if (from >= to) {
@@ -108,6 +109,7 @@ public class MateReplyService {
     /**
      * 디저트메이트 댓글 수정
      * */
+    @Transactional
     public void updateReply(UUID mateUuid, Long replyId, MateReplyCreateRequest request) {
 
         MateUserIds mateUserIds = validateMate(mateUuid);
@@ -120,6 +122,32 @@ public class MateReplyService {
 
         reply.update(request.getContent());
 
+    }
+
+
+    /**
+     * 디저트메이트 댓글 삭제
+     * */
+    @Transactional
+    public void deleteReply(UUID mateUuid, Long replyId) {
+
+        MateUserIds mateUserIds = validateMate(mateUuid);
+        Long mateId = mateUserIds.getMateId();
+
+        MateReply mateReply = mateReplyRepository.findByMateIdAndMateReplyId(mateId, replyId)
+                .orElseThrow(() -> new MateReplyNotFoundException("존재하지 않는 댓글입니다."));
+
+        try {
+
+            mateReply.softDelete();
+
+            mateReplyRepository.save(mateReply);
+
+        } catch (Exception e) {
+
+            System.out.println("❌ 디저트메이트 멤버 탈퇴 중 오류 발생: " + e.getMessage());
+            throw new RuntimeException("디저트메이트 댓글 삭제 실패: " + e.getMessage(), e);
+        }
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -145,6 +145,9 @@ public class MateService {
 
     }
 
+    /**
+     * 디저트메이트 전체 조회
+     * */
     public MatesPageResponse getMates(int from, int to) {
 
 

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -69,12 +69,12 @@ public class MateService {
         //디저트 메이트 mateId를 가진 member 데이터 생성
         mateMemberService.addCreatorAsMember(mate.getMateUuid(), userId);
 
-        return getMateDetails(mate.getMateUuid());
+        return getMateDetail(mate.getMateUuid());
     }
 
 
     /** 메이트 상세 정보 */
-    public MateDetailResponse getMateDetails(UUID mateUuid) {
+    public MateDetailResponse getMateDetail(UUID mateUuid) {
 
         //mateUuid로 mateId 조회
         Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
@@ -176,5 +176,7 @@ public class MateService {
         return new MatesPageResponse(matesResponses, isLast);
 
     }
+
+
 
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MateService {
 
     private final UserRepository userRepository;
@@ -40,6 +39,7 @@ public class MateService {
 
 
     /** 메이트 등록 */
+    @Transactional
     public MateDetailResponse createMate(MateCreateRequest request, List<MultipartFile> mateImage){
 
         Long userId = userRepository.findIdByUserUuid(request.getUserUuid());
@@ -127,6 +127,7 @@ public class MateService {
     /**
      * 메이트 수정
      * */
+    @Transactional
     public void updateMate(UUID mateUuid, MateCreateRequest request, MultipartFile mateImage) {
         //mateUuid로 mateId 조회
         Long mateId = mateRepository.findMateIdByMateUuid(mateUuid);
@@ -148,6 +149,7 @@ public class MateService {
     /**
      * 디저트메이트 전체 조회
      * */
+    @Transactional
     public MatesPageResponse getMates(int from, int to) {
 
 

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -85,12 +85,12 @@ public class UserEntity {
     @JoinColumn(name = "mbti_id", nullable = true)
     private MbtiEntity mbti;
 
-    public boolean hasRole(String roleName) {
-        return userRoles.stream()
-                .map(UserRoleEntity::getRole)
-                .map(RoleEntity::getName)
-                .anyMatch(name -> name.equalsIgnoreCase(roleName));
-    }
+//    public boolean hasRole(String roleName) {
+//        return userRoles.stream()
+//                .map(UserRoleEntity::getRole)
+//                .map(RoleEntity::getName)
+//                .anyMatch(name -> name.equalsIgnoreCase(roleName));
+//    }
 
     public void addRole(RoleEntity role) {
         UserRoleEntity userRole = UserRoleEntity.builder()

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -85,13 +85,6 @@ public class UserEntity {
     @JoinColumn(name = "mbti_id", nullable = true)
     private MbtiEntity mbti;
 
-//    public boolean hasRole(String roleName) {
-//        return userRoles.stream()
-//                .map(UserRoleEntity::getRole)
-//                .map(RoleEntity::getName)
-//                .anyMatch(name -> name.equalsIgnoreCase(roleName));
-//    }
-
     public void addRole(RoleEntity role) {
         UserRoleEntity userRole = UserRoleEntity.builder()
                 .user(this)


### PR DESCRIPTION
## :hash: 연관된 이슈

> 58

## :memo: 작업 내용

> 디저트메이트 댓글 생성 API 구현
> 디저트메이트 댓글 조회(한개만) API 구현
> 디저트메이트 댓글 전체 조회 API 구현
> 디저트메이트 댓글 삭제 API 구현
> 디저트메이트 댓글 수정 API 구현

### 스크린샷 (선택)

## :speech_balloon: 리뷰 요구사항(선택)

