### PR TITLE
[FIX] 가게 api @PreAuthorize 적용

### DIFF
--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -28,6 +29,7 @@ import java.util.Collections;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final JWTUtil jwtUtil;

--- a/src/main/java/org/swyp/dessertbee/store/menu/controller/MenuController.java
+++ b/src/main/java/org/swyp/dessertbee/store/menu/controller/MenuController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.store.menu.dto.request.MenuCreateRequest;
@@ -45,6 +46,7 @@ public class MenuController {
 
     /** 메뉴 등록 (파일 업로드 포함) */
     @Operation(summary = "메뉴 등록", description = "가게에 메뉴를 등록합니다.")
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_OWNER', 'ROLE_ADMIN')")
     @PostMapping
     public ResponseEntity<Void> addMenus(
             @PathVariable UUID storeUuid,
@@ -82,6 +84,7 @@ public class MenuController {
 
     /** 메뉴 수정 (파일 업로드 포함) */
     @Operation(summary = "메뉴 수정", description = "가게의 메뉴를 수정합니다.")
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_OWNER', 'ROLE_ADMIN')")
     @PatchMapping("/{menuUuid}")
     public ResponseEntity<Void> updateMenu(
             @PathVariable UUID storeUuid,
@@ -104,6 +107,7 @@ public class MenuController {
 
     /** 메뉴 삭제 */
     @Operation(summary = "메뉴 삭제", description = "가게의 메뉴를 삭제합니다.")
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_OWNER', 'ROLE_ADMIN')")
     @DeleteMapping("/{menuUuid}")
     public ResponseEntity<Void> deleteMenu(@PathVariable UUID storeUuid, @PathVariable UUID menuUuid) {
         menuService.deleteMenu(storeUuid, menuUuid);

--- a/src/main/java/org/swyp/dessertbee/store/review/controller/StoreReviewController.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/controller/StoreReviewController.java
@@ -1,17 +1,13 @@
 package org.swyp.dessertbee.store.review.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.store.review.dto.request.StoreReviewCreateRequest;
 import org.swyp.dessertbee.store.review.dto.request.StoreReviewUpdateRequest;
 import org.swyp.dessertbee.store.review.dto.response.StoreReviewResponse;
@@ -31,6 +27,7 @@ public class StoreReviewController {
 
     /** 리뷰 등록 */
     @Operation(summary = "한줄 리뷰 등록", description = "한줄 리뷰를 등록합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PostMapping
     public ResponseEntity<StoreReviewResponse> createReview(
             @PathVariable UUID storeUuid,
@@ -52,6 +49,7 @@ public class StoreReviewController {
 
     /** 리뷰 수정 */
     @Operation(summary = "한줄 리뷰 수정", description = "한줄 리뷰를 수장합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PatchMapping("/{reviewUuid}")
     public ResponseEntity<StoreReviewResponse> updateReview(
             @PathVariable UUID storeUuid,
@@ -66,6 +64,7 @@ public class StoreReviewController {
 
     /** 리뷰 삭제 */
     @Operation(summary = "한줄 리뷰 삭제", description = "한줄 리뷰를 삭제합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @DeleteMapping("/{reviewUuid}")
     public ResponseEntity<Void> deleteReview(@PathVariable UUID storeUuid, @PathVariable UUID reviewUuid) {
         storeReviewService.deleteReview(storeUuid, reviewUuid);

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -3,7 +3,6 @@ package org.swyp.dessertbee.store.store.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -12,7 +11,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.swyp.dessertbee.preference.entity.UserPreferenceEntity;
 import org.swyp.dessertbee.store.store.dto.request.StoreCreateRequest;
 import org.swyp.dessertbee.store.store.dto.request.StoreUpdateRequest;
 import org.swyp.dessertbee.store.store.dto.response.StoreDetailResponse;
@@ -34,7 +32,7 @@ public class StoreController {
 
     /** 가게 등록 */
     @Operation(summary = "가게 등록", description = "업주가 가게를 등록합니다.")
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_OWNER')")
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_OWNER', 'ROLE_ADMIN')")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<StoreDetailResponse> createStore(
             @RequestPart("request") String requestJson,
@@ -108,7 +106,7 @@ public class StoreController {
 
     /** 가게 수정 */
     @Operation(summary = "가게 수정", description = "업주가 가게의 정보를 수정합니다.")
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_OWNER')")
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_OWNER', 'ROLE_ADMIN')")
     @PatchMapping(value = "/{storeUuid}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<StoreDetailResponse> updateStore(
             @PathVariable UUID storeUuid,
@@ -136,7 +134,7 @@ public class StoreController {
 
     /** 가게 삭제 */
     @Operation(summary = "가게 삭제", description = "업주가 가게를 삭제합니다.")
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_OWNER')")
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_OWNER', 'ROLE_ADMIN')")
     @DeleteMapping("/{storeUuid}")
     public ResponseEntity<Void> deleteStore(@PathVariable UUID storeUuid,
                                             @AuthenticationPrincipal UserEntity user) {

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.store.store.dto.response.SavedStoreResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListResponse;
@@ -25,6 +26,7 @@ public class UserStoreController {
 
     /** 저장 리스트 전체 조회 */
     @Operation(summary = "저장 리스트 전체 조회", description = "유저의 모든 가게저장 리스트를 조회합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @GetMapping("/{userUuid}/lists")
     public ResponseEntity<List<UserStoreListResponse>> getUserStoreLists(@PathVariable UUID userUuid) {
         return ResponseEntity.ok(userStoreService.getUserStoreLists(userUuid));
@@ -32,6 +34,7 @@ public class UserStoreController {
 
     /** 저장 리스트 생성 */
     @Operation(summary = "저장 리스트 생성", description = "유저의 가게 저장 리스트를 생성합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PostMapping("/{userUuid}/lists")
     public ResponseEntity<UserStoreListResponse> createUserStoreList(@PathVariable UUID userUuid,
                                                              @RequestParam String listName,
@@ -41,6 +44,7 @@ public class UserStoreController {
 
     /** listId로 특정 리스트 정보 조회 */
     @Operation(summary = "저장 리스트 정보 조회", description = "저장 리스트 정보를 조회합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @GetMapping("/lists/{listId}")
     public ResponseEntity<UserStoreListSimpleResponse> getUserStoreList(@PathVariable Long listId) {
         return ResponseEntity.ok(userStoreService.getUserStoreList(listId));
@@ -48,6 +52,7 @@ public class UserStoreController {
 
     /** 저장 리스트 수정 */
     @Operation(summary = "저장 리스트 수정", description = "저장 리스트 정보를 수정합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PatchMapping("/lists/{listId}")
     public ResponseEntity<UserStoreListResponse> updateUserStoreList(@PathVariable Long listId,
                                                              @RequestParam String newName,
@@ -57,6 +62,7 @@ public class UserStoreController {
 
     /** 저장 리스트 삭제 */
     @Operation(summary = "저장 리스트 삭제", description = "저장 리스트를 삭제합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @DeleteMapping("/lists/{listId}")
     public ResponseEntity<Void> deleteUserStoreList(@PathVariable Long listId) {
         userStoreService.deleteUserStoreList(listId);
@@ -65,6 +71,7 @@ public class UserStoreController {
 
     /** 리스트에 가게 추가 */
     @Operation(summary = "리스트에 가게 저장", description = "해당 리스트에 가게를 저장합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PostMapping("/lists/{listId}/stores/{storeUuid}")
     public ResponseEntity<SavedStoreResponse> addStoreToList(@PathVariable Long listId, @PathVariable UUID storeUuid, @RequestBody List<String> userPreferences) {
         return ResponseEntity.ok(userStoreService.addStoreToList(listId, storeUuid, userPreferences));
@@ -72,6 +79,7 @@ public class UserStoreController {
 
     /** 리스트별 저장된 가게 조회 */
     @Operation(summary = "리스트에 저장된 가게 조회", description = "해당 리스트에 저장된 가게를 조회합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @GetMapping("/lists/{listId}/stores")
     public ResponseEntity<UserStoreListResponse> getStoresByList(@PathVariable Long listId) {
         return ResponseEntity.ok(userStoreService.getStoresByList(listId));
@@ -79,6 +87,7 @@ public class UserStoreController {
 
     /** 리스트에서 가게 삭제 */
     @Operation(summary = "리스트에 저장된 가게 삭제", description = "해당 리스트에 저장된 가게를 삭제합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @DeleteMapping("/lists/{listId}/stores/{storeUuid}")
     public ResponseEntity<Void> removeStoreFromList(@PathVariable Long listId, @PathVariable UUID storeUuid) {
         userStoreService.removeStoreFromList(listId, storeUuid);


### PR DESCRIPTION
## :hash: 연관된 이슈

> #139 

## :memo: 작업 내용

> 가게, 메뉴, 한줄리뷰 등록/수정/삭제 api에 @PreAuthorize 어노테이션을 적용해 역할 권한을 검증합니다.

### 스크린샷 

<img width="1289" alt="image" src="https://github.com/user-attachments/assets/89427818-b95c-4369-be13-c534b1800a80" />
권한이 없는 사용자로 메서드 실행 시 Access Denied 오류
