### PR TITLE
[REFACTOR & FEATURE] 리프레시 토큰 경로 수정 및 JWT 토큰 정보 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/dto/userdetails/CustomUserDetails.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/userdetails/CustomUserDetails.java
@@ -15,12 +15,10 @@ import java.util.stream.Collectors;
 @Getter
 public class CustomUserDetails implements UserDetails {
 
-    private final String email;
     private final List<GrantedAuthority> authorities;
     private final UUID userUuid;
 
-    public CustomUserDetails(String email, List<String> roleNames, UUID userUuid) {
-        this.email = email;
+    public CustomUserDetails(List<String> roleNames, UUID userUuid) {
         this.userUuid = userUuid;
         this.authorities = roleNames.stream()
                 .map(role -> (GrantedAuthority) () -> role) // SimpleGrantedAuthority 대체
@@ -39,7 +37,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return email;
+        return String.valueOf(userUuid);
     }
 
     @Override

--- a/src/main/java/org/swyp/dessertbee/auth/enums/TokenType.java
+++ b/src/main/java/org/swyp/dessertbee/auth/enums/TokenType.java
@@ -1,0 +1,4 @@
+package org.swyp.dessertbee.auth.enums;
+
+public enum TokenType {
+}

--- a/src/main/java/org/swyp/dessertbee/auth/enums/TokenType.java
+++ b/src/main/java/org/swyp/dessertbee/auth/enums/TokenType.java
@@ -1,4 +1,5 @@
 package org.swyp.dessertbee.auth.enums;
 
 public enum TokenType {
+    ACCESS, REFRESH, EMAIL_VERIFICATION
 }

--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JWTFilter.java
@@ -80,15 +80,13 @@ public class JWTFilter extends OncePerRequestFilter {
      * JWT 토큰으로부터 인증 객체 생성
      */
     private Authentication createAuthentication(String token) {
-        String email = jwtUtil.getEmail(token, true);
-        log.debug("JWT에서 추출된 이메일: {}", email);
         List<String> roleNames = jwtUtil.getRoles(token, true);
-        UUID userUuid = UUID.fromString(jwtUtil.getUserUuid(token, true));
+        UUID userUuid = jwtUtil.getUserUuid(token, true);
 
         // DB 조회 없이 CustomUserDetails 객체를 생성
-        CustomUserDetails userDetails = new CustomUserDetails(email, roleNames, userUuid);
+        CustomUserDetails userDetails = new CustomUserDetails(roleNames, userUuid);
 
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        return new UsernamePasswordAuthenticationToken(userUuid, null, userDetails.getAuthorities());
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -7,16 +7,19 @@ import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
 import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
 import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
 import org.swyp.dessertbee.auth.exception.AuthExceptions.*;
+
+import java.util.UUID;
+
 /**
  * 인증 관련 서비스 인터페이스
  */
 public interface AuthService {
     /**
      * 리프레시 토큰을 저장하거나 업데이트
-     * @param email 사용자 이메일
+     * @param userUuid 사용자 uuid
      * @param refreshToken 리프레시 토큰
      */
-    void saveRefreshToken(String email, String refreshToken);
+    void saveRefreshToken(UUID userUuid, String refreshToken);
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰 발급
@@ -27,9 +30,9 @@ public interface AuthService {
 
     /**
      * 리프레시 토큰 무효화 (로그아웃)
-     * @param email 사용자 이메일
+     * @param userUuid 사용자 uuid
      */
-    void revokeRefreshToken(String email);
+    void revokeRefreshToken(UUID userUuid);
 
     /**
      * 회원가입 처리

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -35,7 +35,6 @@ import java.util.List;
 public class AuthServiceImpl implements AuthService {
 
     private final UserRepository userRepository;
-    private final RoleRepository roleRepository;
     private final JWTUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
     private final ImageService imageService;

--- a/src/main/java/org/swyp/dessertbee/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/CustomUserDetailsService.java
@@ -32,6 +32,6 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .map(userRole -> userRole.getRole().getRoleName())
                 .toList();
 
-        return new CustomUserDetails(user.getEmail(), roles, user.getUserUuid());
+        return new CustomUserDetails(roles, user.getUserUuid());
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -164,13 +164,13 @@ public class KakaoOAuthService {
 
         // 토큰 발급
         boolean keepLoggedIn = false; // 기본값
-        String accessToken = jwtUtil.createAccessToken(user.getEmail(), user.getUserUuid(), roles, keepLoggedIn);
-        String refreshToken = jwtUtil.createRefreshToken(user.getEmail(), user.getUserUuid(), roles, keepLoggedIn);
+        String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles, keepLoggedIn);
+        String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), keepLoggedIn);
         long expiresIn = jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
 
         // 리프레시 토큰 저장
         tokenService.saveRefreshToken(
-                user.getEmail(),
+                user.getUserUuid(),
                 refreshToken,
                 oauth2Response.getProvider(),
                 oauth2Response.getProviderId()

--- a/src/main/java/org/swyp/dessertbee/email/service/EmailVerificationService.java
+++ b/src/main/java/org/swyp/dessertbee/email/service/EmailVerificationService.java
@@ -4,6 +4,7 @@ import org.swyp.dessertbee.email.dto.EmailVerificationRequestDto;
 import org.swyp.dessertbee.email.dto.EmailVerificationResponseDto;
 import org.swyp.dessertbee.email.dto.EmailVerifyRequestDto;
 import org.swyp.dessertbee.email.dto.EmailVerifyResponseDto;
+import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
 
 public interface EmailVerificationService {
     /**
@@ -15,4 +16,10 @@ public interface EmailVerificationService {
      * 이메일 인증 코드 확인
      */
     EmailVerifyResponseDto verifyEmail(EmailVerifyRequestDto request);
+
+    /**
+     * 이메일 인증 토큰 검증
+     */
+    void validateEmailVerificationToken(String token, String email, EmailVerificationPurpose purpose);
+
 }

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -67,5 +67,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @Query("SELECT u FROM UserEntity u WHERE u.email = :email AND u.deletedAt IS NOT NULL")
     Optional<UserEntity> findDeletedAccountByEmail(String email);
 
-    UserEntity findByUserUuid(@NotNull UUID userUuid);
+
+    @Query("SELECT u FROM UserEntity u WHERE u.userUuid = :userUuid AND u.deletedAt IS NULL")
+    Optional<UserEntity> findByUserUuid(@NotNull UUID userUuid);
 }

--- a/src/main/java/org/swyp/dessertbee/user/service/UserService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserService.java
@@ -8,6 +8,9 @@ import org.swyp.dessertbee.user.dto.request.UserUpdateRequestDto;
 import org.swyp.dessertbee.user.entity.NicknameValidationPurpose;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface UserService {
     /**
      * 현재 인증된 사용자의 상세 정보를 조회
@@ -50,4 +53,6 @@ public interface UserService {
     UserEntity validateUser(String email);
 
     UserEntity findUserByEmail(String email);
+
+    UserEntity findByUserUuid(UUID userUuid);
 }


### PR DESCRIPTION
## :hash: 연관된 이슈
#185 
## :memo: 작업 내용
- 유저 객체를 SecurityContextHolder를 통해 받아올 수 있도록 수정
- 리프레시 토큰 정보 제한 (액세스 토큰 갱신 목적으로만)
- 이메일 토큰 정보 제한(이메일 정보 제외)
- 액세스 토큰 정보 제한(이메일 정보 제외)
- 이메일 토큰 검증 SRP적용하여 해당 서비스 코드로 분리
- 이메일 전송, 검증 / 회원가입 / 로그인 / 토큰갱신 / 로그아웃 / 내 정보 조회 테스트 완료