### PR TITLE
[FIX] 가게 간략 정보 조회 API 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
@@ -21,7 +21,7 @@ public interface StoreReviewRepository extends JpaRepository<StoreReview, Long> 
     /** 특정 가게에 존재하는 리뷰 목록 조회 **/
     List<StoreReview> findByStoreIdAndDeletedAtIsNull(Long storeId);
 
-    Optional<StoreReview> findByReviewId(Long reviewId);
+    Optional<StoreReview> findByReviewIdAndDeletedAtIsNull(Long reviewId);
 
     @Query("SELECT r.reviewId FROM StoreReview r WHERE r.reviewUuid = :reviewUuid")
     Long findReviewIdByReviewUuid(@Param("reviewUuid") UUID reviewUuid);

--- a/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewService.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewService.java
@@ -81,7 +81,7 @@ public class StoreReviewService {
     public StoreReviewResponse updateReview(UUID storeUuid, UUID reviewUuid, StoreReviewUpdateRequest request, List<MultipartFile> newImages) {
         Long storeId = storeRepository.findStoreIdByStoreUuid(storeUuid);
         Long reviewId = storeReviewRepository.findReviewIdByReviewUuid(reviewUuid);
-        StoreReview review = storeReviewRepository.findByReviewId(reviewId)
+        StoreReview review = storeReviewRepository.findByReviewIdAndDeletedAtIsNull(reviewId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 리뷰가 존재하지 않습니다."));
 
         // storeId 검증
@@ -109,7 +109,7 @@ public class StoreReviewService {
     public void deleteReview(UUID storeUuid, UUID reviewUuid) {
         Long storeId = storeRepository.findStoreIdByStoreUuid(storeUuid);
         Long reviewId = storeReviewRepository.findReviewIdByReviewUuid(reviewUuid);
-        StoreReview review = storeReviewRepository.findByReviewId(reviewId)
+        StoreReview review = storeReviewRepository.findByReviewIdAndDeletedAtIsNull(reviewId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 리뷰가 존재하지 않습니다."));
 
         // storeId 검증 추가

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/HolidayResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/HolidayResponse.java
@@ -1,0 +1,13 @@
+package org.swyp.dessertbee.store.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class HolidayResponse {
+    private String date;
+    private String reason;
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/OperatingHourResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/OperatingHourResponse.java
@@ -1,0 +1,19 @@
+package org.swyp.dessertbee.store.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class OperatingHourResponse {
+    private DayOfWeek dayOfWeek;
+    private LocalTime openingTime;
+    private LocalTime closingTime;
+    private LocalTime lastOrderTime;
+    private Boolean isClosed;
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
@@ -34,31 +34,12 @@ public class StoreDetailResponse {
     private BigDecimal averageRating;
     private List<MenuResponse> menus;
     private List<String> storeImages;
-    private List<String> ownerPickImages; // 사장님 픽 이미지 추가
+    private List<String> ownerPickImages;
     private List<StoreReviewResponse> storeReviews;
     private List<String> tags;
     private List<String> notice;
     private List<OperatingHourResponse> operatingHours;
     private List<HolidayResponse> holidays;
-
-    @Data
-    @Builder
-    @AllArgsConstructor
-    public static class OperatingHourResponse {
-        private DayOfWeek dayOfWeek;
-        private LocalTime openingTime;
-        private LocalTime closingTime;
-        private LocalTime lastOrderTime;
-        private Boolean isClosed;
-    }
-
-    @Data
-    @Builder
-    @AllArgsConstructor
-    public static class HolidayResponse {
-        private String date;
-        private String reason;
-    }
 
     public static StoreDetailResponse fromEntity(Store store, Long userId, UUID userUuid,
                                                  List<OperatingHourResponse> operatingHours,

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSummaryResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSummaryResponse.java
@@ -17,8 +17,12 @@ public class StoreSummaryResponse {
     private UUID storeUuid;
     private String name;
     private BigDecimal averageRating;
-    private List<String> tags;
     private List<String> storeImages;
+    private List<String> ownerPickImages;
+    private List<String> tags;
+    private List<OperatingHourResponse> operatingHours;
+    private List<HolidayResponse> holidays;
+    private List<String> topPreferences;
 
     private String address;
     private String phone;
@@ -29,7 +33,11 @@ public class StoreSummaryResponse {
     private Boolean parkingYn;
 
     public static StoreSummaryResponse fromEntity(Store store, List<String> tags,
-                                                  List<String> storeImages) {
+                                                  List<OperatingHourResponse> operatingHours,
+                                                  List<HolidayResponse> holidays,
+                                                  List<String> storeImages,
+                                                  List<String> ownerPickImages,
+                                                  List<String> topPreferences) {
         return StoreSummaryResponse.builder()
                 .storeId(store.getStoreId())
                 .storeUuid(store.getStoreUuid())
@@ -37,6 +45,10 @@ public class StoreSummaryResponse {
                 .averageRating(store.getAverageRating())
                 .tags(tags)
                 .storeImages(storeImages)
+                .ownerPickImages(ownerPickImages)
+                .operatingHours(operatingHours)
+                .holidays(holidays)
+                .topPreferences(topPreferences)
                 .address(store.getAddress())
                 .phone(store.getPhone())
                 .storeLink(store.getStoreLink())

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
@@ -2,6 +2,7 @@ package org.swyp.dessertbee.store.store.repository;
 
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.store.store.entity.SavedStore;
 import org.swyp.dessertbee.store.store.entity.Store;
@@ -15,10 +16,26 @@ public interface SavedStoreRepository extends JpaRepository<SavedStore, Long> {
     List<SavedStore> findByUserStoreList(UserStoreList userStoreList);
     Optional<SavedStore> findByUserStoreListAndStore(UserStoreList userStoreList, Store store);
 
+    /** 여러 저장 리스트에 포함된 모든 가게 조회 */
+    List<SavedStore> findByUserStoreListIn(List<UserStoreList> userStoreLists);
+
     /** 특정 저장 리스트에 저장된 가게 개수 반환 */
     int countByUserStoreList(UserStoreList userStoreList);
 
     /** 특정 리스트에 저장된 가게 삭제 */
     @Transactional
     void deleteByUserStoreList(UserStoreList userStoreList);
+
+    /** 특정 가게를 저장한 사람들의 취향 태그 Top3 조회 */
+    @Query(value = """
+        SELECT preference, COUNT(preference) AS preference_count
+        FROM saved_store_preferences
+        WHERE saved_store_id IN (
+            SELECT id FROM saved_store WHERE store_id = :storeId
+        )
+        GROUP BY preference
+        ORDER BY preference_count DESC
+        LIMIT 3
+    """, nativeQuery = true)
+    List<Object[]> findTop3PreferencesByStoreId(Long storeId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/UserStoreListRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/UserStoreListRepository.java
@@ -11,6 +11,9 @@ import java.util.List;
 public interface UserStoreListRepository extends JpaRepository<UserStoreList, Long> {
     List<UserStoreList> findByUser(UserEntity user);
 
-    /** 특정 유저가 가진 저장 리스트 개수 반환 */
-    long countByUser(UserEntity user);
+    /** 특정 유저가 같은 이름을 가진 저장 리스트가 있는지 확인 */
+    boolean existsByUserAndListName(UserEntity user, String listName);
+
+    /** 특정 유저가 같은 아이콘 색상을 가진 저장 리스트가 있는지 확인 */
+    boolean existsByUserAndIconColorId(UserEntity user, Long iconColorId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
@@ -5,6 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.service.ImageService;
+import org.swyp.dessertbee.preference.entity.PreferenceEntity;
+import org.swyp.dessertbee.preference.entity.UserPreferenceEntity;
+import org.swyp.dessertbee.preference.repository.PreferenceRepository;
 import org.swyp.dessertbee.store.store.dto.response.SavedStoreResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListResponse;
 import org.swyp.dessertbee.store.store.entity.SavedStore;
@@ -29,6 +32,7 @@ public class UserStoreService {
     private final SavedStoreRepository savedStoreRepository;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
+    private final PreferenceRepository preferenceRepository;
     private final ImageService imageService;
 
     /** 저장 리스트 전체 조회 */
@@ -63,6 +67,17 @@ public class UserStoreService {
 
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다."));
+
+        boolean nameExists = userStoreListRepository.existsByUserAndListName(user, listName);
+        boolean colorExists = userStoreListRepository.existsByUserAndIconColorId(user, iconColorId);
+
+        if (nameExists && colorExists) {
+            throw new IllegalArgumentException("동일한 이름과 colorId를 가진 리스트가 이미 존재합니다.");
+        } else if (nameExists) {
+            throw new IllegalArgumentException("동일한 이름의 리스트가 이미 존재합니다.");
+        } else if (colorExists) {
+            throw new IllegalArgumentException("동일한 colorId를 가진 리스트가 이미 존재합니다.");
+        }
 
         UserStoreList newList = userStoreListRepository.save(
                 UserStoreList.builder()
@@ -123,6 +138,12 @@ public class UserStoreService {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
 
+        // 이미 리스트에 존재하는 가게인지 확인
+        boolean exists = savedStoreRepository.findByUserStoreListAndStore(list, store).isPresent();
+        if (exists) {
+            throw new IllegalArgumentException("해당 가게는 이미 리스트에 존재합니다.");
+        }
+
         SavedStore savedStore = savedStoreRepository.save(
                 SavedStore.builder()
                         .userStoreList(list)
@@ -160,6 +181,39 @@ public class UserStoreService {
                         savedStore.getUserPreferences()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    /** 사용자의 취향을 업데이트하고, 저장된 모든 가게 리스트의 취향도 변경 */
+    @Transactional
+    public void updateUserPreferencesAndSavedStores(UUID userUuid, List<String> newUserPreferences) {
+        Long userId = userRepository.findIdByUserUuid(userUuid);
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userUuid));
+
+        // 기존 취향 삭제 후 새로운 취향 저장
+        user.getUserPreferences().clear();
+        for (String preference : newUserPreferences) {
+            PreferenceEntity preferenceEntity = preferenceRepository.findByPreferenceName(preference)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 취향이 존재하지 않습니다: " + preference));
+            user.getUserPreferences().add(UserPreferenceEntity.builder().user(user).preference(preferenceEntity).build());
+        }
+        userRepository.save(user); // 변경된 취향 저장
+
+        // 사용자의 저장 리스트 가져오기
+        List<UserStoreList> userLists = userStoreListRepository.findByUser(user);
+        if (userLists.isEmpty()) return; // 저장 리스트가 없으면 종료
+
+        // 저장 리스트에 속한 모든 가게 찾기
+        List<SavedStore> savedStores = savedStoreRepository.findByUserStoreListIn(userLists);
+        if (savedStores.isEmpty()) return; // 저장된 가게가 없으면 종료
+
+        // 모든 가게의 취향을 새로 업데이트
+        for (SavedStore savedStore : savedStores) {
+            savedStore.getUserPreferences().clear();
+            savedStore.setUserPreferences(newUserPreferences);
+        }
+
+        savedStoreRepository.saveAll(savedStores);
     }
 
     /** 리스트에서 가게 삭제 */

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.store.store.service.UserStoreService;
 import org.swyp.dessertbee.user.dto.NicknameValidationRequestDto;
 import org.swyp.dessertbee.user.dto.UserDetailResponseDto;
 import org.swyp.dessertbee.user.dto.UserResponseDto;
@@ -14,7 +15,9 @@ import org.swyp.dessertbee.user.dto.UserUpdateRequestDto;
 import org.swyp.dessertbee.user.service.UserService;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * 사용자 정보 조회 관련 컨트롤러
@@ -26,6 +29,7 @@ import java.util.Map;
 public class UserController {
 
     private final UserService userService;
+    private final UserStoreService userStoreService;
 
     /**
      * 현재 인증된 사용자의 상세 정보를 조회
@@ -97,5 +101,15 @@ public class UserController {
         log.info("프로필 이미지 업데이트 요청 - 파일명: {}", image.getOriginalFilename());
         UserDetailResponseDto response = userService.updateProfileImage(image);
         return ResponseEntity.ok(response);
+    }
+
+    /** 사용자의 취향을 업데이트하고 저장된 모든 가게 리스트의 취향도 변경 */
+    @PatchMapping("/{userUuid}/preferences")
+    public ResponseEntity<Void> updateUserPreferences(
+            @PathVariable UUID userUuid,
+            @RequestBody List<String> newUserPreferences) {
+
+        userStoreService.updateUserPreferencesAndSavedStores(userUuid, newUserPreferences);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -85,13 +85,6 @@ public class UserEntity {
     @JoinColumn(name = "mbti_id", nullable = true)
     private MbtiEntity mbti;
 
-    public boolean hasRole(String roleName) {
-        return userRoles.stream()
-                .map(UserRoleEntity::getRole)
-                .map(RoleEntity::getName)
-                .anyMatch(name -> name.equalsIgnoreCase(roleName));
-    }
-
     public void addRole(RoleEntity role) {
         UserRoleEntity userRole = UserRoleEntity.builder()
                 .user(this)


### PR DESCRIPTION
## :hash: 연관된 이슈

> #60 

## :memo: 작업 내용

> StoreSummaryResponse 응답 객체 수정
> HolidayResponse, OperatingHourResponse 응답 객체 별도로 정의
> 해당 가게를 저장한 사람들의 취향 태그 Top3 조회
> 리뷰 조회 시 삭제된 리뷰를 제외 (deletedAtisNull 조건 추가)
> 가게 저장 리스트 및 가게 추가 중복 예외처리
> 사용자 선호도 수정 및 저장한 가게 취향 수정 API 구현
> 가게 간략 정보 조회 API 수정 (영업정보, 사장님픽 이미지, 취향 태그 Top3)

### 스크린샷 

<img width="1184" alt="스크린샷 2025-02-21 오전 11 41 39" src="https://github.com/user-attachments/assets/f318930b-d84e-49eb-a876-3d4a869793d7" />
