### PR TITLE
[FEATURE] 가게 상세 디저트메이트 saved(저장 유무) 추가

### DIFF
--- a/src/main/java/org/swyp/dessertbee/mate/dto/response/MateResponse.java
+++ b/src/main/java/org/swyp/dessertbee/mate/dto/response/MateResponse.java
@@ -17,4 +17,5 @@ public class MateResponse {
     private String content;
     private String nickname;
     private Boolean recruitYn;
+    private boolean saved;
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -115,8 +115,7 @@ public class StoreController {
             @RequestPart("request") String requestJson,
             @RequestPart(value = "storeImageFiles", required = false) List<MultipartFile> storeImageFiles,
             @RequestPart(value = "ownerPickImageFiles", required = false) List<MultipartFile> ownerPickImageFiles,
-            @RequestPart(value = "menuImageFiles", required = false) List<MultipartFile> menuImageFiles,
-            @AuthenticationPrincipal UserEntity user) {
+            @RequestPart(value = "menuImageFiles", required = false) List<MultipartFile> menuImageFiles) {
         try {
             // StoreUpdateRequest는 StoreCreateRequest와 유사한 구조를 가정합니다.
             StoreUpdateRequest request = objectMapper.readValue(requestJson, StoreUpdateRequest.class);
@@ -127,7 +126,7 @@ public class StoreController {
             menuImageFiles = (menuImageFiles != null) ? menuImageFiles : Collections.emptyList();
 
             StoreDetailResponse updatedStore = storeService.updateStore(storeUuid, request,
-                    storeImageFiles, ownerPickImageFiles, menuImageFiles, user);
+                    storeImageFiles, ownerPickImageFiles, menuImageFiles);
             return ResponseEntity.ok(updatedStore);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -394,16 +394,19 @@ public class StoreService {
                                            StoreUpdateRequest request,
                                            List<MultipartFile> storeImageFiles,
                                            List<MultipartFile> ownerPickImageFiles,
-                                           List<MultipartFile> menuImageFiles,
-                                           UserEntity user) {
+                                           List<MultipartFile> menuImageFiles) {
         // 가게 존재 여부 및 삭제 여부 체크
         Long storeId = storeRepository.findStoreIdByStoreUuid(storeUuid);
         Store store = storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
-        if (!store.getOwnerUuid().equals(user.getUserUuid())) {
+        if (!store.getOwnerUuid().equals(request.getUserUuid())) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
+
+        Long ownerId = userRepository.findIdByUserUuid(request.getUserUuid());
+        UserEntity user = userRepository.findById(ownerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 가게 기본 정보 업데이트
         store.setName(request.getName());

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -11,8 +11,10 @@ import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.mate.dto.response.MateResponse;
 import org.swyp.dessertbee.mate.entity.Mate;
 import org.swyp.dessertbee.mate.entity.MateCategory;
+import org.swyp.dessertbee.mate.entity.SavedMate;
 import org.swyp.dessertbee.mate.repository.MateCategoryRepository;
 import org.swyp.dessertbee.mate.repository.MateRepository;
+import org.swyp.dessertbee.mate.repository.SavedMateRepository;
 import org.swyp.dessertbee.preference.repository.PreferenceRepository;
 import org.swyp.dessertbee.store.menu.dto.request.MenuCreateRequest;
 import org.swyp.dessertbee.store.menu.dto.response.MenuResponse;
@@ -54,6 +56,7 @@ public class StoreService {
     private final ImageService imageService;
     private final MenuService menuService;
     private final UserRepository userRepository;
+    private final SavedMateRepository savedMateRepository;
 
     /** 가게 등록 (이벤트, 쿠폰, 메뉴 + 이미지 포함) */
     public StoreDetailResponse createStore(StoreCreateRequest request,
@@ -359,6 +362,10 @@ public class StoreService {
             List<String> mateThumbnail = imageService.getImagesByTypeAndId(ImageType.MATE, mate.getMateId());
             //int currentMembers = mateMemberRepository.countByMateIdAndApprovalYn(mate.getMateId(), true);
 
+            //저장했는지 유무 확인
+            SavedMate savedMate = savedMateRepository.findByMate_MateIdAndUserId(mate.getMateId(), userId);
+            boolean mateSaved = (savedMate != null);
+
             return MateResponse.builder()
                     .mateUuid(mate.getMateUuid())
                     .mateCategory(mateCategory)
@@ -367,6 +374,7 @@ public class StoreService {
                     .content(mate.getContent())
                     .nickname(mateCreator.getNickname())
                     .recruitYn(mate.getRecruitYn())
+                    .saved(mateSaved)
                     .build();
         }).toList();
 


### PR DESCRIPTION
## :hash: 연관된 이슈

> #129 

## :memo: 작업 내용

> 가게 상세에서 디저트메이트 탭 조회 시 저장 유무를 응답값으로 추가했습니다.
