### PR TITLE
[FIX]  getCurrentUser() 메서드 버그 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/dto/userdetails/CustomUserDetails.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/userdetails/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package org.swyp.dessertbee.auth.dto.userdetails;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Spring Security의 인증 객체를 표현하는 클래스
+ * DB에서 조회한 사용자 정보를 기반으로 UserDetails를 구현
+ */
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final String email;
+    private final List<GrantedAuthority> authorities;
+
+    public CustomUserDetails(String email, List<String> roleNames) {
+        this.email = email;
+        this.authorities = roleNames.stream()
+                .map(role -> (GrantedAuthority) () -> role) // SimpleGrantedAuthority 대체
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // JWT 기반 인증이므로 비밀번호 불필요
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,37 @@
+package org.swyp.dessertbee.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.swyp.dessertbee.auth.dto.userdetails.CustomUserDetails;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserRepository;
+
+import java.util.List;
+
+/**
+ * Spring Security의 사용자 조회를 담당하는 서비스
+ * JWT 필터에서 인증할 때 DB 조회가 필요한 경우 사용
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        List<String> roles = user.getUserRoles().stream()
+                .map(userRole -> userRole.getRole().getRoleName())
+                .toList();
+
+        return new CustomUserDetails(user.getEmail(), roles);
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -19,6 +19,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.swyp.dessertbee.auth.jwt.JWTFilter;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.swyp.dessertbee.user.repository.UserRepository;
+
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -33,13 +35,14 @@ import java.util.Collections;
 public class SecurityConfig {
 
     private final JWTUtil jwtUtil;
+    private final UserRepository userRepository;
 
 //    @Value("${spring.graphql.cors.allowed-origins}")
 //    private String corsAllowedOrigins;
 
     @Bean
     public JWTFilter jwtFilter() {
-        return new JWTFilter(jwtUtil);
+        return new JWTFilter(jwtUtil, userRepository);
     }
 
     @Bean

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -19,6 +20,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.swyp.dessertbee.auth.jwt.JWTFilter;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.swyp.dessertbee.auth.service.CustomUserDetailsService;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
 import java.util.Arrays;
@@ -35,14 +37,18 @@ import java.util.Collections;
 public class SecurityConfig {
 
     private final JWTUtil jwtUtil;
-    private final UserRepository userRepository;
 
 //    @Value("${spring.graphql.cors.allowed-origins}")
 //    private String corsAllowedOrigins;
 
     @Bean
     public JWTFilter jwtFilter() {
-        return new JWTFilter(jwtUtil, userRepository);
+        return new JWTFilter(jwtUtil);
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserRepository userRepository) {
+        return new CustomUserDetailsService(userRepository);
     }
 
     @Bean

--- a/src/main/java/org/swyp/dessertbee/role/entity/RoleEntity.java
+++ b/src/main/java/org/swyp/dessertbee/role/entity/RoleEntity.java
@@ -22,4 +22,7 @@ public class RoleEntity {
     @Column(nullable = false, unique = true, length = 50)
     private RoleType name;
 
+    public String getRoleName() {
+        return name.getRoleName();
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
@@ -43,10 +43,6 @@ public class UserServiceImpl implements UserService {
 
 
 
-
-    /**
-     * Security Context에서 현재 인증된 사용자의 정보를 조회합니다.
-     */
     /**
      * Security Context에서 현재 인증된 사용자의 정보를 조회합니다.
      * 비로그인 상태인 경우 null 반환
@@ -57,9 +53,14 @@ public class UserServiceImpl implements UserService {
                 authentication instanceof AnonymousAuthenticationToken) {
             return null;
         }
-        String email = authentication.getName();
-        // 사용자 없으면 예외 대신 null 반환
-        return userRepository.findByEmail(email).orElse(null);
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserEntity) {
+            return (UserEntity) principal;
+        } else {
+            log.warn("기대한 UserEntity 값과 일치하지 않음: {}", principal.getClass().getName());
+            return null;
+        }
     }
 
 

--- a/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
@@ -51,16 +51,14 @@ public class UserServiceImpl implements UserService {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated() ||
                 authentication instanceof AnonymousAuthenticationToken) {
+            log.warn("SecurityContext에 인증 정보가 없습니다.");
             return null;
         }
+        log.debug("현재 인증된 사용자: {}", authentication.getName());
 
-        Object principal = authentication.getPrincipal();
-        if (principal instanceof UserEntity) {
-            return (UserEntity) principal;
-        } else {
-            log.warn("기대한 UserEntity 값과 일치하지 않음: {}", principal.getClass().getName());
-            return null;
-        }
+        String email = authentication.getName();
+
+        return userRepository.findByEmail(email).orElse(null);
     }
 
 


### PR DESCRIPTION
## :hash: 연관된 이슈

> #168 

## :memo: 작업 내용

> email을 Principal로 넣지 않고, DB에서 UserEntity를 조회하여 Principal로 설정
> UserEntity를 UsernamePasswordAuthenticationToken에 설정하여, 이후 SecurityContextHolder에서 UserEntity를 직접 가져올 수 있도록 함
> authentication.getPrincipal()이 UserEntity인지 확인 후 반환
