### PR TITLE
[FIX] 가게 상세정보 조회 api 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.store.store.dto.response.SavedStoreResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListResponse;
+import org.swyp.dessertbee.store.store.dto.response.UserStoreListSimpleResponse;
 import org.swyp.dessertbee.store.store.entity.SavedStore;
 import org.swyp.dessertbee.store.store.entity.UserStoreList;
 import org.swyp.dessertbee.store.store.service.UserStoreService;
@@ -31,6 +32,12 @@ public class UserStoreController {
                                                              @RequestParam String listName,
                                                              @RequestParam Long iconColorId) {
         return ResponseEntity.ok(userStoreService.createUserStoreList(userUuid, listName, iconColorId));
+    }
+
+    /** listId로 특정 리스트 정보 조회 */
+    @GetMapping("/lists/{listId}")
+    public ResponseEntity<UserStoreListSimpleResponse> getUserStoreList(@PathVariable Long listId) {
+        return ResponseEntity.ok(userStoreService.getUserStoreList(listId));
     }
 
     /** 저장 리스트 수정 */

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
@@ -42,6 +42,8 @@ public class StoreDetailResponse {
     private List<HolidayResponse> holidays;
     private List<String> topPreferences;
     private List<MateResponse> mate;
+    private boolean saved;
+    private Long savedListId;
 
     public static StoreDetailResponse fromEntity(Store store, Long userId, UUID userUuid,
                                                  int totalReviewCount,
@@ -53,7 +55,9 @@ public class StoreDetailResponse {
                                                  List<String> topPreferences,
                                                  List<StoreReviewResponse> storeReviews,
                                                  List<String> tags,
-                                                 List<MateResponse> mate) {
+                                                 List<MateResponse> mate,
+                                                 boolean saved,
+                                                 Long savedListId) {
         return StoreDetailResponse.builder()
                 .userId(userId)
                 .userUuid(userUuid)
@@ -81,6 +85,8 @@ public class StoreDetailResponse {
                 .storeReviews(storeReviews)
                 .tags(tags)
                 .mate(mate)
+                .saved(saved)
+                .savedListId(savedListId)
                 .build();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/UserStoreListSimpleResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/UserStoreListSimpleResponse.java
@@ -1,0 +1,14 @@
+package org.swyp.dessertbee.store.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class UserStoreListSimpleResponse {
+    private Long listId;
+    private String listName;
+    private Long iconColorId;
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
@@ -38,4 +38,7 @@ public interface SavedStoreRepository extends JpaRepository<SavedStore, Long> {
         LIMIT 3
     """, nativeQuery = true)
     List<Object[]> findTop3PreferencesByStoreId(Long storeId);
+
+    /** 특정 가게를 저장한 사용자가 있다면 해당 SavedStore 엔티티 반환 */
+    Optional<SavedStore> findFirstByStoreAndUserStoreList_User_Id(Store store, Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -61,7 +61,7 @@ public class StoreService {
                                            List<MultipartFile> ownerPickImageFiles,
                                            List<MultipartFile> menuImageFiles) {
 
-        Long ownerId = userRepository.findIdByUserUuid(request.getUserUuid());
+        Long ownerId = userRepository.findIdByUserUuidUsingUuidToBin(request.getUserUuid());
         // ownerId로 UserEntity 조회 (로그인한 사용자 정보)
         UserEntity user = userRepository.findById(ownerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
@@ -12,6 +12,7 @@ import org.swyp.dessertbee.preference.entity.UserPreferenceEntity;
 import org.swyp.dessertbee.preference.repository.PreferenceRepository;
 import org.swyp.dessertbee.store.store.dto.response.SavedStoreResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListResponse;
+import org.swyp.dessertbee.store.store.dto.response.UserStoreListSimpleResponse;
 import org.swyp.dessertbee.store.store.entity.SavedStore;
 import org.swyp.dessertbee.store.store.entity.Store;
 import org.swyp.dessertbee.store.store.entity.UserStoreList;
@@ -22,6 +23,7 @@ import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -58,6 +60,18 @@ public class UserStoreService {
                         savedStoreRepository.countByUserStoreList(list)
                 ))
                 .collect(Collectors.toList());
+    }
+
+    /** listId로 특정 리스트 조회 */
+    public UserStoreListSimpleResponse getUserStoreList(Long listId) {
+        UserStoreList userStoreList = userStoreListRepository.findById(listId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_LIST_NOT_FOUND));
+
+        return UserStoreListSimpleResponse.builder()
+                .listId(userStoreList.getId())
+                .listName(userStoreList.getListName())
+                .iconColorId(userStoreList.getIconColorId())
+                .build();
     }
 
     /** 저장 리스트 생성 */

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -38,8 +38,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     /**
      * Uuid로 userId 조회 (삭제되지 않은 계정만)
      * */
-    /* @Query("SELECT u.id FROM UserEntity u WHERE FUNCTION('UUID_TO_BIN', u.userUuid) = :userUuid AND u.deletedAt IS NULL") */
-    @Query("SELECT u.id FROM UserEntity u WHERE u.userUuid = :userUuid AND u.deletedAt IS NULL")
+    @Query("SELECT u.id FROM UserEntity u WHERE FUNCTION('UUID_TO_BIN', u.userUuid) = :userUuid AND u.deletedAt IS NULL")
+    /* @Query("SELECT u.id FROM UserEntity u WHERE u.userUuid = :userUuid AND u.deletedAt IS NULL") */
     Long findIdByUserUuid(UUID userUuid);
 
     /**

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -38,9 +38,11 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     /**
      * Uuid로 userId 조회 (삭제되지 않은 계정만)
      * */
-    @Query("SELECT u.id FROM UserEntity u WHERE FUNCTION('UUID_TO_BIN', u.userUuid) = :userUuid AND u.deletedAt IS NULL")
-    /* @Query("SELECT u.id FROM UserEntity u WHERE u.userUuid = :userUuid AND u.deletedAt IS NULL") */
+    @Query("SELECT u.id FROM UserEntity u WHERE u.userUuid = :userUuid AND u.deletedAt IS NULL")
     Long findIdByUserUuid(UUID userUuid);
+
+    @Query("SELECT u.id FROM UserEntity u WHERE FUNCTION('UUID_TO_BIN', u.userUuid) = :userUuid AND u.deletedAt IS NULL")
+    Long findIdByUserUuidUsingUuidToBin(UUID userUuid);
 
     /**
      * userId로 userUuid 조회 (삭제되지 않은 계정만)


### PR DESCRIPTION
## :hash: 연관된 이슈

> #95 

## :memo: 작업 내용

> 유저가 저장한 가게인지 여부 추가
> 저장 리스트 id 추가
> user uuid_to_bin 변환 메서드 추가 (가게 등록 service)
> listId로 리스트 정보 조회 api 구현

