### PR TITLE
[Feature] 디저트메이트 필터링, 검색 api 구현 및 수정사항

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -11,20 +11,23 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
 import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
 import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
-import org.swyp.dessertbee.auth.dto.signup.SignUpResponse;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.swyp.dessertbee.auth.service.AuthService;
 import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.util.CookieUtil;
+
 
 @Tag(name = "Authentication", description = "인증 관련 API")
 @RestController
@@ -45,7 +48,9 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<LoginResponse> signup(
             @RequestHeader("X-Email-Verification-Token") String verificationToken,
-            @Valid @RequestBody SignUpRequest request
+            @Valid @RequestBody SignUpRequest request,
+            HttpServletResponse response
+
     ) throws BadRequestException {
         log.debug("회원가입 요청: {}", request.getEmail());
 
@@ -55,8 +60,8 @@ public class AuthController {
         }
 
         // 회원가입 처리
-        LoginResponse response = authService.signup(request, verificationToken);
-        return ResponseEntity.ok(response);
+        LoginResponse signupResponse = authService.signup(request, verificationToken, response);
+        return ResponseEntity.ok(signupResponse);
     }
 
 
@@ -72,9 +77,11 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(
             @Parameter(description = "로그인 정보", required = true)
-            @Valid @RequestBody LoginRequest request
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
     ) {
-        return ResponseEntity.ok(authService.login(request));
+        LoginResponse loginResponse = authService.login(request, response);
+        return ResponseEntity.ok(loginResponse);
     }
 
     @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃합니다.")
@@ -85,10 +92,16 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(
             @Parameter(description = "JWT 액세스 토큰", required = true)
-            @RequestHeader("Authorization") String token
+            @RequestHeader("Authorization") String token,
+            HttpServletResponse response
     ) {
         String accessToken = token.substring(7);
-        return ResponseEntity.ok(authService.logout(accessToken));
+        LogoutResponse logoutResponse = authService.logout(accessToken);
+
+        // 리프레시 토큰 쿠키 삭제
+        CookieUtil.deleteRefreshTokenCookie(response);
+
+        return ResponseEntity.ok(logoutResponse);
     }
 
     @Operation(summary = "비밀번호 재설정", description = "이메일 인증 후 비밀번호를 재설정합니다.")
@@ -108,29 +121,25 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "토큰 재발급", description = "Refresh 토큰을 사용하여 새로운 Access 토큰을 발급받습니다.")
+    @Operation(summary = "토큰 재발급", description = "HTTP-only 쿠키의 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
                     content = @Content(schema = @Schema(implementation = TokenResponse.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh 토큰")
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰")
     })
     @PostMapping("/token/refresh")
     public ResponseEntity<TokenResponse> refreshToken(
-            @RequestHeader("Authorization") String bearerToken) {
+            @CookieValue(name = "refreshToken", required = true) String refreshToken) {
         try {
-            // Bearer 토큰에서 만료된 액세스 토큰 추출
-            String accessToken = bearerToken.substring(7);  // "Bearer " 제거
-
-            // 토큰에서 이메일 추출
-            String email = jwtUtil.getEmail(accessToken, true);
-
-            // 이메일로 새로운 액세스 토큰 발급
-            TokenResponse tokenResponse = authService.refreshAccessToken(email);
-
+            // 리프레시 토큰으로 새 액세스 토큰 발급
+            TokenResponse tokenResponse = authService.refreshAccessToken(refreshToken);
             return ResponseEntity.ok(tokenResponse);
+        } catch (BusinessException e) {
+            log.warn("토큰 재발급 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         } catch (Exception e) {
-            log.error("Token refresh failed", e);
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            log.error("토큰 재발급 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/TokenResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/TokenResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @Builder
 public class TokenResponse {
     private String accessToken;
-    private String refreshToken;
     private String tokenType;
     private long expiresIn;
 }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 @AllArgsConstructor
 public class LoginResponse {
     private String accessToken;     // JWT 액세스 토큰
+    private String tokenType;       // 토큰 타입
+    private long expiresIn;         // 토큰 만료 시간
     private UUID userUuid;          // 사용자 UUID
     private String email;           // 사용자 이메일
     private String nickname;        // 사용자 닉네임
@@ -25,29 +27,20 @@ public class LoginResponse {
 
     /**
      * 로그인 성공 응답 생성
-     * @param token JWT 액세스 토큰
+     * @param accessToken JWT 액세스 토큰
+     * @param expiresIn 액세스 토큰 만료 시간 (파라미터 추가됨)
      * @param user 사용자 엔티티
      * @return 로그인 응답 객체
      */
-    public static LoginResponse success(String token, UserEntity user, String profileImageUrl) {
+    public static LoginResponse success(String accessToken, long expiresIn, UserEntity user, String profileImageUrl) {
         return LoginResponse.builder()
-                .accessToken(token)
+                .accessToken(accessToken)
+                .tokenType("Bearer") // 토큰 타입 설정 (추가됨)
+                .expiresIn(expiresIn) // 만료 시간 설정 (추가됨)
                 .userUuid(user.getUserUuid())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileImageUrl(profileImageUrl)
-                .build();
-    }
-
-    /**
-     * 토큰만 포함된 응답 생성
-     * 토큰 갱신 시 사용
-     * @param token JWT 액세스 토큰
-     * @return 로그인 응답 객체
-     */
-    public static LoginResponse withToken(String token) {
-        return LoginResponse.builder()
-                .accessToken(token)
                 .build();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.auth.service;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
@@ -23,10 +24,10 @@ public interface AuthService {
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰 발급
-     * @param email 유저 이메일
+     * @param refreshToken 리프레시 토큰
      * @return 새로운 액세스 토큰 응답
      */
-    TokenResponse refreshAccessToken(String email);
+    TokenResponse refreshAccessToken(String refreshToken);
 
     /**
      * 리프레시 토큰 무효화 (로그아웃)
@@ -38,20 +39,22 @@ public interface AuthService {
      * 회원가입 처리
      * @param request 회원가입 요청 정보
      * @param verificationToken 이메일 인증 토큰
+     * @param response HTTP 응답 객체 (쿠키 설정용)
      * @return 회원가입 결과
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
      * @throws DuplicateEmailException 이메일 중복
      */
-    LoginResponse signup(SignUpRequest request, String verificationToken);
+    LoginResponse signup(SignUpRequest request, String verificationToken, HttpServletResponse response);
 
 
     /**
      * 로그인 처리
      * @param request 로그인 요청 정보
+     * @param response HTTP 응답 객체 (쿠키 설정용)
      * @return 로그인 응답 정보
      * @throws InvalidCredentialsException 잘못된 인증 정보
      */
-    LoginResponse login(LoginRequest request);
+    LoginResponse login(LoginRequest request, HttpServletResponse response);
 
     /**
      * 비밀번호 재설정

--- a/src/main/java/org/swyp/dessertbee/common/util/CookieUtil.java
+++ b/src/main/java/org/swyp/dessertbee/common/util/CookieUtil.java
@@ -1,0 +1,50 @@
+package org.swyp.dessertbee.common.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+/**
+ * 쿠키 관련 유틸리티 클래스
+ */
+public class CookieUtil {
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final String REFRESH_TOKEN_PATH = "/api/auth/token/refresh";
+
+    /**
+     * 리프레시 토큰을 HTTP-only 쿠키로 설정
+     *
+     * @param response HTTP 응답 객체
+     * @param refreshToken 리프레시 토큰
+     * @param maxAge 쿠키 만료 시간 (초)
+     */
+    public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken, long maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)        // JavaScript에서 접근 불가능
+                .secure(true)          // HTTPS 환경에서만 전송
+                .sameSite("Strict")    // CSRF 방지
+                .path(REFRESH_TOKEN_PATH) // 토큰 갱신 엔드포인트에서만 사용
+                .maxAge(maxAge)        // 쿠키 만료 시간 (초)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    /**
+     * 리프레시 토큰 쿠키 삭제
+     *
+     * @param response HTTP 응답 객체
+     */
+    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path(REFRESH_TOKEN_PATH)
+                .maxAge(0)  // 즉시 만료
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -64,9 +64,9 @@ public class MateController {
      */
     @Operation(summary = "메이트 상세 정보 조회", description = "디저트메이트 상세 정보 조회합니다.")
     @GetMapping("/{mateUuid}")
-    public ResponseEntity<MateDetailResponse> getMateDetail(@PathVariable UUID mateUuid) {
+    public ResponseEntity<MateDetailResponse> getMateDetail(@PathVariable UUID mateUuid, UUID userUuid) {
 
-        MateDetailResponse mate = mateService.getMateDetail(mateUuid);
+        MateDetailResponse mate = mateService.getMateDetail(mateUuid, userUuid);
         return ResponseEntity.ok(mate);
     }
 
@@ -120,7 +120,8 @@ public class MateController {
     @Operation(summary = "메이트 전체 조회", description = "디저트메이트 전체 조회합니다.")
     public ResponseEntity<MatesPageResponse> getMates(
             @RequestParam int from,
-            @RequestParam int to
+            @RequestParam int to,
+            UUID userUuid
     ) {
 
         if (from >= to) {
@@ -129,6 +130,6 @@ public class MateController {
 
 
         Pageable pageable = PageRequest.of(from, to);
-        return ResponseEntity.ok(mateService.getMates(pageable));
+        return ResponseEntity.ok(mateService.getMates(pageable, userUuid));
     }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -121,6 +121,7 @@ public class MateController {
     public ResponseEntity<MatesPageResponse> getMates(
             @RequestParam int from,
             @RequestParam int to,
+            @RequestParam String keyword,
             UUID userUuid,
             Long mateCategoryId
     ) {
@@ -131,6 +132,6 @@ public class MateController {
 
 
         Pageable pageable = PageRequest.of(from, to);
-        return ResponseEntity.ok(mateService.getMates(pageable, userUuid, mateCategoryId));
+        return ResponseEntity.ok(mateService.getMates(pageable, userUuid, mateCategoryId, keyword));
     }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -134,4 +134,23 @@ public class MateController {
         Pageable pageable = PageRequest.of(from, to);
         return ResponseEntity.ok(mateService.getMates(pageable, userUuid, mateCategoryId, keyword));
     }
+
+    /**
+     * 내가 참여한 디저트메이트 조회
+     * */
+    @GetMapping("/me")
+    public ResponseEntity<MatesPageResponse> getMyMates(@RequestParam int from,
+                                                        @RequestParam int to,
+                                                        UUID userUuid){
+
+        if (from >= to) {
+            throw new FromToMateException("잘못된 범위 요청입니다.");
+        }
+
+
+        Pageable pageable = PageRequest.of(from, to);
+
+        return ResponseEntity.ok(mateService.getMyMates(pageable, userUuid));
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -121,7 +121,8 @@ public class MateController {
     public ResponseEntity<MatesPageResponse> getMates(
             @RequestParam int from,
             @RequestParam int to,
-            UUID userUuid
+            UUID userUuid,
+            Long mateCategoryId
     ) {
 
         if (from >= to) {
@@ -130,6 +131,6 @@ public class MateController {
 
 
         Pageable pageable = PageRequest.of(from, to);
-        return ResponseEntity.ok(mateService.getMates(pageable, userUuid));
+        return ResponseEntity.ok(mateService.getMates(pageable, userUuid, mateCategoryId));
     }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -130,8 +130,9 @@ public class MateController {
             throw new FromToMateException("잘못된 범위 요청입니다.");
         }
 
-
-        Pageable pageable = PageRequest.of(from, to);
+        int size = to - from;
+        int page = from / size;
+        Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(mateService.getMates(pageable, userUuid, mateCategoryId, keyword));
     }
 
@@ -147,8 +148,10 @@ public class MateController {
             throw new FromToMateException("잘못된 범위 요청입니다.");
         }
 
+        int size = to - from;
+        int page = from / size;
+        Pageable pageable = PageRequest.of(page, size);
 
-        Pageable pageable = PageRequest.of(from, to);
 
         return ResponseEntity.ok(mateService.getMyMates(pageable, userUuid));
     }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
@@ -43,7 +43,7 @@ public class MateMemberController {
     /**
      * 디저트 메이트 대기 멤버 전체 조회
      **/
-    @GetMapping("apply")
+    @GetMapping("/pending")
     public ResponseEntity<List<MateMemberResponse>> pendingMate(@PathVariable UUID mateUuid) {
 
         List<MateMemberResponse> members = mateMemberService.pendingMate(mateUuid);
@@ -63,7 +63,7 @@ public class MateMemberController {
     /**
      * 디저트 메이트 멤버 신청 거절 api
      * */
-    @DeleteMapping("/apply")
+    @DeleteMapping("/reject")
     public ResponseEntity<String> rejectMemeber(@PathVariable UUID mateUuid, UUID creatorUuid, UUID targetUuid) {
 
         mateMemberService.rejectMember(mateUuid, creatorUuid, targetUuid);

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
@@ -41,6 +41,15 @@ public class MateMemberController {
     }
 
     /**
+     * 디저트메이트 멤버 신청 취소 api
+     * */
+    @DeleteMapping("/apply")
+    public ResponseEntity<String> cancelApplyMate(@PathVariable UUID mateUuid, UUID userUuid) {
+
+        mateMemberService.cancelApplyMate(mateUuid, userUuid);
+        return ResponseEntity.ok("디저트메이트 성공적으로 신청 취소되었습니다.");
+    }
+    /**
      * 디저트 메이트 대기 멤버 전체 조회
      **/
     @GetMapping("/pending")

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
@@ -89,7 +89,9 @@ public class MateReplyController {
             throw new MateExceptions.FromToMateException("잘못된 범위 요청입니다.");
         }
 
-        Pageable pageable = PageRequest.of(from, to, Sort.by("mateReplyId").ascending());
+        int size = to - from;
+        int page = from / size;
+        Pageable pageable = PageRequest.of(page, size);
 
         return ResponseEntity.ok(mateReplyService.getReplies(mateUuid, pageable));
     }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/SavedMateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/SavedMateController.java
@@ -61,7 +61,10 @@ public class SavedMateController {
         if (from >= to) {
             throw new FromToMateException("잘못된 범위 요청입니다.");
         }
-        Pageable pageable = PageRequest.of(from, to);
+
+        int size = to - from;
+        int page = from / size;
+        Pageable pageable = PageRequest.of(page, size);
 
         return ResponseEntity.ok(savedMateService.getSavedMates(pageable, userUuid));
     }

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
@@ -29,6 +29,7 @@ public class MateDetailResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private boolean saved;
+    private String applyStatus;
 
     //디저트메이트 카테고리명
     private String mateCategory;
@@ -38,7 +39,8 @@ public class MateDetailResponse {
                                                 String category,
                                                 UserEntity creator,
                                                 List<String> profileImage,
-                                                boolean saved){
+                                                boolean saved,
+                                                String applyStatus) {
 
         return MateDetailResponse.builder()
                 .mateUuid(mate.getMateUuid())
@@ -60,6 +62,7 @@ public class MateDetailResponse {
                 .createdAt(mate.getCreatedAt())
                 .updatedAt(mate.getUpdatedAt())
                 .saved(saved)
+                .applyStatus(applyStatus)
                 .build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
@@ -28,6 +28,7 @@ public class MateDetailResponse {
     private MatePlace place;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean saved;
 
     //디저트메이트 카테고리명
     private String mateCategory;
@@ -36,7 +37,8 @@ public class MateDetailResponse {
                                                 List<String> mateImage,
                                                 String category,
                                                 UserEntity creator,
-                                                List<String> profileImage){
+                                                List<String> profileImage,
+                                                boolean saved){
 
         return MateDetailResponse.builder()
                 .mateUuid(mate.getMateUuid())
@@ -57,6 +59,7 @@ public class MateDetailResponse {
                         .build())
                 .createdAt(mate.getCreatedAt())
                 .updatedAt(mate.getUpdatedAt())
+                .saved(saved)
                 .build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
@@ -80,11 +80,12 @@ public class Mate {
     private LocalDateTime deletedAt;
 
 
-    public void update(MateCreateRequest request) {
+    public void update(MateCreateRequest request, Long storeId) {
         this.title = request.getTitle();
         this.content = request.getContent();
         this.recruitYn = request.getRecruitYn();
         this.mateCategoryId = request.getMateCategoryId();
+        this.storeId = storeId;
         this.placeName = request.getPlace().getPlaceName();
     }
 

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateApplyStatus.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateApplyStatus.java
@@ -1,0 +1,9 @@
+package org.swyp.dessertbee.mate.entity;
+
+public enum MateApplyStatus {
+        NONE,       // 신청 기록이 없음
+        PENDING,    // 신청 중 (대기 상태)
+        APPROVED,   // 승인됨
+        REJECTED,   // 거절됨
+        REAPPLY     // 재신청 중
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateMember.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateMember.java
@@ -64,5 +64,7 @@ public class MateMember {
         return this.getApprovalYn() && this.getDeletedAt() != null ;
     }
 
-
+    public Boolean isApprove() {
+        return this.getApprovalYn()&& this.getDeletedAt() == null;
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
@@ -37,4 +37,8 @@ public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
     Optional<MateMember> findByMateIdAndUserIdAndDeletedAtIsNull(Long mateId, Long userId);
 
     Optional<MateMember> findByMateIdAndUserId(Long mateId, Long userId);
+
+
+    //신청했는지 안했는지 확인하는 필드
+    MateMember findByMateIdAndDeletedAtIsNullAndUserId(Long mateId, Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
@@ -47,4 +47,8 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL AND m.mateId IN :mateIds")
     List<Mate> findByMateIdIn(@Param("mateIds") List<Long> mateIds);
+
+    @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL " +
+            "AND m.userId = :userId")
+    Page<Mate> findByDeletedAtIsNullAndUserId(Pageable pageable, Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
@@ -29,11 +29,14 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     @Query("SELECT m.mateId FROM Mate m where m.mateUuid = :mateUuid")
     Optional<Long> findMateIdByMateUuid(UUID mateUuid);
 
+
     /**
-     *
-     * */
-    @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL ORDER BY m.mateId DESC")
-    Page<Mate> findAllByDeletedAtIsNull(Pageable pageable);
+     * 디저트 메이트 카테고리로 조회(카테고리 아이디 없을 떄는 null)
+     **/
+    @Query("SELECT m FROM Mate m " +
+            "WHERE m.deletedAt IS NULL " +
+            "AND (:mateCategoryId IS NULL OR m.mateCategoryId = :mateCategoryId) ORDER BY m.mateId DESC")
+    Page<Mate> findByDeletedAtIsNullAndMateCategoryId(@Param("mateCategoryId") Long mateCategoryId, Pageable pageable);
 
 
     @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL AND m.mateId IN :mateIds")

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
@@ -35,8 +35,14 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
      **/
     @Query("SELECT m FROM Mate m " +
             "WHERE m.deletedAt IS NULL " +
-            "AND (:mateCategoryId IS NULL OR m.mateCategoryId = :mateCategoryId) ORDER BY m.mateId DESC")
-    Page<Mate> findByDeletedAtIsNullAndMateCategoryId(@Param("mateCategoryId") Long mateCategoryId, Pageable pageable);
+            "AND (:mateCategoryId IS NULL OR m.mateCategoryId = :mateCategoryId) " +
+            "AND (:keyword IS NULL OR (m.title LIKE CONCAT('%', :keyword, '%') " +
+            "     OR m.content LIKE CONCAT('%', :keyword, '%') " +
+            "     OR m.placeName LIKE CONCAT('%', :keyword, '%'))) " +
+            "ORDER BY m.mateId DESC")
+    Page<Mate> findByDeletedAtIsNullAndMateCategoryId(@Param("mateCategoryId") Long mateCategoryId,
+                                                      @Param("keyword") String keyword,
+                                                      Pageable pageable);
 
 
     @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL AND m.mateId IN :mateIds")

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -170,6 +170,8 @@ public class MateMemberService {
         }
 
 
+
+
         //재신청 로직
         if (mateMember.isReapply()) {
 

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -153,10 +153,6 @@ public class MateMemberService {
             return;
         }
 
-        if(mateMember.getUserId().equals(userId)) {
-            throw new AlreadyTeamMemberException("해당 사용자는 이미 팀원입니다.");
-        }
-
         if (mateMember.getBannedYn()) {
             throw new MateApplyBannedException("디저트메이트 강퇴 당한 사람입니다. 신청 불가능합니다.");
         }
@@ -196,7 +192,25 @@ public class MateMemberService {
     }
 
 
+    /**
+     * 디저트메이트 신청 취소 api
+     * */
+    public void cancelApplyMate(UUID mateUuid, UUID userUuid) {
 
+        //mateId,userId  유효성 검사
+        MateUserIds validate = validateMateAndUser(mateUuid, userUuid);
+        Long mateId = validate.getMateId();
+        Long userId = validate.getUserId();
+
+        MateMember mateMember = mateMemberRepository.findByMateIdAndUserId(mateId, userId)
+                .orElseThrow(() ->  new MateNotFoundException("디저트메이트 신청하신 분이 아닙니다."));
+
+        assert mateMember != null;
+        if(mateMember.isPending()){
+            mateMemberRepository.delete(mateMember);
+        }
+
+    }
     /**
      * 디저트 메이트 대기 멤버 전체 조회
      **/
@@ -422,6 +436,7 @@ public class MateMemberService {
 
         return new MateUserIds(mateId, userId);
     }
+
 
 }
 

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -138,6 +138,7 @@ public class MateMemberService {
         MateMember mateMember = mateMemberRepository.findByMateIdAndUserId(mateId, userId)
                 .orElse(null);
 
+
         if(mateMember == null) {
             // mateMember가 없으면 새로 저장 후 종료
             mateMemberRepository.save(
@@ -150,6 +151,10 @@ public class MateMemberService {
                             .build()
             );
             return;
+        }
+
+        if(mateMember.getUserId().equals(userId)) {
+            throw new AlreadyTeamMemberException("해당 사용자는 이미 팀원입니다.");
         }
 
         if (mateMember.getBannedYn()) {

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -200,15 +200,15 @@ public class MateService {
      * 디저트메이트 전체 조회
      * */
     @Transactional
-    public MatesPageResponse getMates(Pageable pageable,UUID userUuid, Long mateCategoryId) {
+    public MatesPageResponse getMates(Pageable pageable,UUID userUuid, Long mateCategoryId, String keyword) {
 
 
 
         // limit + 1 만큼 데이터를 가져와서 다음 데이터가 있는지 확인
-        Page<Mate> mates = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, pageable);
+        Page<Mate> mates = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, keyword,pageable);
 
 
-        List<MateDetailResponse> matesResponses = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, pageable)
+        List<MateDetailResponse> matesResponses = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, keyword, pageable)
                     .stream()
                     .map(mate -> {
                         List<String> mateImages = imageService.getImagesByTypeAndId(ImageType.MATE, mate.getMateId());

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -171,15 +171,15 @@ public class MateService {
      * 디저트메이트 전체 조회
      * */
     @Transactional
-    public MatesPageResponse getMates(Pageable pageable,UUID userUuid) {
+    public MatesPageResponse getMates(Pageable pageable,UUID userUuid, Long mateCategoryId) {
 
 
 
         // limit + 1 만큼 데이터를 가져와서 다음 데이터가 있는지 확인
-        Page<Mate> mates = mateRepository.findAllByDeletedAtIsNull(pageable);
+        Page<Mate> mates = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, pageable);
 
 
-        List<MateDetailResponse> matesResponses = mateRepository.findAllByDeletedAtIsNull(pageable)
+        List<MateDetailResponse> matesResponses = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, pageable)
                     .stream()
                     .map(mate -> {
                         List<String> mateImages = imageService.getImagesByTypeAndId(ImageType.MATE, mate.getMateId());
@@ -209,7 +209,5 @@ public class MateService {
         return new MatesPageResponse(matesResponses, isLast);
 
     }
-
-
 
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -203,8 +203,6 @@ public class MateService {
     public MatesPageResponse getMates(Pageable pageable,UUID userUuid, Long mateCategoryId, String keyword) {
 
 
-
-        // limit + 1 만큼 데이터를 가져와서 다음 데이터가 있는지 확인
         Page<Mate> mates = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, keyword,pageable);
 
 
@@ -267,7 +265,7 @@ public class MateService {
 
         Long userId = userRepository.findIdByUserUuid(userUuid);
 
-        // limit + 1 만큼 데이터를 가져와서 다음 데이터가 있는지 확인
+
         Page<Mate> mates = mateRepository.findByDeletedAtIsNullAndUserId(pageable, userId);
 
 

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -156,7 +156,10 @@ public class MateService {
         Mate mate = mateRepository.findByMateUuidAndDeletedAtIsNull(mateUuid)
                 .orElseThrow(() -> new MateNotFoundException("존재하지 않는 디저트메이트입니다."));
 
-        mate.update(request);
+        //장소명으로 storeId 조회
+        Long storeId = storeRepository.findStoreIdByName(request.getPlace().getPlaceName());
+
+        mate.update(request, storeId);
 
 
 

--- a/src/main/java/org/swyp/dessertbee/mate/service/SavedMateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/SavedMateService.java
@@ -122,7 +122,9 @@ public class SavedMateService {
                     UserEntity creator = mateMemberRepository.findByMateId(mate.getMateId());
                     List<String> profileImage = imageService.getImagesByTypeAndId(ImageType.PROFILE, mate.getUserId());
 
-                    return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage);
+                    //저장된 디저트메이트 데이터만 지고 오는거니까 true
+                    boolean saved = true;
+                    return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage, saved);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/org/swyp/dessertbee/mate/service/SavedMateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/SavedMateService.java
@@ -10,6 +10,8 @@ import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.mate.dto.response.MateDetailResponse;
 import org.swyp.dessertbee.mate.dto.response.MatesPageResponse;
 import org.swyp.dessertbee.mate.entity.Mate;
+import org.swyp.dessertbee.mate.entity.MateApplyStatus;
+import org.swyp.dessertbee.mate.entity.MateMember;
 import org.swyp.dessertbee.mate.entity.SavedMate;
 import org.swyp.dessertbee.mate.exception.MateExceptions.*;
 import org.swyp.dessertbee.mate.repository.MateCategoryRepository;
@@ -124,7 +126,29 @@ public class SavedMateService {
 
                     //저장된 디저트메이트 데이터만 지고 오는거니까 true
                     boolean saved = true;
-                    return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage, saved);
+
+
+                    //신청했는지 유무 확인
+                    MateMember applyMember = mateMemberRepository.findByMateIdAndDeletedAtIsNullAndUserId(mate.getMateId(), userId);
+
+                    String applyStatus = "";
+
+                    if (applyMember == null) {
+                        applyStatus = MateApplyStatus.NONE.name();
+                    }else{
+
+
+                        if(applyMember.isPending())
+                        {
+                            applyStatus = MateApplyStatus.PENDING.name();
+                        }
+
+                        if (applyMember.isApprove()){
+                            applyStatus = MateApplyStatus.APPROVED.name();
+                        }
+
+                    }
+                    return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage, saved, applyStatus);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/org/swyp/dessertbee/preference/repository/PreferenceRepository.java
+++ b/src/main/java/org/swyp/dessertbee/preference/repository/PreferenceRepository.java
@@ -5,11 +5,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.swyp.dessertbee.preference.entity.PreferenceEntity;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PreferenceRepository extends JpaRepository<PreferenceEntity, Long> {
     Optional<PreferenceEntity> findByPreferenceName(String preferenceName);
 
-    @Query("SELECT p.preferenceName FROM PreferenceEntity p WHERE p.id = :id")
-    String findPreferenceNameById(@Param("id") Long id);
+    @Query("SELECT p.preferenceName FROM PreferenceEntity p WHERE p.id IN :preferenceTagIds")
+    List<String> findPreferenceNamesByIds(@Param("preferenceTagIds") List<Long> preferenceTagIds);
+
 }

--- a/src/main/java/org/swyp/dessertbee/preference/service/PreferenceService.java
+++ b/src/main/java/org/swyp/dessertbee/preference/service/PreferenceService.java
@@ -3,10 +3,17 @@ package org.swyp.dessertbee.preference.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.preference.dto.PreferenceResponseDto;
+import org.swyp.dessertbee.preference.entity.PreferenceEntity;
+import org.swyp.dessertbee.preference.entity.UserPreferenceEntity;
 import org.swyp.dessertbee.preference.repository.PreferenceRepository;
+import org.swyp.dessertbee.user.entity.UserEntity;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,4 +37,49 @@ public class PreferenceService {
                         .build())
                 .collect(Collectors.toList());
     }
+
+    /**
+     * 사용자의 선호도 정보를 업데이트합니다.
+     * 기존 선호도를 모두 제거하고 새로운 선호도로 대체합니다.
+     */
+    @Transactional
+    public void updateUserPreferences(UserEntity user, List<Long> newPreferenceIds) {
+        // 기존 선호도 모두 제거
+        user.getUserPreferences().clear();
+
+        // 새로운 선호도가 없는 경우 종료
+        if (newPreferenceIds == null || newPreferenceIds.isEmpty()) {
+            return;
+        }
+
+        // 새로운 선호도 ID들의 유효성을 한 번에 검사
+        Set<PreferenceEntity> preferences = new HashSet<>(preferenceRepository.findAllById(newPreferenceIds));
+
+        // 요청된 모든 선호도 ID가 유효한지 확인
+        if (preferences.size() != newPreferenceIds.size()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "존재하지 않는 선호도가 포함되어 있습니다.");
+        }
+
+        // 새로운 선호도 설정
+        preferences.forEach(preference -> {
+            UserPreferenceEntity userPreference = UserPreferenceEntity.builder()
+                    .user(user)
+                    .preference(preference)
+                    .build();
+            user.getUserPreferences().add(userPreference);
+        });
+    }
+
+    /**
+     * UserPreferenceEntity Set을 preference ID List로 변환합니다.
+     */
+    public List<Long> convertToPreferenceIds(Set<UserPreferenceEntity> preferences) {
+        if (preferences == null || preferences.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return preferences.stream()
+                .map(up -> up.getPreference().getId())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -60,11 +60,11 @@ public class StoreController {
             @RequestParam Double latitude,
             @RequestParam Double longitude,
             @RequestParam Double radius,
-            @RequestParam(required = false) Long preferenceTagId,
+            @RequestParam(required = false) List<Long> preferenceTagIds,
             @RequestParam(required = false) String searchKeyword) {
 
-        if (preferenceTagId != null) {
-            return storeService.getStoresByLocationAndTag(latitude, longitude, radius, preferenceTagId);
+        if (preferenceTagIds != null && !preferenceTagIds.isEmpty()) {
+            return storeService.getStoresByLocationAndTags(latitude, longitude, radius, preferenceTagIds);
         } else if (searchKeyword != null) {
             return storeService.getStoresByLocationAndKeyword(latitude, longitude, radius, searchKeyword);
         } else {

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
@@ -63,7 +63,7 @@ public class UserStoreController {
 
     /** 리스트별 저장된 가게 조회 */
     @GetMapping("/lists/{listId}/stores")
-    public ResponseEntity<List<SavedStoreResponse>> getStoresByList(@PathVariable Long listId) {
+    public ResponseEntity<UserStoreListResponse> getStoresByList(@PathVariable Long listId) {
         return ResponseEntity.ok(userStoreService.getStoresByList(listId));
     }
 

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/UserStoreListResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/UserStoreListResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -15,4 +16,5 @@ public class UserStoreListResponse {
     private String listName;
     private Long iconColorId;
     private int storeCount;
+    private List<SavedStoreResponse> storeData;
 }

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -61,5 +61,4 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
      */
     @Query("SELECT u FROM UserEntity u WHERE u.email = :email AND u.deletedAt IS NOT NULL")
     Optional<UserEntity> findDeletedAccountByEmail(String email);
-
 }


### PR DESCRIPTION
## :hash: 연관된 이슈

> 71

## :memo: 작업 내용

> 디저트메이트 필터링, 검색 api 구현(전체 조회 api 수정)
> 디저트메이트 applyStatus 필드 추가
> 디저트메이트 전채 조회 시 saved 필드 추가
> 디저트메이트 신청 취소 api 구현
> 신청 대기,거절 엔드포인트 변경
> 디저트메이트 내가 참여한 디저트메이트 조회 api 구현



## :speech_balloon: 리뷰 요구사항(선택)

> 이번에 변경 된 부분들이 좀 많습니다. 보시다가 이해 안되는 부분들은 편하게 물어봐주세요!
> 디저트메이트 부분만 보시면 될 거 같습니다!
