### PR TITLE
[FEATURE] 토큰 및 http 파싱시 에러 처리

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
@@ -1,6 +1,9 @@
 package org.swyp.dessertbee.auth.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,11 +17,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.swyp.dessertbee.auth.dto.CustomOAuth2User;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.user.dto.UserOAuthDto;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -35,32 +39,51 @@ public class JWTFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     @Override
-    protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
-
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
         try {
             String token = extractTokenFromHeader(request);
 
-            if (token != null && jwtUtil.validateToken(token, true)) {
-                // 토큰이 유효한 경우 인증 처리
-                Authentication authentication = createAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-
-                log.debug("Set Authentication to security context for '{}' token",
-                        maskToken(token));
+            if (token != null) {
+                if (jwtUtil.validateToken(token, true)) {
+                    Authentication authentication = createAuthentication(token);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
 
+            filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
-            // 만료된 토큰 처리는 프론트엔드에서 처리하도록 함
+            log.info("만료된 JWT 토큰: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+            sendAuthenticationError(response, ErrorCode.EXPIRED_VERIFICATION_TOKEN, "만료된 인증 토큰입니다.");
+        } catch (JwtException e) {
+            log.warn("유효하지 않은 JWT 토큰: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+            sendAuthenticationError(response, ErrorCode.INVALID_VERIFICATION_TOKEN, "유효하지 않은 인증 토큰입니다.");
         } catch (Exception e) {
             log.error("JWT 토큰 처리 중 오류 발생", e);
+            SecurityContextHolder.clearContext();
+            sendAuthenticationError(response, ErrorCode.INTERNAL_SERVER_ERROR, "인증 처리 중 오류가 발생했습니다.");
         }
-
-        filterChain.doFilter(request, response);
     }
+
+    private void sendAuthenticationError(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("status", errorCode.getHttpStatus().value());
+        errorResponse.put("code", errorCode.getCode());
+        errorResponse.put("message", message);
+        errorResponse.put("timestamp", LocalDateTime.now().toString());
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+
+
 
     /**
      * Request Header에서 토큰 추출

--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,4 +1,52 @@
 package org.swyp.dessertbee.auth.jwt;
 
-public class JwtAuthenticationEntryPoint {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.common.exception.ErrorResponse;
+
+import java.io.IOException;
+
+/**
+ * JWT 인증 실패 처리를 위한 EntryPoint
+ * 인증이 필요한 리소스에 인증 없이 접근하는 경우 처리
+ */
+@Component
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationEntryPoint() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+        this.objectMapper.configure(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+
+        log.warn("인증 실패: {}", authException.getMessage());
+
+        response.setStatus(ErrorCode.INVALID_CREDENTIALS.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        // ErrorResponse 사용
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(ErrorCode.INVALID_CREDENTIALS.getHttpStatus().value())
+                .code(ErrorCode.INVALID_CREDENTIALS.getCode())
+                .message("인증이 필요합니다.")
+                .timestamp(java.time.LocalDateTime.now())
+                .build();
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,4 @@
+package org.swyp.dessertbee.auth.jwt;
+
+public class JwtAuthenticationEntryPoint {
+}


### PR DESCRIPTION
## :hash: 연관된 이슈
#98 

## :memo: 작업 내용
- 인증이 필요한 곳에 토큰이 없다면 401 에러
- enum 값이 제대로 안들어 온 것 처리 잘못된 값 입력 400 에러

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fcac98aa-a0cb-4422-8960-8b978a434fd5)
![image](https://github.com/user-attachments/assets/c7df18a2-4769-4097-b0f3-214faa913627)

## :speech_balloon: 리뷰 요구사항(선택)
추후에 경로를 구체적으로 제한할 것인데 일단 테스트 용이성을 위해서 인증이 필요없도록 처리할 엔드포인트를 정의해주세요!