### PR TITLE
[FIX] 유저가 저장한 가게의 선호도 정보를 업데이트

### DIFF
--- a/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
@@ -102,14 +102,4 @@ public class UserController {
         UserDetailResponseDto response = userService.updateProfileImage(image);
         return ResponseEntity.ok(response);
     }
-
-    /** 사용자의 취향을 업데이트하고 저장된 모든 가게 리스트의 취향도 변경 */
-    @PatchMapping("/{userUuid}/preferences")
-    public ResponseEntity<Void> updateUserPreferences(
-            @PathVariable UUID userUuid,
-            @RequestBody List<String> newUserPreferences) {
-
-        userStoreService.updateUserPreferencesAndSavedStores(userUuid, newUserPreferences);
-        return ResponseEntity.noContent().build();
-    }
 }


### PR DESCRIPTION
## :hash: 연관된 이슈

> #107 

## :memo: 작업 내용

> 유저의 선호도 정보 수정 후, 유저가 저장한 가게의 선호도 정보를 업데이트하는 로직 추가