### PR TITLE
[FIX] encode되서 넘어오는 한글 검색 가능하도록 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/community/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/controller/MateController.java
@@ -22,6 +22,7 @@ import org.swyp.dessertbee.user.service.UserServiceImpl;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -112,7 +113,7 @@ public class MateController {
             @RequestParam(required = false, defaultValue = "10") int to,
             @RequestParam(required = false, defaultValue = "") String keyword,
             @RequestParam(required = false) Long mateCategoryId
-    ) throws UnsupportedEncodingException {
+    ) {
 
         if (from >= to) {
             throw new FromToMateException("잘못된 범위 요청입니다.");
@@ -122,7 +123,9 @@ public class MateController {
         int page = from / size;
         Pageable pageable = PageRequest.of(page, size);
 
-        keyword = URLDecoder.decode(keyword,"UTF-8");
+        if(keyword != null) {
+            keyword = URLDecoder.decode(keyword, StandardCharsets.UTF_8);
+        }
         return ResponseEntity.ok(mateService.getMates(pageable, keyword, mateCategoryId));
     }
 

--- a/src/main/java/org/swyp/dessertbee/community/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/controller/MateController.java
@@ -20,6 +20,8 @@ import org.swyp.dessertbee.community.mate.exception.MateExceptions.*;
 import org.swyp.dessertbee.community.mate.service.MateService;
 import org.swyp.dessertbee.user.service.UserServiceImpl;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -110,7 +112,7 @@ public class MateController {
             @RequestParam(required = false, defaultValue = "10") int to,
             @RequestParam(required = false, defaultValue = "") String keyword,
             @RequestParam(required = false) Long mateCategoryId
-    ) {
+    ) throws UnsupportedEncodingException {
 
         if (from >= to) {
             throw new FromToMateException("잘못된 범위 요청입니다.");
@@ -119,6 +121,8 @@ public class MateController {
         int size = to - from;
         int page = from / size;
         Pageable pageable = PageRequest.of(page, size);
+
+        keyword = URLDecoder.decode(keyword,"UTF-8");
         return ResponseEntity.ok(mateService.getMates(pageable, keyword, mateCategoryId));
     }
 
@@ -137,7 +141,6 @@ public class MateController {
         int size = to - from;
         int page = from / size;
         Pageable pageable = PageRequest.of(page, size);
-
 
         return ResponseEntity.ok(mateService.getMyMates(pageable));
     }

--- a/src/main/java/org/swyp/dessertbee/community/review/controller/ReviewController.java
+++ b/src/main/java/org/swyp/dessertbee/community/review/controller/ReviewController.java
@@ -23,6 +23,7 @@ import org.swyp.dessertbee.community.review.service.ReviewService;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,13 +75,15 @@ public class ReviewController {
             @RequestParam(required = false, defaultValue = "10") int to,
             @RequestParam(required = false, defaultValue = "") String keyword,
             @RequestParam(required = false) Long reviewCategoryId
-    ) throws UnsupportedEncodingException {
+    ) {
 
         if (from >= to) {
             throw new MateExceptions.FromToMateException("잘못된 범위 요청입니다.");
         }
 
-        keyword = URLDecoder.decode(keyword,"UTF-8");
+        if(keyword != null) {
+            keyword = URLDecoder.decode(keyword, StandardCharsets.UTF_8);
+        }
         int size = to - from;
         int page = from / size;
         Pageable pageable = PageRequest.of(page, size);

--- a/src/main/java/org/swyp/dessertbee/community/review/controller/ReviewController.java
+++ b/src/main/java/org/swyp/dessertbee/community/review/controller/ReviewController.java
@@ -21,6 +21,8 @@ import org.swyp.dessertbee.community.review.dto.response.ReviewPageResponse;
 import org.swyp.dessertbee.community.review.dto.response.ReviewResponse;
 import org.swyp.dessertbee.community.review.service.ReviewService;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,12 +74,13 @@ public class ReviewController {
             @RequestParam(required = false, defaultValue = "10") int to,
             @RequestParam(required = false, defaultValue = "") String keyword,
             @RequestParam(required = false) Long reviewCategoryId
-    ){
+    ) throws UnsupportedEncodingException {
 
         if (from >= to) {
             throw new MateExceptions.FromToMateException("잘못된 범위 요청입니다.");
         }
 
+        keyword = URLDecoder.decode(keyword,"UTF-8");
         int size = to - from;
         int page = from / size;
         Pageable pageable = PageRequest.of(page, size);


### PR DESCRIPTION
## :hash: 연관된 이슈

> 175

## :memo: 작업 내용

> keyword=%ED%99%8D%EB%8C%80 이런 형식으로 넘어오던 한글 decode해서 검색 되도록 수정

