### PR TITLE
[FEATURE] 지도 반경 내 태그 필터링된 가게 조회 api

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
     INVALID_USER_UUID(HttpStatus.BAD_REQUEST, "U005", "유효하지 않은 사용자 식별자입니다."),
 
     // Preference
-    PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "취향 정보를 찾을 수 없습니다."),
+    PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 취향 태그입니다."),
+    USER_PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P002", "취향을 등록하지 않은 사용자입니다."),
 
     // Store
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 가게입니다."),

--- a/src/main/java/org/swyp/dessertbee/preference/repository/PreferenceRepository.java
+++ b/src/main/java/org/swyp/dessertbee/preference/repository/PreferenceRepository.java
@@ -1,10 +1,15 @@
 package org.swyp.dessertbee.preference.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.swyp.dessertbee.preference.entity.PreferenceEntity;
 
 import java.util.Optional;
 
 public interface PreferenceRepository extends JpaRepository<PreferenceEntity, Long> {
     Optional<PreferenceEntity> findByPreferenceName(String preferenceName);
+
+    @Query("SELECT p.preferenceName FROM PreferenceEntity p WHERE p.id = :id")
+    String findPreferenceNameById(@Param("id") Long id);
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -6,8 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.preference.entity.UserPreferenceEntity;
 import org.swyp.dessertbee.store.store.dto.request.StoreCreateRequest;
 import org.swyp.dessertbee.store.store.dto.response.StoreDetailResponse;
 import org.swyp.dessertbee.store.store.dto.response.StoreMapResponse;
@@ -15,10 +17,7 @@ import org.swyp.dessertbee.store.store.dto.response.StoreSummaryResponse;
 import org.swyp.dessertbee.store.store.service.StoreService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @RestController
 @RequestMapping("/api/stores")
@@ -66,6 +65,20 @@ public class StoreController {
         } else {
             return storeService.getStoresByLocation(latitude, longitude, radius);
         }
+    }
+
+    /**
+     * 반경 내 가게 조회 (인증된 사용자의 취향 태그 기반)
+     */
+    @GetMapping("/map/my-preferences")
+    public ResponseEntity<List<StoreMapResponse>> getStoresByMyPreferences(
+            @RequestParam("latitude") Double latitude,
+            @RequestParam("longitude") Double longitude,
+            @RequestParam("radius") Double radius,
+            @AuthenticationPrincipal UserEntity user) {
+
+        List<StoreMapResponse> storeMapResponses = storeService.getStoresByMyPreferences(latitude, longitude, radius, user);
+        return ResponseEntity.ok(storeMapResponses);
     }
 
     /** 가게 간략 정보 조회 */

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -58,8 +58,14 @@ public class StoreController {
     public List<StoreMapResponse> getStoresByLocation(
             @RequestParam Double latitude,
             @RequestParam Double longitude,
-            @RequestParam Double radius) {
-        return storeService.getStoresByLocation(latitude, longitude, radius);
+            @RequestParam Double radius,
+            @RequestParam(required = false) Long preferenceTagId) {
+
+        if (preferenceTagId != null) {
+            return storeService.getStoresByLocationAndTag(latitude, longitude, radius, preferenceTagId);
+        } else {
+            return storeService.getStoresByLocation(latitude, longitude, radius);
+        }
     }
 
     /** 가게 간략 정보 조회 */

--- a/src/main/java/org/swyp/dessertbee/store/store/entity/StoreHoliday.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/entity/StoreHoliday.java
@@ -26,7 +26,6 @@ public class StoreHoliday {
     @Column(nullable = false)
     private LocalDate holidayDate; // 특정 휴무일
 
-    @Column(length = 255)
     private String reason; // 휴무 사유
 
     @CreationTimestamp

--- a/src/main/java/org/swyp/dessertbee/store/store/entity/StoreOperatingHour.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/entity/StoreOperatingHour.java
@@ -29,10 +29,8 @@ public class StoreOperatingHour {
     @Column(nullable = false, length = 10)
     private DayOfWeek dayOfWeek; // 요일 (월~일)
 
-    @Column(nullable = false)
     private LocalTime openingTime; // 개점 시간
 
-    @Column(nullable = false)
     private LocalTime closingTime; // 폐점 시간
 
     private LocalTime lastOrderTime; // 라스트오더 시간

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
@@ -49,6 +49,27 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
                                            @Param("radius") Double radius,
                                            @Param("preferenceName") String preferenceName);
 
+    // 반경 내 사용자의 취향 태그(Top3 중 하나가 해당하는)를 가지는 가게 조회 메서드
+    @Query(value = """
+        SELECT s.*
+        FROM store s
+        JOIN (
+            SELECT ss.store_id, sp.preference,
+                   ROW_NUMBER() OVER (PARTITION BY ss.store_id ORDER BY COUNT(*) DESC) AS rn
+            FROM saved_store ss
+            JOIN saved_store_preferences sp ON ss.id = sp.saved_store_id
+            GROUP BY ss.store_id, sp.preference
+        ) AS top_pref ON s.store_id = top_pref.store_id
+        WHERE top_pref.rn <= 3
+          AND top_pref.preference IN (:preferenceNames)
+          AND ST_Distance_Sphere(point(:lng, :lat), point(s.longitude, s.latitude)) <= :radius
+          AND s.deleted_at IS NULL
+    """, nativeQuery = true)
+    List<Store> findStoresByUserPreferences(@Param("lng") Double lng,
+                                            @Param("lat") Double lat,
+                                            @Param("radius") Double radius,
+                                            @Param("preferenceNames") List<String> preferenceNames);
+
     Optional<Store> findByStoreIdAndDeletedAtIsNull(Long storeId);
 
     @Query("SELECT s.storeId FROM Store s WHERE s.storeUuid = :storeUuid")

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
@@ -28,6 +28,27 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     """, nativeQuery = true)
     List<Store> findStoresByLocation(@Param("lat") Double lat, @Param("lng") Double lng, @Param("radius") Double radius);
 
+    // 반경 내 특정 취향 태그(저장된 Top3 취향 태그 중 하나)를 가지는 가게 조회
+    @Query(value = """
+        SELECT s.*
+        FROM store s
+        JOIN (
+            SELECT ss.store_id, sp.preference,
+                   ROW_NUMBER() OVER (PARTITION BY ss.store_id ORDER BY COUNT(*) DESC) AS rn
+            FROM saved_store ss
+            JOIN saved_store_preferences sp ON ss.id = sp.saved_store_id
+            GROUP BY ss.store_id, sp.preference
+        ) AS top_pref ON s.store_id = top_pref.store_id
+        WHERE top_pref.rn <= 3
+          AND top_pref.preference = :preferenceName
+          AND ST_Distance_Sphere(point(:lng, :lat), point(s.longitude, s.latitude)) <= :radius
+          AND s.deleted_at IS NULL
+    """, nativeQuery = true)
+    List<Store> findStoresByLocationAndTag(@Param("lat") Double lat,
+                                           @Param("lng") Double lng,
+                                           @Param("radius") Double radius,
+                                           @Param("preferenceName") String preferenceName);
+
     Optional<Store> findByStoreIdAndDeletedAtIsNull(Long storeId);
 
     @Query("SELECT s.storeId FROM Store s WHERE s.storeUuid = :storeUuid")

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
@@ -74,4 +74,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
     @Query("SELECT s.storeId FROM Store s WHERE s.storeUuid = :storeUuid")
     Long findStoreIdByStoreUuid(@Param("storeUuid") UUID storeUuid);
+
+    @Query("SELECT s.storeId FROM Store s WHERE s.name = :name")
+    Long findStoreIdByName(@Param("name") String name);
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -15,6 +15,7 @@ import org.swyp.dessertbee.mate.entity.MateCategory;
 import org.swyp.dessertbee.mate.repository.MateCategoryRepository;
 import org.swyp.dessertbee.mate.repository.MateMemberRepository;
 import org.swyp.dessertbee.mate.repository.MateRepository;
+import org.swyp.dessertbee.preference.repository.PreferenceRepository;
 import org.swyp.dessertbee.store.menu.dto.response.MenuResponse;
 import org.swyp.dessertbee.store.menu.service.MenuService;
 import org.swyp.dessertbee.store.review.dto.response.StoreReviewResponse;
@@ -30,6 +31,7 @@ import org.swyp.dessertbee.user.repository.UserRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 
 @Service
@@ -46,8 +48,8 @@ public class StoreService {
     private final StoreHolidayRepository storeHolidayRepository;
     private final SavedStoreRepository savedStoreRepository;
     private final MateCategoryRepository mateCategoryRepository;
-    private final MateMemberRepository mateMemberRepository;
     private final MateRepository mateRepository;
+    private final PreferenceRepository preferenceRepository;
     private final ImageService imageService;
     private final MenuService menuService;
     private final UserRepository userRepository;
@@ -176,6 +178,19 @@ public class StoreService {
     /** 반경 내 가게 조회 */
     public List<StoreMapResponse> getStoresByLocation(Double lat, Double lng, Double radius) {
         List<Store> stores = storeRepository.findStoresByLocation(lat, lng, radius);
+
+        return stores.stream()
+                .map(StoreMapResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    /** 반경 내 특정 취향 태그를 가지는 가게 조회 */
+    public List<StoreMapResponse> getStoresByLocationAndTag(Double lat, Double lng, Double radius, Long preferenceTagId) {
+        if (preferenceRepository.findById(preferenceTagId).isEmpty()){
+            throw new BusinessException(ErrorCode.PREFERENCES_NOT_FOUND);
+        }
+        String preferenceName = preferenceRepository.findPreferenceNameById(preferenceTagId);
+        List<Store> stores = storeRepository.findStoresByLocationAndTag(lat, lng, radius, preferenceName);
 
         return stores.stream()
                 .map(StoreMapResponse::fromEntity)


### PR DESCRIPTION
## :hash: 연관된 이슈

> #79 

## :memo: 작업 내용

> 반경 내 가게 조회 시 요청값에 태그를 포함할 수 있도록 수정
> 태그가 포함된 요청일 경우 "반경 내 가게를 저장한 사용자들의 취향 태그 Top3 중 하나가 태그와 일치하는 가게만 조회"하는 조건 추가
> 태그가 포함되지 않은 요청일 경우 "반경 내 모든 가게 조회"
> 인증된 사용자가 /api/stores/map/my-preferences로 요청을 보낼 경우, "반경 내 해당 사용자의 취향 태그 중 하나라도 일치하는 가게를 조회"
> 인증되지 않은 사용자의 요청은 예외처리
> 취향 관련 ErrorCode 추가
> 조회 쿼리 작성

### 스크린샷

![image](https://github.com/user-attachments/assets/4cd6e897-f61c-4cb9-acd9-11eaeae7691b)

> 인증되지 않은 사용자일 경우
