### PR TITLE
refactor : 회원가입 시 로그인 응답과 동일하게 변경

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController {
             @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
     })
     @PostMapping("/signup")
-    public ResponseEntity<SignUpResponse> signup(
+    public ResponseEntity<LoginResponse> signup(
             @RequestHeader("X-Email-Verification-Token") String verificationToken,
             @Valid @RequestBody SignUpRequest request
     ) throws BadRequestException {
@@ -55,7 +55,7 @@ public class AuthController {
         }
 
         // 회원가입 처리
-        SignUpResponse response = authService.signup(request, verificationToken);
+        LoginResponse response = authService.signup(request, verificationToken);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -42,7 +42,7 @@ public interface AuthService {
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
      * @throws DuplicateEmailException 이메일 중복
      */
-    SignUpResponse signup(SignUpRequest request, String verificationToken);
+    LoginResponse signup(SignUpRequest request, String verificationToken);
 
 
     /**

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -91,7 +91,7 @@ public class SecurityConfig {
 
         // allowedOrigins를 yml 설정값에서 가져와서 설정
         String[] origins = corsAllowedOrigins.split(",");
-        configuration.setAllowedOrigins(Arrays.asList(origins));
+        configuration.setAllowedOrigins(Collections.singletonList("*")); // 일단 모든 오리진 허용하도록 수정
 
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## :hash: 연관된 이슈
#80 

## :memo: 작업 내용
- 회원가입 시 로그인 응답과 동일하게 변경
  - 회원가입 시 로그인을 하지 않아도 됨.
- CORS 설정 모든 origin 허용으로 변경(임시적)
### 스크린샷 (선택)
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/ac097d65-ade4-4315-9654-ddabc062a024" />