### PR TITLE
[FEATURE] 가게 상세 정보 커뮤니티 리뷰 조회

### DIFF
--- a/src/main/java/org/swyp/dessertbee/community/review/dto/response/ReviewSummaryResponse.java
+++ b/src/main/java/org/swyp/dessertbee/community/review/dto/response/ReviewSummaryResponse.java
@@ -1,0 +1,26 @@
+package org.swyp.dessertbee.community.review.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewSummaryResponse {
+    private UUID reviewUuid;
+    private UUID userUuid;
+    private String nickname;
+    private String profileImage;
+    private String thumbnail; // 리뷰 첫 번째 이미지 (썸네일)
+    private String title;
+    private String content; // 리뷰 글 내용
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/swyp/dessertbee/community/review/repository/ReviewRepository.java
+++ b/src/main/java/org/swyp/dessertbee/community/review/repository/ReviewRepository.java
@@ -8,12 +8,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.community.review.entity.Review;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByReviewUuid(UUID communityReviewUuid);
+
+    List<Review> findByStoreIdAndDeletedAtIsNull(Long storeId);
 
     @Query("SELECT DISTINCT rc.name From ReviewCategory rc JOIN Review c ON rc.reviewCategoryId = c.reviewCategoryId WHERE rc.reviewCategoryId = :reviewCategoryId")
     String findNameByReviewCategoryId(Long reviewCategoryId);

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -62,6 +62,12 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/public/**").permitAll()
                         .requestMatchers("/api/stores/map/**").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/preferences/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/mbtis/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/stores/**").permitAll()

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import org.swyp.dessertbee.community.mate.dto.response.MateResponse;
+import org.swyp.dessertbee.community.review.dto.response.ReviewSummaryResponse;
 import org.swyp.dessertbee.store.menu.dto.response.MenuResponse;
 import org.swyp.dessertbee.store.review.dto.response.StoreReviewResponse;
 import org.swyp.dessertbee.store.store.entity.Store;
@@ -43,6 +44,7 @@ public class StoreDetailResponse {
     private List<OperatingHourResponse> operatingHours;
     private List<HolidayResponse> holidays;
     private List<String> topPreferences;
+    private List<ReviewSummaryResponse> communityReviews;
     private List<MateResponse> mate;
     private boolean saved;
     private Long savedListId;
@@ -57,6 +59,7 @@ public class StoreDetailResponse {
                                                  List<String> topPreferences,
                                                  List<StoreReviewResponse> storeReviews,
                                                  List<String> tags,
+                                                 List<ReviewSummaryResponse> communityReviews,
                                                  List<MateResponse> mate,
                                                  boolean saved,
                                                  Long savedListId) {
@@ -88,6 +91,7 @@ public class StoreDetailResponse {
                 .totalReviewCount(totalReviewCount)
                 .storeReviews(storeReviews)
                 .tags(tags)
+                .communityReviews(communityReviews)
                 .mate(mate)
                 .saved(saved)
                 .savedListId(savedListId)

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -375,19 +375,21 @@ public class StoreService {
             List<String> profileImageList = imageService.getImagesByTypeAndId(ImageType.PROFILE, reviewer.getId());
             String profileImage = profileImageList.isEmpty() ? null : profileImageList.get(0);
 
-            // 리뷰의 첫 번째 이미지 찾기
-            String thumbnail = review.getReviewContents().stream()
-                    .filter(content -> "image".equals(content.getType()))
-                    .map(ReviewContent::getValue)
-                    .findFirst()
-                    .orElse(null);
+            String thumbnail = null;
+            String content = "";
 
-            // 리뷰의 대표 텍스트 찾기 (첫 번째 "text" 타입의 값)
-            String content = review.getReviewContents().stream()
-                    .filter(contentItem -> "text".equals(contentItem.getType()))
-                    .map(ReviewContent::getValue)
-                    .findFirst()
-                    .orElse("");
+            for (ReviewContent contentItem : review.getReviewContents()) {
+                if (thumbnail == null && "image".equals(contentItem.getType())) {
+                    thumbnail = contentItem.getValue();
+                } else if (content.isEmpty() && "text".equals(contentItem.getType())) {
+                    content = contentItem.getValue();
+                }
+
+                // 두 값이 모두 설정되면 반복문 끝
+                if (thumbnail != null && !content.isEmpty()) {
+                    break;
+                }
+            }
 
             return ReviewSummaryResponse.builder()
                     .reviewUuid(review.getReviewUuid())


### PR DESCRIPTION
## :hash: 연관된 이슈

> #192 

## :memo: 작업 내용

> 가게 상세정보에서 보여질 간략한 커뮤니티 리뷰 응답 dto 생성 
> 썸네일 - ReviewContent의 type="image"인 첫번째 값
> 내용 - ReviewContent의 type="text"
> 그 외 - reviewUuid, userUuid, nickname, profileImage, title, createdAt, updatedAt
> SecurityConfig에서 Swagger 관련 경로 허용
