### PR TITLE
[FEATURE] userUuid를 토큰 payload에 삽입

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/dto/userdetails/CustomUserDetails.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/userdetails/CustomUserDetails.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -16,9 +17,11 @@ public class CustomUserDetails implements UserDetails {
 
     private final String email;
     private final List<GrantedAuthority> authorities;
+    private final UUID userUuid;
 
-    public CustomUserDetails(String email, List<String> roleNames) {
+    public CustomUserDetails(String email, List<String> roleNames, UUID userUuid) {
         this.email = email;
+        this.userUuid = userUuid;
         this.authorities = roleNames.stream()
                 .map(role -> (GrantedAuthority) () -> role) // SimpleGrantedAuthority 대체
                 .collect(Collectors.toList());

--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
@@ -9,21 +9,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.swyp.dessertbee.auth.dto.userdetails.CustomUserDetails;
-import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.exception.ErrorResponse;
-import org.swyp.dessertbee.role.entity.RoleType;
-import org.swyp.dessertbee.user.entity.UserEntity;
-import org.swyp.dessertbee.user.repository.UserRepository;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.UUID;
 /**
  * JWT 토큰을 검증하고 인증을 처리하는 필터
  * Spring Security Filter Chain에서 사용됨
@@ -88,9 +83,10 @@ public class JWTFilter extends OncePerRequestFilter {
         String email = jwtUtil.getEmail(token, true);
         log.debug("JWT에서 추출된 이메일: {}", email);
         List<String> roleNames = jwtUtil.getRoles(token, true);
+        UUID userUuid = UUID.fromString(jwtUtil.getUserUuid(token, true));
 
         // DB 조회 없이 CustomUserDetails 객체를 생성
-        CustomUserDetails userDetails = new CustomUserDetails(email, roleNames);
+        CustomUserDetails userDetails = new CustomUserDetails(email, roleNames, userUuid);
 
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -112,8 +112,8 @@ public class AuthServiceImpl implements AuthService {
             userRepository.save(user);
 
             // Access Token, Refresh Token 생성
-            String accessToken = jwtUtil.createAccessToken(user.getEmail(), roles, false);
-            String refreshToken = jwtUtil.createRefreshToken(user.getEmail(), roles, false);
+            String accessToken = jwtUtil.createAccessToken(user.getEmail(), user.getUserUuid(), roles, false);
+            String refreshToken = jwtUtil.createRefreshToken(user.getEmail(), user.getUserUuid(), roles, false);
             long expiresIn = jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
 
 
@@ -162,8 +162,8 @@ public class AuthServiceImpl implements AuthService {
 
             // 4. Access Token, Refresh Token 생성
             boolean keepLoggedIn = request.isKeepLoggedIn();
-            String accessToken = jwtUtil.createAccessToken(user.getEmail(), roles, keepLoggedIn);
-            String refreshToken = jwtUtil.createRefreshToken(user.getEmail(), roles, keepLoggedIn);
+            String accessToken = jwtUtil.createAccessToken(user.getEmail(), user.getUserUuid(), roles, keepLoggedIn);
+            String refreshToken = jwtUtil.createRefreshToken(user.getEmail(), user.getUserUuid(), roles, keepLoggedIn);
             long expiresIn = keepLoggedIn ?
                     jwtUtil.getLONG_ACCESS_TOKEN_EXPIRE() :
                     jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
@@ -214,8 +214,8 @@ public class AuthServiceImpl implements AuthService {
             }
 
             // 4. 개발용 짧은 유효기간의 Access Token, Refresh Token 생성 (3~5분)
-            String accessToken = jwtUtil.createDevAccessToken(user.getEmail(), roles);
-            String refreshToken = jwtUtil.createDevRefreshToken(user.getEmail(), roles);
+            String accessToken = jwtUtil.createDevAccessToken(user.getEmail(), user.getUserUuid(), roles);
+            String refreshToken = jwtUtil.createDevRefreshToken(user.getEmail(), user.getUserUuid(), roles);
 
             // 개발 환경용 토큰 만료 시간 (3분 = 180초)
             long expiresIn = 180;

--- a/src/main/java/org/swyp/dessertbee/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/CustomUserDetailsService.java
@@ -32,6 +32,6 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .map(userRole -> userRole.getRole().getRoleName())
                 .toList();
 
-        return new CustomUserDetails(user.getEmail(), roles);
+        return new CustomUserDetails(user.getEmail(), roles, user.getUserUuid());
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -164,8 +164,8 @@ public class KakaoOAuthService {
 
         // 토큰 발급
         boolean keepLoggedIn = false; // 기본값
-        String accessToken = jwtUtil.createAccessToken(user.getEmail(), roles, keepLoggedIn);
-        String refreshToken = jwtUtil.createRefreshToken(user.getEmail(), roles, keepLoggedIn);
+        String accessToken = jwtUtil.createAccessToken(user.getEmail(), user.getUserUuid(), roles, keepLoggedIn);
+        String refreshToken = jwtUtil.createRefreshToken(user.getEmail(), user.getUserUuid(), roles, keepLoggedIn);
         long expiresIn = jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
 
         // 리프레시 토큰 저장

--- a/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
@@ -161,7 +161,7 @@ public class TokenService {
                     .collect(Collectors.toList());
 
             boolean keepLoggedIn = false; // 로그인 유지 여부 (프론트엔드에서 전달받을 수도 있음)
-            String newAccessToken = jwtUtil.createAccessToken(email, roles, keepLoggedIn);
+            String newAccessToken = jwtUtil.createAccessToken(email, user.getUserUuid(), roles, keepLoggedIn);
 
             log.info("리프레시 토큰 검증 성공 - 새로운 액세스 토큰 발급 완료: {}", email);
 


### PR DESCRIPTION
## :hash: 연관된 이슈
#179 
## :memo: 작업 내용
- 토큰 페이로드 구성 메서드를 캡슐화 적용
- 토큰 페이로드에 userUuid 삽입
- 관련 서비스 메서드에도 동일하게 적용

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/677c5e2b-da64-40ab-a7cb-2c1ccacde4ee)
![image](https://github.com/user-attachments/assets/cd20a645-7d13-41e4-9ead-fbf507569157)
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/91ed0bca-a641-41ad-8103-1dc94895598a" />

## :speech_balloon: 리뷰 요구사항(선택)
- 변경이 힘들어지네요. 뭔가 코드 구조를 객체지향적으로 바꾸어야...ㅠ