### PR TITLE
[Fix] 메뉴 리스트 등록 시 이미지 매핑 오류 해결

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/service/ImageService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/ImageService.java
@@ -23,7 +23,7 @@ public class ImageService {
     private final ImageRepository imageRepository;
     private final S3Service s3Service;
 
-    /** 다중 이미지 업로드 후 URL 반환 */
+    /** 다중 이미지 업로드 */
     @Transactional
     public void uploadAndSaveImages(List<MultipartFile> files, ImageType refType, Long refId, String folder) {
         if (files == null || files.isEmpty()) return;
@@ -44,9 +44,9 @@ public class ImageService {
         imageRepository.saveAll(images);
     }
 
-    /** 단일 이미지 업로드 후 URL 반환 */
-    public String uploadAndSaveImage(MultipartFile file, ImageType refType, Long refId, String folder) {
-        if (file == null) return null;
+    /** 단일 이미지 업로드 */
+    public void uploadAndSaveImage(MultipartFile file, ImageType refType, Long refId, String folder) {
+        if (file == null) return;
 
         try {
             String url = s3Service.uploadFile(file, folder);
@@ -60,7 +60,6 @@ public class ImageService {
 
             imageRepository.save(image);
             log.info("이미지 업로드 성공 - type: {}, refId: {}", refType, refId);
-            return url;
         } catch (Exception e) {
             log.error("이미지 업로드 실패 - type: {}, refId: {}", refType, refId, e);
             throw new BusinessException(ErrorCode.FILE_UPLOAD_ERROR);

--- a/src/main/java/org/swyp/dessertbee/common/util/CustomMultipartFile.java
+++ b/src/main/java/org/swyp/dessertbee/common/util/CustomMultipartFile.java
@@ -1,0 +1,58 @@
+package org.swyp.dessertbee.common.util;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CustomMultipartFile implements MultipartFile {
+
+    private final MultipartFile original;
+    private final String customFilename;
+
+    public CustomMultipartFile(MultipartFile original, String customFilename) {
+        this.original = original;
+        this.customFilename = customFilename;
+    }
+
+    @Override
+    public String getName() {
+        return original.getName();
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return customFilename;
+    }
+
+    @Override
+    public String getContentType() {
+        return original.getContentType();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return original.isEmpty();
+    }
+
+    @Override
+    public long getSize() {
+        return original.getSize();
+    }
+
+    @Override
+    public byte[] getBytes() throws IOException {
+        return original.getBytes();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return original.getInputStream();
+    }
+
+    @Override
+    public void transferTo(File dest) throws IOException, IllegalStateException {
+        original.transferTo(dest);
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/store/menu/controller/MenuController.java
+++ b/src/main/java/org/swyp/dessertbee/store/menu/controller/MenuController.java
@@ -64,10 +64,10 @@ public class MenuController {
         if (menuRequests.isEmpty()) {
             return ResponseEntity.badRequest().build();
         }
-
-        // **파일 업로드 단일/다중 지원**
+        // 기존의 getName() 대신 getOriginalFilename()을 사용하여 파일 맵 생성
         Map<String, MultipartFile> menuImageMap = menuImageFiles != null
-                ? menuImageFiles.stream().collect(Collectors.toMap(MultipartFile::getOriginalFilename, file -> file, (a, b) -> a))
+                ? menuImageFiles.stream()
+                .collect(Collectors.toMap(MultipartFile::getOriginalFilename, file -> file, (a, b) -> a))
                 : Collections.emptyMap();
 
         menuService.addMenus(storeUuid, menuRequests, menuImageMap);

--- a/src/main/java/org/swyp/dessertbee/store/menu/dto/request/MenuCreateRequest.java
+++ b/src/main/java/org/swyp/dessertbee/store/menu/dto/request/MenuCreateRequest.java
@@ -20,6 +20,6 @@ public class    MenuCreateRequest {
     private BigDecimal price; // 가격
 
     private Boolean isPopular = false; // 인기 메뉴 여부 (기본값: false)
-
     private String description; // 메뉴 설명
+    private String imageFileKey;
 }


### PR DESCRIPTION
## :hash: 연관된 이슈

> #89 

## :memo: 작업 내용

> CustomMultipartFile 클래스 생성하여 파일이름 사용자화
> 메뉴 리스트를 인덱스로 매핑하여 각 메뉴 이름으로 파일 이름을 바꿔 이미지 업로드/저장
> 가게 등록 시 각 메뉴별 이미지 업로드 테스트 (이미지가 있을 경우 menu 객체 안에 imageFileKey 포함하여 요청 보낼 것)
> ImageService uploadAndSaveImage() 리턴값 void로 변경

### 스크린샷

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/feba4526-d5a1-44a8-b107-0b2bb4a0a6dc" />
