### PR TITLE
[Fix] 리프레시 토큰 전달 방식 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -11,20 +11,23 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
 import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
 import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
-import org.swyp.dessertbee.auth.dto.signup.SignUpResponse;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.swyp.dessertbee.auth.service.AuthService;
 import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.util.CookieUtil;
+
 
 @Tag(name = "Authentication", description = "인증 관련 API")
 @RestController
@@ -45,7 +48,9 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<LoginResponse> signup(
             @RequestHeader("X-Email-Verification-Token") String verificationToken,
-            @Valid @RequestBody SignUpRequest request
+            @Valid @RequestBody SignUpRequest request,
+            HttpServletResponse response
+
     ) throws BadRequestException {
         log.debug("회원가입 요청: {}", request.getEmail());
 
@@ -55,8 +60,8 @@ public class AuthController {
         }
 
         // 회원가입 처리
-        LoginResponse response = authService.signup(request, verificationToken);
-        return ResponseEntity.ok(response);
+        LoginResponse signupResponse = authService.signup(request, verificationToken, response);
+        return ResponseEntity.ok(signupResponse);
     }
 
 
@@ -72,9 +77,11 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(
             @Parameter(description = "로그인 정보", required = true)
-            @Valid @RequestBody LoginRequest request
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
     ) {
-        return ResponseEntity.ok(authService.login(request));
+        LoginResponse loginResponse = authService.login(request, response);
+        return ResponseEntity.ok(loginResponse);
     }
 
     @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃합니다.")
@@ -85,10 +92,16 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(
             @Parameter(description = "JWT 액세스 토큰", required = true)
-            @RequestHeader("Authorization") String token
+            @RequestHeader("Authorization") String token,
+            HttpServletResponse response
     ) {
         String accessToken = token.substring(7);
-        return ResponseEntity.ok(authService.logout(accessToken));
+        LogoutResponse logoutResponse = authService.logout(accessToken);
+
+        // 리프레시 토큰 쿠키 삭제
+        CookieUtil.deleteRefreshTokenCookie(response);
+
+        return ResponseEntity.ok(logoutResponse);
     }
 
     @Operation(summary = "비밀번호 재설정", description = "이메일 인증 후 비밀번호를 재설정합니다.")
@@ -108,29 +121,25 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "토큰 재발급", description = "Refresh 토큰을 사용하여 새로운 Access 토큰을 발급받습니다.")
+    @Operation(summary = "토큰 재발급", description = "HTTP-only 쿠키의 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
                     content = @Content(schema = @Schema(implementation = TokenResponse.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh 토큰")
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰")
     })
     @PostMapping("/token/refresh")
     public ResponseEntity<TokenResponse> refreshToken(
-            @RequestHeader("Authorization") String bearerToken) {
+            @CookieValue(name = "refreshToken", required = true) String refreshToken) {
         try {
-            // Bearer 토큰에서 만료된 액세스 토큰 추출
-            String accessToken = bearerToken.substring(7);  // "Bearer " 제거
-
-            // 토큰에서 이메일 추출
-            String email = jwtUtil.getEmail(accessToken, true);
-
-            // 이메일로 새로운 액세스 토큰 발급
-            TokenResponse tokenResponse = authService.refreshAccessToken(email);
-
+            // 리프레시 토큰으로 새 액세스 토큰 발급
+            TokenResponse tokenResponse = authService.refreshAccessToken(refreshToken);
             return ResponseEntity.ok(tokenResponse);
+        } catch (BusinessException e) {
+            log.warn("토큰 재발급 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         } catch (Exception e) {
-            log.error("Token refresh failed", e);
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            log.error("토큰 재발급 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/TokenResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/TokenResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @Builder
 public class TokenResponse {
     private String accessToken;
-    private String refreshToken;
     private String tokenType;
     private long expiresIn;
 }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 @AllArgsConstructor
 public class LoginResponse {
     private String accessToken;     // JWT 액세스 토큰
+    private String tokenType;       // 토큰 타입
+    private long expiresIn;         // 토큰 만료 시간
     private UUID userUuid;          // 사용자 UUID
     private String email;           // 사용자 이메일
     private String nickname;        // 사용자 닉네임
@@ -25,29 +27,20 @@ public class LoginResponse {
 
     /**
      * 로그인 성공 응답 생성
-     * @param token JWT 액세스 토큰
+     * @param accessToken JWT 액세스 토큰
+     * @param expiresIn 액세스 토큰 만료 시간 (파라미터 추가됨)
      * @param user 사용자 엔티티
      * @return 로그인 응답 객체
      */
-    public static LoginResponse success(String token, UserEntity user, String profileImageUrl) {
+    public static LoginResponse success(String accessToken, long expiresIn, UserEntity user, String profileImageUrl) {
         return LoginResponse.builder()
-                .accessToken(token)
+                .accessToken(accessToken)
+                .tokenType("Bearer") // 토큰 타입 설정 (추가됨)
+                .expiresIn(expiresIn) // 만료 시간 설정 (추가됨)
                 .userUuid(user.getUserUuid())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileImageUrl(profileImageUrl)
-                .build();
-    }
-
-    /**
-     * 토큰만 포함된 응답 생성
-     * 토큰 갱신 시 사용
-     * @param token JWT 액세스 토큰
-     * @return 로그인 응답 객체
-     */
-    public static LoginResponse withToken(String token) {
-        return LoginResponse.builder()
-                .accessToken(token)
                 .build();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.auth.service;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
@@ -23,10 +24,10 @@ public interface AuthService {
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰 발급
-     * @param email 유저 이메일
+     * @param refreshToken 리프레시 토큰
      * @return 새로운 액세스 토큰 응답
      */
-    TokenResponse refreshAccessToken(String email);
+    TokenResponse refreshAccessToken(String refreshToken);
 
     /**
      * 리프레시 토큰 무효화 (로그아웃)
@@ -38,20 +39,22 @@ public interface AuthService {
      * 회원가입 처리
      * @param request 회원가입 요청 정보
      * @param verificationToken 이메일 인증 토큰
+     * @param response HTTP 응답 객체 (쿠키 설정용)
      * @return 회원가입 결과
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
      * @throws DuplicateEmailException 이메일 중복
      */
-    LoginResponse signup(SignUpRequest request, String verificationToken);
+    LoginResponse signup(SignUpRequest request, String verificationToken, HttpServletResponse response);
 
 
     /**
      * 로그인 처리
      * @param request 로그인 요청 정보
+     * @param response HTTP 응답 객체 (쿠키 설정용)
      * @return 로그인 응답 정보
      * @throws InvalidCredentialsException 잘못된 인증 정보
      */
-    LoginResponse login(LoginRequest request);
+    LoginResponse login(LoginRequest request, HttpServletResponse response);
 
     /**
      * 비밀번호 재설정

--- a/src/main/java/org/swyp/dessertbee/common/util/CookieUtil.java
+++ b/src/main/java/org/swyp/dessertbee/common/util/CookieUtil.java
@@ -1,0 +1,50 @@
+package org.swyp.dessertbee.common.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+/**
+ * 쿠키 관련 유틸리티 클래스
+ */
+public class CookieUtil {
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final String REFRESH_TOKEN_PATH = "/api/auth/token/refresh";
+
+    /**
+     * 리프레시 토큰을 HTTP-only 쿠키로 설정
+     *
+     * @param response HTTP 응답 객체
+     * @param refreshToken 리프레시 토큰
+     * @param maxAge 쿠키 만료 시간 (초)
+     */
+    public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken, long maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)        // JavaScript에서 접근 불가능
+                .secure(true)          // HTTPS 환경에서만 전송
+                .sameSite("Strict")    // CSRF 방지
+                .path(REFRESH_TOKEN_PATH) // 토큰 갱신 엔드포인트에서만 사용
+                .maxAge(maxAge)        // 쿠키 만료 시간 (초)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    /**
+     * 리프레시 토큰 쿠키 삭제
+     *
+     * @param response HTTP 응답 객체
+     */
+    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path(REFRESH_TOKEN_PATH)
+                .maxAge(0)  // 즉시 만료
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}


### PR DESCRIPTION
## :hash: 연관된 이슈
#99 
## :memo: 작업 내용
리프레시 토큰관련해서 기존 전달방식에 대한 수정
- 기존 : 서버측에서만 저장
- 변경 : 클라이언트측으로 헤더 쿠키에 넣어서 전달

관련 api
- 액세스 토큰 갱신
- 로그인
- 회원가입

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e41104f3-bf0b-483a-8083-fe5f2ce8bade)