### PR TITLE
[Fix] 가게 상세 정보 조회 api 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -36,6 +36,31 @@ public enum ErrorCode {
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "U004", "해당 정보에 대한 접근 권한이 없습니다."),
     INVALID_USER_UUID(HttpStatus.BAD_REQUEST, "U005", "유효하지 않은 사용자 식별자입니다."),
 
+    // Preference
+    PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "취향 정보를 찾을 수 없습니다."),
+
+    // Store
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 가게입니다."),
+    STORE_CREATION_FAILED(HttpStatus.BAD_REQUEST, "S002", "가게 생성에 실패했습니다."),
+    STORE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "S003", "가게에 대한 접근 권한이 없습니다."),
+    STORE_ALREADY_EXISTS(HttpStatus.CONFLICT, "S004", "이미 존재하는 가게입니다."),
+    STORE_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "S005", "저장 리스트를 찾을 수 없습니다."),
+    STORE_DUPLICATE_LIST(HttpStatus.CONFLICT, "S006", "동일한 이름과 colorId를 가진 리스트가 이미 존재합니다."),
+    STORE_DUPLICATE_LIST_NAME(HttpStatus.CONFLICT, "S007", "동일한 이름의 리스트가 이미 존재합니다."),
+    STORE_DUPLICATE_COLOR(HttpStatus.CONFLICT, "S008", "동일한 colorId를 가진 리스트가 이미 존재합니다."),
+    STORE_ALREADY_SAVED(HttpStatus.CONFLICT, "S009", "해당 가게는 이미 리스트에 존재합니다."),
+    SAVED_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S010", "해당 리스트에 저장된 가게가 없습니다."),
+    INVALID_STORE_UUID(HttpStatus.BAD_REQUEST, "S011", "유효하지 않은 가게 식별자입니다."),
+    INVALID_TAG_SELECTION(HttpStatus.BAD_REQUEST, "S012", "태그는 1개 이상 3개 이하로 선택해야 합니다."),
+    INVALID_TAG_INCLUDED(HttpStatus.BAD_REQUEST, "S013", "유효하지 않은 태그가 포함되어 있습니다."),
+    INVALID_STORE_REVIEW_UUID(HttpStatus.BAD_REQUEST, "S014", "유효하지 않은 한줄 리뷰 식별자입니다."),
+    STORE_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "S015", "존재하지 않는 한줄 리뷰입니다."),
+    INVALID_STORE_REVIEW(HttpStatus.NOT_FOUND, "S016", "해당 가게에 존재하는 리뷰가 아닙니다."),
+    INVALID_STORE_MENU_UUID(HttpStatus.BAD_REQUEST, "S017", "유효하지 않은 메뉴 식별자입니다."),
+    STORE_MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "S018", "존재하지 않는 메뉴입니다."),
+    INVALID_STORE_MENU(HttpStatus.NOT_FOUND, "S019", "해당 가게에 존재하는 메뉴가 아닙니다."),
+
+
     // 사장님 권한
     /**
      * 필요한 에러코드에 대하 추가적으로 더 적으시면 됩니다. - 영민 -

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateResponse.java
@@ -1,0 +1,22 @@
+package org.swyp.dessertbee.mate.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class MateResponse {
+    private UUID mateUuid;
+    private String mateCategory;
+    private String thumbnail;
+    private String title;
+    private String content;
+    private int currentMembers;
+    private String nickname;
+    private Boolean recruitYn;
+}

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateResponse.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -16,7 +15,6 @@ public class MateResponse {
     private String thumbnail;
     private String title;
     private String content;
-    private int currentMembers;
     private String nickname;
     private Boolean recruitYn;
 }

--- a/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
@@ -35,6 +35,9 @@ public class Mate {
     @Column(name = "user_id")
     private Long userId;
 
+    @Column(name = "store_id")
+    private Long storeId;
+
     @Column(name = "mate_category_id")
     private Long mateCategoryId; //메이트 카테고리(ex:친목,빵지순례 등등)
 

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
@@ -18,6 +18,8 @@ public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
 
     List<MateMember> findByMateIdAndDeletedAtIsNullAndApprovalYnTrue(Long mateId);
 
+    int countByMateIdAndApprovalYn(Long mateId, Boolean approvalYn);
+
     @Query("SELECT u FROM UserEntity u " +
             "JOIN MateMember m ON u.id = m.userId " +
             "WHERE m.mateId = :mateId AND m.grade = 'CREATOR'")

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
@@ -3,6 +3,7 @@ package org.swyp.dessertbee.mate.repository;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.mate.entity.Mate;
 
@@ -15,6 +16,9 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     @Transactional
     Optional<Mate> findByMateIdAndDeletedAtIsNull(Long mateId);
+
+    @Query("SELECT m FROM Mate m WHERE m.storeId = :storeId AND m.deletedAt IS NULL")
+    List<Mate> findByStoreIdAndDeletedAtIsNull(@Param("storeId") Long storeId);
 
     /**
      * MateUuid로 MateId 조회

--- a/src/main/java/org/swyp/dessertbee/store/menu/service/MenuService.java
+++ b/src/main/java/org/swyp/dessertbee/store/menu/service/MenuService.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.common.entity.ImageType;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.store.menu.dto.request.MenuCreateRequest;
 import org.swyp.dessertbee.store.menu.dto.response.MenuResponse;
@@ -32,7 +34,7 @@ public class MenuService {
     public List<MenuResponse> getMenusByStore(UUID storeUuid) {
         Long storeId = storeRepository.findStoreIdByStoreUuid(storeUuid);
         if (storeId == null) {
-            throw new IllegalArgumentException("storeUuid에 해당하는 storeId를 찾을 수 없습니다: " + storeUuid);
+            throw new BusinessException(ErrorCode.INVALID_STORE_UUID);
         }
 
         return menuRepository.findByStoreIdAndDeletedAtIsNull(storeId).stream()
@@ -45,10 +47,10 @@ public class MenuService {
         Long storeId = storeRepository.findStoreIdByStoreUuid(storeUuid);
         Long menuId = menuRepository.findMenuIdByMenuUuid(menuUuid);
         if (menuId == null) {
-            throw new IllegalArgumentException("해당 메뉴 UUID에 대한 menuId를 찾을 수 없습니다: " + menuUuid);
+            throw new BusinessException(ErrorCode.INVALID_STORE_MENU_UUID);
         }
         Menu menu = menuRepository.findByMenuIdAndStoreIdAndDeletedAtIsNull(menuId, storeId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 가게에 존재하지 않는 메뉴입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_STORE_MENU));
 
         return MenuResponse.fromEntity(menu, imageService.getImagesByTypeAndId(ImageType.MENU, menuId));
     }
@@ -59,7 +61,7 @@ public class MenuService {
 
         Long storeId = storeRepository.findStoreIdByStoreUuid(storeUuid);
         if (storeId == null) {
-            throw new IllegalArgumentException("해당 UUID의 가게가 존재하지 않습니다. storeUuid=" + storeUuid);
+            throw new BusinessException(ErrorCode.INVALID_STORE_UUID);
         }
 
         // 메뉴 저장
@@ -91,7 +93,7 @@ public class MenuService {
         Long storeId = storeRepository.findStoreIdByStoreUuid(storeUuid);
         Long menuId = menuRepository.findMenuIdByMenuUuid(menuUuid);
         Menu menu = menuRepository.findByMenuIdAndStoreIdAndDeletedAtIsNull(menuId, storeId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메뉴입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_MENU_NOT_FOUND));
 
         menu.update(request.getName(), request.getPrice(), request.getIsPopular(), request.getDescription());
 
@@ -106,7 +108,7 @@ public class MenuService {
         Long storeId = storeRepository.findStoreIdByStoreUuid(storeUuid);
         Long menuId = menuRepository.findMenuIdByMenuUuid(menuUuid);
         Menu menu = menuRepository.findByMenuIdAndStoreIdAndDeletedAtIsNull(menuId, storeId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메뉴입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_MENU_NOT_FOUND));
 
         menu.softDelete();
         menuRepository.save(menu);

--- a/src/main/java/org/swyp/dessertbee/store/review/dto/response/StoreReviewResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/dto/response/StoreReviewResponse.java
@@ -16,12 +16,14 @@ import java.util.UUID;
 public class StoreReviewResponse {
     private UUID reviewUuid;
     private Long storeId;
+    private String nickname;
+    private String profileImage;
     private String content;
     private BigDecimal rating;
     private LocalDateTime createdAt;
     private List<String> images;
 
-    public static StoreReviewResponse fromEntity(StoreReview review, List<String> images) {
+    public static StoreReviewResponse fromEntity(StoreReview review, String nickname, String profileImage, List<String> images) {
         if (review.getReviewUuid() == null) {
             throw new IllegalStateException("reviewUuid가 null입니다. 리뷰가 정상적으로 저장되었는지 확인해주세요.");
         }
@@ -29,6 +31,8 @@ public class StoreReviewResponse {
         return StoreReviewResponse.builder()
                 .reviewUuid(review.getReviewUuid())
                 .storeId(review.getStoreId())
+                .nickname(nickname)
+                .profileImage(profileImage)
                 .content(review.getContent())
                 .rating(review.getRating())
                 .createdAt(review.getCreatedAt())

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -71,9 +71,6 @@ public class StoreController {
     /** 가게 상세 정보 조회 */
     @GetMapping("/{storeUuid}/details")
     public StoreDetailResponse getStoreDetails(@PathVariable UUID storeUuid, UserEntity user) {
-        if (storeUuid == null) {
-            throw new IllegalArgumentException("storeUuid가 요청에서 누락되었습니다.");
-        }
         return storeService.getStoreDetails(storeUuid, user);
     }
 

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/request/StoreCreateRequest.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/request/StoreCreateRequest.java
@@ -15,6 +15,7 @@ import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Builder
 @Data
@@ -23,7 +24,7 @@ import java.util.Map;
 public class StoreCreateRequest {
 
     @NotNull
-    private Long ownerId;
+    private UUID userUuid;
 
     @NotBlank
     private String name;

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
@@ -3,6 +3,7 @@ package org.swyp.dessertbee.store.store.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import org.swyp.dessertbee.mate.dto.response.MateResponse;
 import org.swyp.dessertbee.store.menu.dto.response.MenuResponse;
 import org.swyp.dessertbee.store.review.dto.response.StoreReviewResponse;
 import org.swyp.dessertbee.store.store.entity.Store;
@@ -31,24 +32,31 @@ public class StoreDetailResponse {
     private Boolean animalYn;
     private Boolean tumblerYn;
     private Boolean parkingYn;
+    private String description;
     private BigDecimal averageRating;
     private List<MenuResponse> menus;
     private List<String> storeImages;
     private List<String> ownerPickImages;
+    private int totalReviewCount;
     private List<StoreReviewResponse> storeReviews;
     private List<String> tags;
     private List<String> notice;
     private List<OperatingHourResponse> operatingHours;
     private List<HolidayResponse> holidays;
+    private List<String> topPreferences;
+    private List<MateResponse> mate;
 
     public static StoreDetailResponse fromEntity(Store store, Long userId, UUID userUuid,
+                                                 int totalReviewCount,
                                                  List<OperatingHourResponse> operatingHours,
                                                  List<HolidayResponse> holidays,
                                                  List<MenuResponse> menus,
                                                  List<String> storeImages,
                                                  List<String> ownerPickImages,
+                                                 List<String> topPreferences,
                                                  List<StoreReviewResponse> storeReviews,
-                                                 List<String> tags) {
+                                                 List<String> tags,
+                                                 List<MateResponse> mate) {
         return StoreDetailResponse.builder()
                 .userId(userId)
                 .userUuid(userUuid)
@@ -61,15 +69,19 @@ public class StoreDetailResponse {
                 .animalYn(store.getAnimalYn())
                 .tumblerYn(store.getTumblerYn())
                 .parkingYn(store.getParkingYn())
+                .description(store.getDescription())
                 .averageRating(store.getAverageRating())
                 .notice(store.getNotice())
                 .operatingHours(operatingHours)
                 .holidays(holidays)
+                .topPreferences(topPreferences)
                 .menus(menus)
                 .storeImages(storeImages)
                 .ownerPickImages(ownerPickImages)
+                .totalReviewCount(totalReviewCount)
                 .storeReviews(storeReviews)
                 .tags(tags)
+                .mate(mate)
                 .build();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/entity/Store.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/entity/Store.java
@@ -32,6 +32,9 @@ public class Store {
     @Column(name = "owner_id")
     private Long ownerId;
 
+    @Column(name = "owner_uuid")
+    private UUID ownerUuid;
+
     @Column(nullable = false)
     private String name;
 

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -59,8 +59,9 @@ public class StoreService {
                                            List<MultipartFile> ownerPickImageFiles,
                                            List<MultipartFile> menuImageFiles) {
 
+        Long ownerId = userRepository.findIdByUserUuid(request.getUserUuid());
         // ownerId로 UserEntity 조회 (로그인한 사용자 정보)
-        UserEntity user = userRepository.findById(request.getOwnerId())
+        UserEntity user = userRepository.findById(ownerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         if (menuImageFiles == null) {
@@ -69,7 +70,8 @@ public class StoreService {
 
         Store store = storeRepository.save(
                 Store.builder()
-                        .ownerId(request.getOwnerId())
+                        .ownerId(ownerId)
+                        .ownerUuid(request.getUserUuid())
                         .name(request.getName())
                         .phone(request.getPhone())
                         .address(request.getAddress())

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -295,7 +295,7 @@ public class StoreService {
             String mateCategory = mateCategoryRepository.findById(mate.getMateCategoryId())
                     .map(MateCategory::getName).orElse("알 수 없음");
             List<String> mateThumbnail = imageService.getImagesByTypeAndId(ImageType.MATE, mate.getMateId());
-            int currentMembers = mateMemberRepository.countByMateIdAndApprovalYn(mate.getMateId(), true);
+            //int currentMembers = mateMemberRepository.countByMateIdAndApprovalYn(mate.getMateId(), true);
 
             return MateResponse.builder()
                     .mateUuid(mate.getMateUuid())
@@ -303,7 +303,6 @@ public class StoreService {
                     .thumbnail(mateThumbnail.isEmpty() ? null : mateThumbnail.get(0))
                     .title(mate.getTitle())
                     .content(mate.getContent())
-                    .currentMembers(currentMembers)
                     .nickname(mateCreator.getNickname())
                     .recruitYn(mate.getRecruitYn())
                     .build();


### PR DESCRIPTION
## :hash: 연관된 이슈

> #74 

## :memo: 작업 내용

> description(가게 소개) 추가
> 해당 가게를 저장한 사람들의 취향 태그 Top3 조회
> 한줄리뷰: 닉네임, 프로필 이미지, 리뷰 갯수 포함
> 가게에 해당하는 디저트메이트 모임 조회
> 가게 상세 정보 조회 API 수정
> Store 관련 공통 에러코드 정리 -> ErrorCode
