### PR TITLE
[FEATURE] 유저 별 최근 검색어 저장, 조회 api

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -1,0 +1,34 @@
+package org.swyp.dessertbee.common.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swyp.dessertbee.common.service.SearchService;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.service.UserService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+    private final UserService userService;
+
+    /** 🔹 최근 검색어 조회 API */
+    @GetMapping("/recent")
+    public ResponseEntity<List<String>> getRecentSearches() {
+        UserEntity user = userService.getCurrentUser();
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        List<String> recentSearches = searchService.getRecentSearches(user.getId());
+        return ResponseEntity.ok(recentSearches);
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -20,7 +20,7 @@ public class SearchController {
     private final SearchService searchService;
     private final UserService userService;
 
-    /** 🔹 최근 검색어 조회 API */
+    /** 최근 검색어 조회 API */
     @GetMapping("/recent")
     public ResponseEntity<List<String>> getRecentSearches() {
         UserEntity user = userService.getCurrentUser();

--- a/src/main/java/org/swyp/dessertbee/common/entity/UserSearchHistory.java
+++ b/src/main/java/org/swyp/dessertbee/common/entity/UserSearchHistory.java
@@ -1,0 +1,37 @@
+package org.swyp.dessertbee.common.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_search_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserSearchHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    private String keyword;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    // 엔티티 객체를 생성
+    public static UserSearchHistory create(Long userId, String keyword) {
+        return UserSearchHistory.builder()
+                .userId(userId)
+                .keyword(keyword)
+                .build();
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/common/repository/UserSearchHistoryRepository.java
+++ b/src/main/java/org/swyp/dessertbee/common/repository/UserSearchHistoryRepository.java
@@ -1,0 +1,30 @@
+package org.swyp.dessertbee.common.repository;
+
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.common.entity.UserSearchHistory;
+
+import java.util.List;
+
+@Repository
+public interface UserSearchHistoryRepository extends JpaRepository<UserSearchHistory, Long> {
+
+    List<UserSearchHistory> findTop10ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM UserSearchHistory u WHERE u.userId = :userId AND u.keyword = :keyword")
+    void deleteByUserIdAndKeyword(Long userId, String keyword);
+
+    @Query("SELECT h.id FROM UserSearchHistory h WHERE h.userId = :userId ORDER BY h.createdAt DESC")
+    List<Long> findRecentSearchIdsByUserId(Long userId, Pageable pageable);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM UserSearchHistory h WHERE h.userId = :userId AND h.id NOT IN :searchIds")
+    void deleteByUserIdAndIdNotIn(Long userId, List<Long> searchIds);
+}

--- a/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
@@ -19,6 +19,10 @@ public class SearchService {
 
     private static final int MAX_RECENT_SEARCHES = 10;
 
+    public String removeTrailingSpaces(String input) {
+        return input.replaceAll("\\s+$", ""); // 문자열 끝부분의 공백만 제거
+    }
+
     /** 최근 검색어 저장 (인증된 사용자만) */
     @Transactional
     public void saveRecentSearch(Long userId, String keyword) {

--- a/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
@@ -32,11 +32,11 @@ public class SearchService {
         // 새 검색어 저장
         searchHistoryRepository.save(UserSearchHistory.create(userId, keyword));
 
-        // 최대 10개 유지 (초과 시 오래된 검색어 삭제)
+        // 검색어 최대 10개 유지
         deleteOldSearches(userId);
     }
 
-    /** 🔹 초과 검색어 삭제 (최신 10개 유지) */
+    /** 검색어 10개 초과 시 예전 검색어 삭제 */
     @Transactional
     public void deleteOldSearches(Long userId) {
         Pageable pageable = PageRequest.of(0, MAX_RECENT_SEARCHES);

--- a/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
@@ -1,0 +1,61 @@
+package org.swyp.dessertbee.common.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.swyp.dessertbee.common.entity.UserSearchHistory;
+import org.swyp.dessertbee.common.repository.UserSearchHistoryRepository;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final UserSearchHistoryRepository searchHistoryRepository;
+
+    private static final int MAX_RECENT_SEARCHES = 10;
+
+    /** 최근 검색어 저장 (인증된 사용자만) */
+    @Transactional
+    public void saveRecentSearch(Long userId, String keyword) {
+        if (userId == null || keyword == null || keyword.isEmpty()) {
+            return;
+        }
+
+        // 기존 검색어 삭제 (중복 방지)
+        searchHistoryRepository.deleteByUserIdAndKeyword(userId, keyword);
+
+        // 새 검색어 저장
+        searchHistoryRepository.save(UserSearchHistory.create(userId, keyword));
+
+        // 최대 10개 유지 (초과 시 오래된 검색어 삭제)
+        deleteOldSearches(userId);
+    }
+
+    /** 🔹 초과 검색어 삭제 (최신 10개 유지) */
+    @Transactional
+    public void deleteOldSearches(Long userId) {
+        Pageable pageable = PageRequest.of(0, MAX_RECENT_SEARCHES);
+        List<Long> searchIds = searchHistoryRepository.findRecentSearchIdsByUserId(userId, pageable);
+
+        if (!searchIds.isEmpty()) {
+            searchHistoryRepository.deleteByUserIdAndIdNotIn(userId, searchIds);
+        }
+    }
+
+    /** 최근 검색어 조회 */
+    public List<String> getRecentSearches(Long userId) {
+        if (userId == null) {
+            return Collections.emptyList(); // 로그인되지 않은 경우 빈 리스트 반환
+        }
+
+        return searchHistoryRepository.findTop10ByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(UserSearchHistory::getKeyword)
+                .toList();
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -10,6 +10,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.common.service.SearchService;
 import org.swyp.dessertbee.store.store.dto.request.StoreCreateRequest;
 import org.swyp.dessertbee.store.store.dto.request.StoreUpdateRequest;
 import org.swyp.dessertbee.store.store.dto.response.StoreDetailResponse;
@@ -17,6 +18,7 @@ import org.swyp.dessertbee.store.store.dto.response.StoreMapResponse;
 import org.swyp.dessertbee.store.store.dto.response.StoreSummaryResponse;
 import org.swyp.dessertbee.store.store.service.StoreService;
 import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.service.UserService;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -29,6 +31,8 @@ import java.util.*;
 public class StoreController {
 
     private final StoreService storeService;
+    private final SearchService searchService;
+    private final UserService userService;
 
     /** 가게 등록 */
     @Operation(summary = "가게 등록", description = "업주가 가게를 등록합니다.")
@@ -57,6 +61,12 @@ public class StoreController {
 
         if (searchKeyword != null) {
             searchKeyword = URLDecoder.decode(searchKeyword, StandardCharsets.UTF_8);
+
+            UserEntity user = userService.getCurrentUser();
+            // 인증된 사용자일 경우 >> 최근 검색어 저장
+            if (user != null) {
+                searchService.saveRecentSearch(user.getId(), searchKeyword);
+            }
         }
 
         if (preferenceTagIds != null && !preferenceTagIds.isEmpty()) {

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -61,6 +61,7 @@ public class StoreController {
 
         if (searchKeyword != null) {
             searchKeyword = URLDecoder.decode(searchKeyword, StandardCharsets.UTF_8);
+            searchKeyword = searchService.removeTrailingSpaces(searchKeyword);
 
             UserEntity user = userService.getCurrentUser();
             // 인증된 사용자일 경우 >> 최근 검색어 저장

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -34,7 +34,7 @@ import org.swyp.dessertbee.store.store.entity.*;
 import org.swyp.dessertbee.store.store.repository.*;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
-import org.swyp.dessertbee.user.service.UserServiceImpl;
+import org.swyp.dessertbee.user.service.UserService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -63,7 +63,7 @@ public class StoreService {
     private final MenuService menuService;
     private final UserRepository userRepository;
     private final SavedMateRepository savedMateRepository;
-    private final UserServiceImpl userService;
+    private final UserService userService;
     private final ReviewRepository reviewRepository;
 
     /** 가게 등록 (이벤트, 쿠폰, 메뉴 + 이미지 포함) */

--- a/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
@@ -37,7 +37,6 @@ public class UserStoreService {
     private final SavedStoreRepository savedStoreRepository;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
-    private final PreferenceRepository preferenceRepository;
     private final ImageService imageService;
 
     /** 저장 리스트 전체 조회 */

--- a/src/main/java/org/swyp/dessertbee/user/service/UserService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserService.java
@@ -13,6 +13,12 @@ import java.util.UUID;
 
 public interface UserService {
     /**
+     * Security Context에서 현재 인증된 사용자의 정보를 조회
+     * 비로그인 상태인 경우 null 반환
+     */
+    UserEntity getCurrentUser();
+
+    /**
      * 현재 인증된 사용자의 상세 정보를 조회
      * @return 사용자 상세 정보 DTO
      */


### PR DESCRIPTION
## :hash: 연관된 이슈

> #194 

## :memo: 작업 내용

> 인증된 사용자가 가게 검색 시 최근 검색어를 최대 10개까지 저장합니다.
> 유저별 최대 10개까지 검색어 저장 (초과 시 예전 검색어부터 삭제)
> 동일 검색어 저장 x (추가 커밋: 테스트 시 "디저트 ", "디저트" 다른 단어로 인식되는 문제 해결 -> 마지막 공백만 제거 )
> 인증된 사용자의 id와 함께 저장
> 최신(생성일 desc)순으로 조회
> 기존에 UserServiceImpl의 getCurrentUser() 호출하는 부분 수정 (인터페이스 코드 추가)

### 스크린샷

![image](https://github.com/user-attachments/assets/cd23c0a6-ee57-4133-ae52-9532ff8e5666)

<img width="414" alt="image" src="https://github.com/user-attachments/assets/31d93946-2ba2-45d1-9701-7524eb129143" />
