### PR TITLE
refactor: 쿠키로 전달하던 리프레시 토큰을 바디값으로 전달

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -92,14 +92,9 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(
             @Parameter(description = "JWT 액세스 토큰", required = true)
-            @RequestHeader("Authorization") String token,
-            HttpServletResponse response
-    ) {
+            @RequestHeader("Authorization") String token) {
         String accessToken = token.substring(7);
         LogoutResponse logoutResponse = authService.logout(accessToken);
-
-        // 리프레시 토큰 쿠키 삭제
-        CookieUtil.deleteRefreshTokenCookie(response);
 
         return ResponseEntity.ok(logoutResponse);
     }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class LoginResponse {
     private String accessToken;     // JWT 액세스 토큰
+    private String refreshToken;    // JWT 리프레시 토큰
     private String tokenType;       // 토큰 타입
     private long expiresIn;         // 토큰 만료 시간
     private UUID userUuid;          // 사용자 UUID
@@ -33,11 +34,12 @@ public class LoginResponse {
      * @param user 사용자 엔티티
      * @return 로그인 응답 객체
      */
-    public static LoginResponse success(String accessToken, long expiresIn, UserEntity user, String profileImageUrl, boolean isPreferenceSet) {
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl, boolean isPreferenceSet) {
         return LoginResponse.builder()
                 .accessToken(accessToken)
-                .tokenType("Bearer") // 토큰 타입 설정
-                .expiresIn(expiresIn) // 만료 시간 설정
+                .refreshToken(refreshToken)
+                .tokenType("Bearer") // 토큰 타입 설정 (추가됨)
+                .expiresIn(expiresIn) // 만료 시간 설정 (추가됨)
                 .userUuid(user.getUserUuid())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
@@ -49,7 +51,7 @@ public class LoginResponse {
     /**
      * 회원가입을 위한 오버로딩 메서드
      */
-    public static LoginResponse success(String accessToken, long expiresIn, UserEntity user, String profileImageUrl) {
-        return success(accessToken, expiresIn, user, profileImageUrl, false);
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl) {
+        return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, false);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -189,7 +189,7 @@ public class KakaoOAuthService {
         String profileImageUrl = profileImages.isEmpty() ? null : profileImages.get(0);
 
         boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
-        return LoginResponse.success(accessToken, expiresIn, user, profileImageUrl, isPreferenceSet);
+        return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, isPreferenceSet);
     }
 
     /**


### PR DESCRIPTION
## :hash: 연관된 이슈
#124 
## :memo: 작업 내용
쿠키로 전달하던 리프레시 토큰을 바디값으로 전달하였습니다.
- 카카오로그인
- 일반 로그인
- 일반 회원가입
### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/61e02a8a-f6e5-4f4b-a97c-297279f3652e)
![image](https://github.com/user-attachments/assets/8e574891-a3b5-47a1-9c34-2f4794600cdc)