### PR TITLE
[FIX] 가게 상세조회 시 저장여부 null값 오류 수정 

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/store/entity/UserStoreList.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/entity/UserStoreList.java
@@ -22,7 +22,7 @@ public class UserStoreList {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
     private UserEntity user;
 
     @Column(name = "list_name", nullable = false, length = 50)

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
@@ -41,7 +41,10 @@ public interface SavedStoreRepository extends JpaRepository<SavedStore, Long> {
 """, nativeQuery = true)
     List<Object[]> findTop3PreferencesByStoreId(@Param("storeId") Long storeId);
 
-
     /** 특정 가게를 저장한 사용자가 있다면 해당 SavedStore 엔티티 반환 */
-    Optional<SavedStore> findFirstByStoreAndUserStoreList_User_Id(Store store, Long userId);
+    @Query("SELECT s FROM SavedStore s " +
+            "JOIN s.userStoreList usl " +
+            "JOIN usl.user u " +
+            "WHERE s.store = :store AND u.id = :userId")
+    Optional<SavedStore> findFirstByStoreAndUserId(@Param("store") Store storeId, @Param("userId") Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -2,6 +2,7 @@ package org.swyp.dessertbee.store.store.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.common.entity.ImageType;
@@ -39,6 +40,7 @@ import java.util.*;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -288,13 +290,15 @@ public class StoreService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
         UserEntity user = userService.getCurrentUser();
-        Long userId = Optional.ofNullable(user).map(UserEntity::getId).orElse(null);
-        UUID userUuid = Optional.ofNullable(user).map(UserEntity::getUserUuid).orElse(null);
+        Long userId = user.getId();
+        UUID userUuid = user.getUserUuid();
 
-        Optional<SavedStore> savedStoreOpt = Optional.ofNullable(user)
-                .flatMap(u -> savedStoreRepository.findFirstByStoreAndUserStoreList_User_Id(store, u.getId()));
+        Optional<SavedStore> savedStoreOpt = savedStoreRepository.findFirstByStoreAndUserId(store, userId);
+
         boolean saved = savedStoreOpt.isPresent();
         Long savedListId = savedStoreOpt.map(s -> s.getUserStoreList().getId()).orElse(null);
+
+        log.info("사용자가 가게를 저장했는지 여부: {}, savedListId: {}", saved, savedListId);
 
         // 가게 대표 이미지
         List<String> storeImages = imageService.getImagesByTypeAndId(ImageType.STORE, storeId);


### PR DESCRIPTION
## :hash: 연관된 이슈

> #166 

## :memo: 작업 내용

> 가게 상세조회 시 saved:false,  savedStoreId:null, useruuid:null 로 받아와지는 오류 수정
> UserStoreList에서 user_id가 UserEntity의 id컬럼을 명확히 참조하도록 함
> findFirstByStoreAndUserId()에서 테이블 조인을 통해 정확하게 가게 저장 여부 검색
> 서비스 코드 수정