### PR TITLE
[Feature] 디저트메이트 필터링 및 검색 api 구현

### DIFF
--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateController.java
@@ -64,9 +64,9 @@ public class MateController {
      */
     @Operation(summary = "메이트 상세 정보 조회", description = "디저트메이트 상세 정보 조회합니다.")
     @GetMapping("/{mateUuid}")
-    public ResponseEntity<MateDetailResponse> getMateDetail(@PathVariable UUID mateUuid) {
+    public ResponseEntity<MateDetailResponse> getMateDetail(@PathVariable UUID mateUuid, UUID userUuid) {
 
-        MateDetailResponse mate = mateService.getMateDetail(mateUuid);
+        MateDetailResponse mate = mateService.getMateDetail(mateUuid, userUuid);
         return ResponseEntity.ok(mate);
     }
 
@@ -120,15 +120,40 @@ public class MateController {
     @Operation(summary = "메이트 전체 조회", description = "디저트메이트 전체 조회합니다.")
     public ResponseEntity<MatesPageResponse> getMates(
             @RequestParam int from,
-            @RequestParam int to
+            @RequestParam int to,
+            @RequestParam String keyword,
+            UUID userUuid,
+            Long mateCategoryId
     ) {
 
         if (from >= to) {
             throw new FromToMateException("잘못된 범위 요청입니다.");
         }
 
-
-        Pageable pageable = PageRequest.of(from, to);
-        return ResponseEntity.ok(mateService.getMates(pageable));
+        int size = to - from;
+        int page = from / size;
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(mateService.getMates(pageable, userUuid, mateCategoryId, keyword));
     }
+
+    /**
+     * 내가 참여한 디저트메이트 조회
+     * */
+    @GetMapping("/me")
+    public ResponseEntity<MatesPageResponse> getMyMates(@RequestParam int from,
+                                                        @RequestParam int to,
+                                                        UUID userUuid){
+
+        if (from >= to) {
+            throw new FromToMateException("잘못된 범위 요청입니다.");
+        }
+
+        int size = to - from;
+        int page = from / size;
+        Pageable pageable = PageRequest.of(page, size);
+
+
+        return ResponseEntity.ok(mateService.getMyMates(pageable, userUuid));
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateMemberController.java
@@ -41,9 +41,18 @@ public class MateMemberController {
     }
 
     /**
+     * 디저트메이트 멤버 신청 취소 api
+     * */
+    @DeleteMapping("/apply")
+    public ResponseEntity<String> cancelApplyMate(@PathVariable UUID mateUuid, UUID userUuid) {
+
+        mateMemberService.cancelApplyMate(mateUuid, userUuid);
+        return ResponseEntity.ok("디저트메이트 성공적으로 신청 취소되었습니다.");
+    }
+    /**
      * 디저트 메이트 대기 멤버 전체 조회
      **/
-    @GetMapping("apply")
+    @GetMapping("/pending")
     public ResponseEntity<List<MateMemberResponse>> pendingMate(@PathVariable UUID mateUuid) {
 
         List<MateMemberResponse> members = mateMemberService.pendingMate(mateUuid);
@@ -63,7 +72,7 @@ public class MateMemberController {
     /**
      * 디저트 메이트 멤버 신청 거절 api
      * */
-    @DeleteMapping("/apply")
+    @DeleteMapping("/reject")
     public ResponseEntity<String> rejectMemeber(@PathVariable UUID mateUuid, UUID creatorUuid, UUID targetUuid) {
 
         mateMemberService.rejectMember(mateUuid, creatorUuid, targetUuid);

--- a/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/MateReplyController.java
@@ -89,7 +89,9 @@ public class MateReplyController {
             throw new MateExceptions.FromToMateException("잘못된 범위 요청입니다.");
         }
 
-        Pageable pageable = PageRequest.of(from, to, Sort.by("mateReplyId").ascending());
+        int size = to - from;
+        int page = from / size;
+        Pageable pageable = PageRequest.of(page, size);
 
         return ResponseEntity.ok(mateReplyService.getReplies(mateUuid, pageable));
     }

--- a/src/main/java/org/swyp/dessertbee/mate/controller/SavedMateController.java
+++ b/src/main/java/org/swyp/dessertbee/mate/controller/SavedMateController.java
@@ -61,7 +61,10 @@ public class SavedMateController {
         if (from >= to) {
             throw new FromToMateException("잘못된 범위 요청입니다.");
         }
-        Pageable pageable = PageRequest.of(from, to);
+
+        int size = to - from;
+        int page = from / size;
+        Pageable pageable = PageRequest.of(page, size);
 
         return ResponseEntity.ok(savedMateService.getSavedMates(pageable, userUuid));
     }

--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateDetailResponse.java
@@ -28,6 +28,8 @@ public class MateDetailResponse {
     private MatePlace place;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean saved;
+    private String applyStatus;
 
     //디저트메이트 카테고리명
     private String mateCategory;
@@ -36,7 +38,9 @@ public class MateDetailResponse {
                                                 List<String> mateImage,
                                                 String category,
                                                 UserEntity creator,
-                                                List<String> profileImage){
+                                                List<String> profileImage,
+                                                boolean saved,
+                                                String applyStatus) {
 
         return MateDetailResponse.builder()
                 .mateUuid(mate.getMateUuid())
@@ -57,6 +61,8 @@ public class MateDetailResponse {
                         .build())
                 .createdAt(mate.getCreatedAt())
                 .updatedAt(mate.getUpdatedAt())
+                .saved(saved)
+                .applyStatus(applyStatus)
                 .build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/Mate.java
@@ -80,11 +80,12 @@ public class Mate {
     private LocalDateTime deletedAt;
 
 
-    public void update(MateCreateRequest request) {
+    public void update(MateCreateRequest request, Long storeId) {
         this.title = request.getTitle();
         this.content = request.getContent();
         this.recruitYn = request.getRecruitYn();
         this.mateCategoryId = request.getMateCategoryId();
+        this.storeId = storeId;
         this.placeName = request.getPlace().getPlaceName();
     }
 

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateApplyStatus.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateApplyStatus.java
@@ -1,0 +1,9 @@
+package org.swyp.dessertbee.mate.entity;
+
+public enum MateApplyStatus {
+        NONE,       // 신청 기록이 없음
+        PENDING,    // 신청 중 (대기 상태)
+        APPROVED,   // 승인됨
+        REJECTED,   // 거절됨
+        REAPPLY     // 재신청 중
+}

--- a/src/main/java/org/swyp/dessertbee/mate/entity/MateMember.java
+++ b/src/main/java/org/swyp/dessertbee/mate/entity/MateMember.java
@@ -64,5 +64,7 @@ public class MateMember {
         return this.getApprovalYn() && this.getDeletedAt() != null ;
     }
 
-
+    public Boolean isApprove() {
+        return this.getApprovalYn()&& this.getDeletedAt() == null;
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateMemberRepository.java
@@ -37,4 +37,8 @@ public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
     Optional<MateMember> findByMateIdAndUserIdAndDeletedAtIsNull(Long mateId, Long userId);
 
     Optional<MateMember> findByMateIdAndUserId(Long mateId, Long userId);
+
+
+    //신청했는지 안했는지 확인하는 필드
+    MateMember findByMateIdAndDeletedAtIsNullAndUserId(Long mateId, Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
+++ b/src/main/java/org/swyp/dessertbee/mate/repository/MateRepository.java
@@ -29,13 +29,26 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
     @Query("SELECT m.mateId FROM Mate m where m.mateUuid = :mateUuid")
     Optional<Long> findMateIdByMateUuid(UUID mateUuid);
 
+
     /**
-     *
-     * */
-    @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL ORDER BY m.mateId DESC")
-    Page<Mate> findAllByDeletedAtIsNull(Pageable pageable);
+     * 디저트 메이트 카테고리로 조회(카테고리 아이디 없을 떄는 null)
+     **/
+    @Query("SELECT m FROM Mate m " +
+            "WHERE m.deletedAt IS NULL " +
+            "AND (:mateCategoryId IS NULL OR m.mateCategoryId = :mateCategoryId) " +
+            "AND (:keyword IS NULL OR (m.title LIKE CONCAT('%', :keyword, '%') " +
+            "     OR m.content LIKE CONCAT('%', :keyword, '%') " +
+            "     OR m.placeName LIKE CONCAT('%', :keyword, '%'))) " +
+            "ORDER BY m.mateId DESC")
+    Page<Mate> findByDeletedAtIsNullAndMateCategoryId(@Param("mateCategoryId") Long mateCategoryId,
+                                                      @Param("keyword") String keyword,
+                                                      Pageable pageable);
 
 
     @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL AND m.mateId IN :mateIds")
     List<Mate> findByMateIdIn(@Param("mateIds") List<Long> mateIds);
+
+    @Query("SELECT m FROM Mate m WHERE m.deletedAt IS NULL " +
+            "AND m.userId = :userId")
+    Page<Mate> findByDeletedAtIsNullAndUserId(Pageable pageable, Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateMemberService.java
@@ -138,6 +138,7 @@ public class MateMemberService {
         MateMember mateMember = mateMemberRepository.findByMateIdAndUserId(mateId, userId)
                 .orElse(null);
 
+
         if(mateMember == null) {
             // mateMember가 없으면 새로 저장 후 종료
             mateMemberRepository.save(
@@ -165,6 +166,8 @@ public class MateMemberService {
         }
 
 
+
+
         //재신청 로직
         if (mateMember.isReapply()) {
 
@@ -189,7 +192,25 @@ public class MateMemberService {
     }
 
 
+    /**
+     * 디저트메이트 신청 취소 api
+     * */
+    public void cancelApplyMate(UUID mateUuid, UUID userUuid) {
 
+        //mateId,userId  유효성 검사
+        MateUserIds validate = validateMateAndUser(mateUuid, userUuid);
+        Long mateId = validate.getMateId();
+        Long userId = validate.getUserId();
+
+        MateMember mateMember = mateMemberRepository.findByMateIdAndUserId(mateId, userId)
+                .orElseThrow(() ->  new MateNotFoundException("디저트메이트 신청하신 분이 아닙니다."));
+
+        assert mateMember != null;
+        if(mateMember.isPending()){
+            mateMemberRepository.delete(mateMember);
+        }
+
+    }
     /**
      * 디저트 메이트 대기 멤버 전체 조회
      **/
@@ -415,6 +436,7 @@ public class MateMemberService {
 
         return new MateUserIds(mateId, userId);
     }
+
 
 }
 

--- a/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/MateService.java
@@ -12,6 +12,8 @@ import org.swyp.dessertbee.mate.dto.request.MateCreateRequest;
 import org.swyp.dessertbee.mate.dto.response.MateDetailResponse;
 import org.swyp.dessertbee.mate.dto.response.MatesPageResponse;
 import org.swyp.dessertbee.mate.entity.Mate;
+import org.swyp.dessertbee.mate.entity.MateApplyStatus;
+import org.swyp.dessertbee.mate.entity.MateMember;
 import org.swyp.dessertbee.mate.entity.SavedMate;
 import org.swyp.dessertbee.mate.exception.MateExceptions;
 import org.swyp.dessertbee.mate.exception.MateExceptions.*;
@@ -27,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -67,6 +70,7 @@ public class MateService {
                         .content(request.getContent())
                         .recruitYn(Boolean.TRUE.equals(request.getRecruitYn()))
                         .placeName(request.getPlace().getPlaceName())
+                        .updatedAt(null)
                         .build()
         );
 
@@ -81,12 +85,12 @@ public class MateService {
         //디저트 메이트 mateId를 가진 member 데이터 생성
         mateMemberService.addCreatorAsMember(mate.getMateUuid(), userId);
 
-        return getMateDetail(mate.getMateUuid());
+        return getMateDetail(mate.getMateUuid(), request.getUserUuid());
     }
 
 
     /** 메이트 상세 정보 */
-    public MateDetailResponse getMateDetail(UUID mateUuid) {
+    public MateDetailResponse getMateDetail(UUID mateUuid, UUID userUuid) {
 
         //mateId로 디저트메이트 여부 확인
         Mate mate = mateRepository.findByMateUuidAndDeletedAtIsNull(mateUuid)
@@ -98,15 +102,47 @@ public class MateService {
 
         //mateCategoryId로 name 조회
         String mateCategory = String.valueOf(mateCategoryRepository.findCategoryNameById( mate.getMateCategoryId()));
-
-
-        // 사용자 UUID 조회
+        //작성자 UUID 조회
         UserEntity creator = mateMemberRepository.findByMateId(mate.getMateId());
 
-        //사용자 프로필 조회
+        //작성자 프로필 조회
         List<String> profileImage = imageService.getImagesByTypeAndId(ImageType.PROFILE, mate.getUserId());
 
-        return MateDetailResponse.fromEntity(mate, mateImage, mateCategory, creator, profileImage);
+        //현재 접속해 있는 사용자의 user 정보
+        Long userId = userRepository.findIdByUserUuid(userUuid);
+
+
+        //저장했는지 유무 확인
+        SavedMate savedMate = null;
+        if (userId != null) {
+            savedMate = savedMateRepository.findByMate_MateIdAndUserId(mate.getMateId(), userId);
+        }
+        boolean saved = (savedMate != null);
+
+
+        //신청했는지 유무 확인
+        MateMember  applyMember = mateMemberRepository.findByMateIdAndUserId(mate.getMateId(), userId)
+                .orElse(null);
+
+        String applyStatus = "";
+
+        if (applyMember == null) {
+            applyStatus = MateApplyStatus.NONE.name();
+        }else{
+
+
+            if(applyMember.isPending())
+            {
+                applyStatus = MateApplyStatus.PENDING.name();
+            }
+
+            if (applyMember.isApprove()){
+                applyStatus = MateApplyStatus.APPROVED.name();
+            }
+
+        }
+
+        return MateDetailResponse.fromEntity(mate, mateImage, mateCategory, creator, profileImage, saved, applyStatus);
 
     }
 
@@ -146,7 +182,10 @@ public class MateService {
         Mate mate = mateRepository.findByMateUuidAndDeletedAtIsNull(mateUuid)
                 .orElseThrow(() -> new MateNotFoundException("존재하지 않는 디저트메이트입니다."));
 
-        mate.update(request);
+        //장소명으로 storeId 조회
+        Long storeId = storeRepository.findStoreIdByName(request.getPlace().getPlaceName());
+
+        mate.update(request, storeId);
 
 
 
@@ -161,15 +200,13 @@ public class MateService {
      * 디저트메이트 전체 조회
      * */
     @Transactional
-    public MatesPageResponse getMates(Pageable pageable) {
+    public MatesPageResponse getMates(Pageable pageable,UUID userUuid, Long mateCategoryId, String keyword) {
 
 
-
-        // limit + 1 만큼 데이터를 가져와서 다음 데이터가 있는지 확인
-        Page<Mate> mates = mateRepository.findAllByDeletedAtIsNull(pageable);
+        Page<Mate> mates = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, keyword,pageable);
 
 
-        List<MateDetailResponse> matesResponses = mateRepository.findAllByDeletedAtIsNull(pageable)
+        List<MateDetailResponse> matesResponses = mateRepository.findByDeletedAtIsNullAndMateCategoryId( mateCategoryId, keyword, pageable)
                     .stream()
                     .map(mate -> {
                         List<String> mateImages = imageService.getImagesByTypeAndId(ImageType.MATE, mate.getMateId());
@@ -178,7 +215,39 @@ public class MateService {
                         //사용자 프로필 조회
                         List<String> profileImage = imageService.getImagesByTypeAndId(ImageType.PROFILE, mate.getUserId());
 
-                        return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage);
+
+                        //현재 접속해 있는 사용자의 user 정보
+                        Long userId = userRepository.findIdByUserUuid(userUuid);
+
+                        SavedMate savedMate = null;
+                        if (userId != null) {
+                            savedMate = savedMateRepository.findByMate_MateIdAndUserId(mate.getMateId(), userId);
+                        }
+                        boolean saved = (savedMate != null);
+
+                        //신청했는지 유무 확인
+                        MateMember applyMember = mateMemberRepository.findByMateIdAndDeletedAtIsNullAndUserId(mate.getMateId(), userId);
+
+                        String applyStatus = "";
+
+                        if (applyMember == null) {
+                            applyStatus = MateApplyStatus.NONE.name();
+                        }else{
+
+
+                            if(applyMember.isPending())
+                            {
+                                applyStatus = MateApplyStatus.PENDING.name();
+                            }
+
+                            if (applyMember.isApprove()){
+                                applyStatus = MateApplyStatus.APPROVED.name();
+                            }
+
+                        }
+
+                        return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage, saved, applyStatus);
+
                     })
                     .collect(Collectors.toList());
 
@@ -189,6 +258,62 @@ public class MateService {
 
     }
 
+    /**
+     * 내가 참여한 디저트메이트 조회
+     * */
+    public MatesPageResponse getMyMates(Pageable pageable, UUID userUuid) {
+
+        Long userId = userRepository.findIdByUserUuid(userUuid);
 
 
+        Page<Mate> mates = mateRepository.findByDeletedAtIsNullAndUserId(pageable, userId);
+
+
+        List<MateDetailResponse> matesResponses = mateRepository.findByDeletedAtIsNullAndUserId(pageable, userId)
+                .stream()
+                .map(mate -> {
+                    List<String> mateImages = imageService.getImagesByTypeAndId(ImageType.MATE, mate.getMateId());
+                    String mateCategory = mateCategoryRepository.findCategoryNameById(mate.getMateCategoryId());
+                    UserEntity creator = mateMemberRepository.findByMateId(mate.getMateId());
+                    //사용자 프로필 조회
+                    List<String> profileImage = imageService.getImagesByTypeAndId(ImageType.PROFILE, mate.getUserId());
+
+
+                    SavedMate savedMate = null;
+                    if (userId != null) {
+                        savedMate = savedMateRepository.findByMate_MateIdAndUserId(mate.getMateId(), userId);
+                    }
+                    boolean saved = (savedMate != null);
+
+                    //신청했는지 유무 확인
+                    MateMember applyMember = mateMemberRepository.findByMateIdAndDeletedAtIsNullAndUserId(mate.getMateId(), userId);
+
+                    String applyStatus = "";
+
+                    if (applyMember == null) {
+                        applyStatus = MateApplyStatus.NONE.name();
+                    }else{
+
+
+                        if(applyMember.isPending())
+                        {
+                            applyStatus = MateApplyStatus.PENDING.name();
+                        }
+
+                        if (applyMember.isApprove()){
+                            applyStatus = MateApplyStatus.APPROVED.name();
+                        }
+
+                    }
+
+                    return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage, saved, applyStatus);
+
+                })
+                .collect(Collectors.toList());
+
+        // 다음 페이지 존재 여부 확인
+        boolean isLast = mates.isLast();
+
+        return new MatesPageResponse(matesResponses, isLast);
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/mate/service/SavedMateService.java
+++ b/src/main/java/org/swyp/dessertbee/mate/service/SavedMateService.java
@@ -10,6 +10,8 @@ import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.mate.dto.response.MateDetailResponse;
 import org.swyp.dessertbee.mate.dto.response.MatesPageResponse;
 import org.swyp.dessertbee.mate.entity.Mate;
+import org.swyp.dessertbee.mate.entity.MateApplyStatus;
+import org.swyp.dessertbee.mate.entity.MateMember;
 import org.swyp.dessertbee.mate.entity.SavedMate;
 import org.swyp.dessertbee.mate.exception.MateExceptions.*;
 import org.swyp.dessertbee.mate.repository.MateCategoryRepository;
@@ -122,7 +124,31 @@ public class SavedMateService {
                     UserEntity creator = mateMemberRepository.findByMateId(mate.getMateId());
                     List<String> profileImage = imageService.getImagesByTypeAndId(ImageType.PROFILE, mate.getUserId());
 
-                    return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage);
+                    //저장된 디저트메이트 데이터만 지고 오는거니까 true
+                    boolean saved = true;
+
+
+                    //신청했는지 유무 확인
+                    MateMember applyMember = mateMemberRepository.findByMateIdAndDeletedAtIsNullAndUserId(mate.getMateId(), userId);
+
+                    String applyStatus = "";
+
+                    if (applyMember == null) {
+                        applyStatus = MateApplyStatus.NONE.name();
+                    }else{
+
+
+                        if(applyMember.isPending())
+                        {
+                            applyStatus = MateApplyStatus.PENDING.name();
+                        }
+
+                        if (applyMember.isApprove()){
+                            applyStatus = MateApplyStatus.APPROVED.name();
+                        }
+
+                    }
+                    return MateDetailResponse.fromEntity(mate, mateImages, mateCategory, creator, profileImage, saved, applyStatus);
                 })
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## :hash: 연관된 이슈

> 71

## :memo: 작업 내용

> 디저트메이트 필터링, 검색 api 구현(전체 조회 api 수정)
> 디저트메이트 applyStatus 필드 추가
> 디저트메이트 전채 조회 시 saved 필드 추가
> 디저트메이트 신청 취소 api 구현
> 신청 대기,거절 엔드포인트 변경
> 디저트메이트 내가 참여한 디저트메이트 조회 api 구현



## :speech_balloon: 리뷰 요구사항(선택)

> 이번에 변경 된 부분들이 좀 많습니다. 보시다가 이해 안되는 부분들은 편하게 물어봐주세요!
> 디저트메이트 부분만 보시면 될 거 같습니다!
