### PR TITLE
[FEATURE] 카카오 프로필 이미지 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
 
     implementation 'software.amazon.awssdk:s3:2.20.86'
+    implementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -19,14 +19,9 @@ import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
 import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
 import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
-import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.swyp.dessertbee.auth.service.AuthService;
 import jakarta.validation.Valid;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.swyp.dessertbee.common.exception.BusinessException;
-import org.swyp.dessertbee.common.util.CookieUtil;
 
 
 @Tag(name = "Authentication", description = "인증 관련 API")
@@ -37,7 +32,6 @@ import org.swyp.dessertbee.common.util.CookieUtil;
 public class AuthController {
 
     private final AuthService authService;
-    private final JWTUtil jwtUtil;
 
     @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
     @ApiResponses({
@@ -48,9 +42,7 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<LoginResponse> signup(
             @RequestHeader("X-Email-Verification-Token") String verificationToken,
-            @Valid @RequestBody SignUpRequest request,
-            HttpServletResponse response
-
+            @Valid @RequestBody SignUpRequest request
     ) throws BadRequestException {
         log.debug("회원가입 요청: {}", request.getEmail());
 
@@ -60,7 +52,7 @@ public class AuthController {
         }
 
         // 회원가입 처리
-        LoginResponse signupResponse = authService.signup(request, verificationToken, response);
+        LoginResponse signupResponse = authService.signup(request, verificationToken);
         return ResponseEntity.ok(signupResponse);
     }
 
@@ -77,10 +69,9 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(
             @Parameter(description = "로그인 정보", required = true)
-            @Valid @RequestBody LoginRequest request,
-            HttpServletResponse response
+            @Valid @RequestBody LoginRequest request
     ) {
-        LoginResponse loginResponse = authService.login(request, response);
+        LoginResponse loginResponse = authService.login(request);
         return ResponseEntity.ok(loginResponse);
     }
 

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -1,6 +1,5 @@
 package org.swyp.dessertbee.auth.controller;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -26,12 +26,11 @@ public class OAuthController {
      */
     @PostMapping("/callback")
     public ResponseEntity<LoginResponse> oauthCallback(
-            @RequestBody OAuthCodeRequest request,
-            HttpServletResponse response) {
+            @RequestBody OAuthCodeRequest request) {
 
         log.info("OAuth 인가 코드 수신 - 제공자: {}", request.getProvider());
         LoginResponse loginResponse = oAuthService.processOAuthLogin(
-                request.getCode(), request.getProvider(), response);
+                request.getCode(), request.getProvider());
 
         return ResponseEntity.ok(loginResponse);
     }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -1,14 +1,10 @@
 package org.swyp.dessertbee.auth.service;
 
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
 import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
 import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
-import org.swyp.dessertbee.auth.dto.signup.SignUpResponse;
 import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
 import org.swyp.dessertbee.auth.exception.AuthExceptions.*;
 /**
@@ -39,22 +35,20 @@ public interface AuthService {
      * 회원가입 처리
      * @param request 회원가입 요청 정보
      * @param verificationToken 이메일 인증 토큰
-     * @param response HTTP 응답 객체 (쿠키 설정용)
      * @return 회원가입 결과
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
      * @throws DuplicateEmailException 이메일 중복
      */
-    LoginResponse signup(SignUpRequest request, String verificationToken, HttpServletResponse response);
+    LoginResponse signup(SignUpRequest request, String verificationToken);
 
 
     /**
      * 로그인 처리
      * @param request 로그인 요청 정보
-     * @param response HTTP 응답 객체 (쿠키 설정용)
      * @return 로그인 응답 정보
      * @throws InvalidCredentialsException 잘못된 인증 정보
      */
-    LoginResponse login(LoginRequest request, HttpServletResponse response);
+    LoginResponse login(LoginRequest request);
 
     /**
      * 비밀번호 재설정

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -1,6 +1,5 @@
 package org.swyp.dessertbee.auth.service;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,7 +65,7 @@ public class AuthServiceImpl implements AuthService {
      */
     @Override
     @Transactional
-    public LoginResponse signup(SignUpRequest request, String verificationToken, HttpServletResponse response) {
+    public LoginResponse signup(SignUpRequest request, String verificationToken) {
         try {
             // 메일 인증 토큰 검증
             validateEmailVerificationToken(verificationToken, request.getEmail(), EmailVerificationPurpose.SIGNUP);
@@ -138,7 +137,7 @@ public class AuthServiceImpl implements AuthService {
      */
     @Override
     @Transactional
-    public LoginResponse login(LoginRequest request, HttpServletResponse response) {
+    public LoginResponse login(LoginRequest request) {
         try {
             // 1. 사용자 조회
             UserEntity user = userRepository.findByEmail(request.getEmail())

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -1,6 +1,5 @@
 package org.swyp.dessertbee.auth.service;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.KakaoResponse;
 import org.swyp.dessertbee.auth.dto.OAuth2Response;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
@@ -19,7 +17,6 @@ import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.service.ImageService;
-import org.swyp.dessertbee.common.util.CookieUtil;
 import org.swyp.dessertbee.preference.service.PreferenceService;
 import org.swyp.dessertbee.role.entity.RoleEntity;
 import org.swyp.dessertbee.role.entity.RoleType;

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -26,16 +26,15 @@ public class OAuthService {
      *
      * @param code 인가 코드
      * @param provider OAuth 제공자 (kakao, naver, google 등)
-     * @param response HTTP 응답
      * @return 로그인 응답 (JWT 토큰 포함)
      */
     @Transactional
-    public LoginResponse processOAuthLogin(String code, String provider, HttpServletResponse response) {
+    public LoginResponse processOAuthLogin(String code, String provider) {
         try {
             // 제공자에 따라 적절한 서비스 호출
             switch (provider.toLowerCase()) {
                 case "kakao":
-                    return kakaoOAuthService.processKakaoLogin(code, response);
+                    return kakaoOAuthService.processKakaoLogin(code);
                 // 추후 다른 OAuth 제공자 추가
                 default:
                     throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE,

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -1,6 +1,5 @@
 package org.swyp.dessertbee.auth.service;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
## :hash: 연관된 이슈
#127 
## :memo: 작업 내용
- 첫 카카오 회원가입 시 만약 카카오 프로필 이미지가 전달되었다면 
  - 카카오 프로필 이미지 등록
  - 이미 동일한 이메일로 카카오 가입 시에는 유효하지 않게 처리
- 외부 url을 통한 s3 등록 함수 구현 

### 스크린샷 (선택)
<img width="755" alt="image" src="https://github.com/user-attachments/assets/915da7bd-3655-4169-9225-ecdd392c332c" />
<img width="1069" alt="image" src="https://github.com/user-attachments/assets/c68d467a-69e8-4353-933f-a65524940477" />

이미지 등록이 되는 것을 확인