### PR TITLE
feat : 로그인 응답에 isPreferenceSet을 반환

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
@@ -24,6 +24,7 @@ public class LoginResponse {
     private String email;           // 사용자 이메일
     private String nickname;        // 사용자 닉네임
     private String profileImageUrl; // 프로필 이미지
+    private boolean isPreferenceSet; // 사용자 선호도 설정 여부
 
     /**
      * 로그인 성공 응답 생성
@@ -32,15 +33,23 @@ public class LoginResponse {
      * @param user 사용자 엔티티
      * @return 로그인 응답 객체
      */
-    public static LoginResponse success(String accessToken, long expiresIn, UserEntity user, String profileImageUrl) {
+    public static LoginResponse success(String accessToken, long expiresIn, UserEntity user, String profileImageUrl, boolean isPreferenceSet) {
         return LoginResponse.builder()
                 .accessToken(accessToken)
-                .tokenType("Bearer") // 토큰 타입 설정 (추가됨)
-                .expiresIn(expiresIn) // 만료 시간 설정 (추가됨)
+                .tokenType("Bearer") // 토큰 타입 설정
+                .expiresIn(expiresIn) // 만료 시간 설정
                 .userUuid(user.getUserUuid())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileImageUrl(profileImageUrl)
+                .isPreferenceSet(isPreferenceSet) // 선호도 설정 여부
                 .build();
+    }
+
+    /**
+     * 회원가입을 위한 오버로딩 메서드
+     */
+    public static LoginResponse success(String accessToken, long expiresIn, UserEntity user, String profileImageUrl) {
+        return success(accessToken, expiresIn, user, profileImageUrl, false);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -22,6 +22,7 @@ import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.common.util.CookieUtil;
 import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
+import org.swyp.dessertbee.preference.service.PreferenceService;
 import org.swyp.dessertbee.role.entity.RoleEntity;
 import org.swyp.dessertbee.role.repository.RoleRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
@@ -41,7 +42,7 @@ public class AuthServiceImpl implements AuthService {
     private final JWTUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
     private final ImageService imageService;
-
+    private final PreferenceService preferenceService;
 
     @Autowired
     private TokenService tokenService;
@@ -182,8 +183,11 @@ public class AuthServiceImpl implements AuthService {
             List<String> profileImages = imageService.getImagesByTypeAndId(ImageType.PROFILE, user.getId());
             String profileImageUrl = profileImages.isEmpty() ? null : profileImages.get(0);
 
-            // 7. 로그인 응답 생성
-            return LoginResponse.success(accessToken, expiresIn, user, profileImageUrl);
+            // 7. 선호도 설정 여부 파악
+            boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
+
+            // 8. 로그인 응답 생성
+            return LoginResponse.success(accessToken, expiresIn, user, profileImageUrl, isPreferenceSet);
 
         } catch (InvalidCredentialsException e) {
             log.warn("로그인 실패 - 이메일: {}, 사유: {}", request.getEmail(), e.getMessage());

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -19,6 +19,7 @@ import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.common.util.CookieUtil;
+import org.swyp.dessertbee.preference.service.PreferenceService;
 import org.swyp.dessertbee.role.entity.RoleEntity;
 import org.swyp.dessertbee.role.entity.RoleType;
 import org.swyp.dessertbee.role.repository.RoleRepository;
@@ -42,6 +43,7 @@ public class KakaoOAuthService {
     private final JWTUtil jwtUtil;
     private final ImageService imageService;
     private final RestTemplate restTemplate = new RestTemplate();
+    private final PreferenceService preferenceService;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
@@ -186,7 +188,8 @@ public class KakaoOAuthService {
                 ImageType.PROFILE, user.getId());
         String profileImageUrl = profileImages.isEmpty() ? null : profileImages.get(0);
 
-        return LoginResponse.success(accessToken, expiresIn, user, profileImageUrl);
+        boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
+        return LoginResponse.success(accessToken, expiresIn, user, profileImageUrl, isPreferenceSet);
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/preference/service/PreferenceService.java
+++ b/src/main/java/org/swyp/dessertbee/preference/service/PreferenceService.java
@@ -45,6 +45,16 @@ public class PreferenceService {
     }
 
     /**
+     * 사용자의 선호도 설정 여부를 확인합니다.
+     * @param user 확인할 사용자 엔티티
+     * @return 선호도 설정 여부 (설정된 경우 true)
+     */
+    public boolean isUserPreferenceSet(UserEntity user) {
+        // 사용자의 선호도 설정이 존재하고 비어있지 않은 경우 true 반환
+        return user.getUserPreferences() != null && !user.getUserPreferences().isEmpty();
+    }
+
+    /**
      * 사용자의 선호도 정보를 업데이트합니다.
      * 기존 선호도를 모두 제거하고 새로운 선호도로 대체합니다.
      */


### PR DESCRIPTION
## :hash: 연관된 이슈
#121 
## :memo: 작업 내용
로그인 응답에 isPreferenceSet을 반환 작업을 했습니다.
일반 로그인, 회원가입
카카오 로그인, 회원가입에 isPreferenceSet을 반환합니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2a45305a-962f-49ba-a559-e61bc92227d1)
