### PR TITLE
[FEATURE] 실시간 인기검색어 저장, 동기화, 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
 
+    // Spring Data Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Lettuce Redis Client
+    implementation 'io.lettuce.core:lettuce-core'
+
     implementation 'software.amazon.awssdk:s3:2.20.86'
     implementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,7 @@ dependencies {
 
     // Spring Data Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-    // Lettuce Redis Client
-    implementation 'io.lettuce.core:lettuce-core'
+    implementation 'redis.clients:jedis:4.3.1'
 
     implementation 'software.amazon.awssdk:s3:2.20.86'
     implementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/swyp/dessertbee/DessertBeeApplication.java
+++ b/src/main/java/org/swyp/dessertbee/DessertBeeApplication.java
@@ -4,9 +4,11 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class DessertBeeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -12,9 +12,8 @@ import org.swyp.dessertbee.common.service.SearchService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.service.UserService;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/search")
@@ -36,12 +35,20 @@ public class SearchController {
         return ResponseEntity.ok(recentSearches);
     }
 
-    /** 실시간 인기 검색어 조회 API */
+    /** 실시간 인기 검색어 조회 API (이전 검색 횟수 차이 + 업데이트 시간 포함) */
     @GetMapping("/popular")
-    public ResponseEntity<List<PopularSearchResponse>> getPopularSearches(
+    public ResponseEntity<Map<String, Object>> getPopularSearches(
             @RequestParam(defaultValue = "10") int limit
     ) {
-        List<PopularSearchResponse> response = searchService.getPopularSearchesFromDB(limit);
+        Map<String, Object> response = searchService.getPopularSearchesWithDifference(limit);
         return ResponseEntity.ok(response);
     }
+
+    /** Redis 인기 검색어 초기화 API (테스트용) */
+    @GetMapping("/popular/clear")
+    public ResponseEntity<String> clearPopularSearchCache() {
+        searchService.clearPopularSearchCache();
+        return ResponseEntity.ok("✅ Redis 캐싱된 인기 검색어 데이터가 초기화되었습니다.");
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 @RestController
-@RequestMapping("/search")
+@RequestMapping("/api/search")
 @RequiredArgsConstructor
 public class SearchController {
 

--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -41,15 +41,7 @@ public class SearchController {
     public ResponseEntity<List<PopularSearchResponse>> getPopularSearches(
             @RequestParam(defaultValue = "10") int limit
     ) {
-        Set<String> keywords = searchService.getPopularSearches(limit);
-
-        List<PopularSearchResponse> response = new ArrayList<>();
-        int rank = 1;
-        for (String keyword : keywords) {
-            response.add(new PopularSearchResponse(keyword, rank++));
-        }
-
+        List<PopularSearchResponse> response = searchService.getPopularSearchesFromDB(limit);
         return ResponseEntity.ok(response);
     }
-
 }

--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -5,12 +5,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.swyp.dessertbee.common.dto.PopularSearchResponse;
 import org.swyp.dessertbee.common.service.SearchService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.service.UserService;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/search")
@@ -31,4 +35,21 @@ public class SearchController {
         List<String> recentSearches = searchService.getRecentSearches(user.getId());
         return ResponseEntity.ok(recentSearches);
     }
+
+    /** 실시간 인기 검색어 조회 API */
+    @GetMapping("/popular")
+    public ResponseEntity<List<PopularSearchResponse>> getPopularSearches(
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        Set<String> keywords = searchService.getPopularSearches(limit);
+
+        List<PopularSearchResponse> response = new ArrayList<>();
+        int rank = 1;
+        for (String keyword : keywords) {
+            response.add(new PopularSearchResponse(keyword, rank++));
+        }
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/common/dto/PopularSearchResponse.java
+++ b/src/main/java/org/swyp/dessertbee/common/dto/PopularSearchResponse.java
@@ -1,0 +1,11 @@
+package org.swyp.dessertbee.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PopularSearchResponse {
+    private String keyword;
+    private int rank;
+}

--- a/src/main/java/org/swyp/dessertbee/common/dto/PopularSearchResponse.java
+++ b/src/main/java/org/swyp/dessertbee/common/dto/PopularSearchResponse.java
@@ -7,5 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PopularSearchResponse {
     private String keyword;
+    private int searchCount;
     private int rank;
+    private int difference;
 }

--- a/src/main/java/org/swyp/dessertbee/common/entity/PopularSearchKeyword.java
+++ b/src/main/java/org/swyp/dessertbee/common/entity/PopularSearchKeyword.java
@@ -1,0 +1,34 @@
+package org.swyp.dessertbee.common.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "popular_search_keywords")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PopularSearchKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String keyword;
+
+    @Column(nullable = false)
+    private int searchCount;
+
+    public void incrementCount(int count) {
+        this.searchCount += count;
+    }
+
+    public static PopularSearchKeyword create(String keyword) {
+        return PopularSearchKeyword.builder()
+                .keyword(keyword)
+                .searchCount(1)
+                .build();
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/common/entity/PopularSearchKeyword.java
+++ b/src/main/java/org/swyp/dessertbee/common/entity/PopularSearchKeyword.java
@@ -28,7 +28,7 @@ public class PopularSearchKeyword {
     public static PopularSearchKeyword create(String keyword) {
         return PopularSearchKeyword.builder()
                 .keyword(keyword)
-                .searchCount(1)
+                .searchCount(0)
                 .build();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/common/repository/PopularSearchKeywordRepository.java
+++ b/src/main/java/org/swyp/dessertbee/common/repository/PopularSearchKeywordRepository.java
@@ -1,0 +1,22 @@
+package org.swyp.dessertbee.common.repository;
+
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.common.entity.PopularSearchKeyword;
+
+import java.util.Optional;
+
+@Repository
+public interface PopularSearchKeywordRepository extends JpaRepository<PopularSearchKeyword, Long> {
+
+    Optional<PopularSearchKeyword> findByKeyword(String keyword);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE PopularSearchKeyword p SET p.searchCount = p.searchCount + :count WHERE p.keyword = :keyword")
+    void incrementSearchCount(@Param("keyword") String keyword, @Param("count") int count);
+}

--- a/src/main/java/org/swyp/dessertbee/common/repository/PopularSearchKeywordRepository.java
+++ b/src/main/java/org/swyp/dessertbee/common/repository/PopularSearchKeywordRepository.java
@@ -1,21 +1,12 @@
 package org.swyp.dessertbee.common.repository;
 
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.common.entity.PopularSearchKeyword;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PopularSearchKeywordRepository extends JpaRepository<PopularSearchKeyword, Long> {
-
-    @Query("SELECT p FROM PopularSearchKeyword p ORDER BY p.searchCount DESC LIMIT :limit")
-    List<PopularSearchKeyword> findTopKeywords(@Param("limit") int limit);
-
     Optional<PopularSearchKeyword> findByKeyword(String keyword);
 }

--- a/src/main/java/org/swyp/dessertbee/common/repository/PopularSearchKeywordRepository.java
+++ b/src/main/java/org/swyp/dessertbee/common/repository/PopularSearchKeywordRepository.java
@@ -8,15 +8,14 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.common.entity.PopularSearchKeyword;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PopularSearchKeywordRepository extends JpaRepository<PopularSearchKeyword, Long> {
 
-    Optional<PopularSearchKeyword> findByKeyword(String keyword);
+    @Query("SELECT p FROM PopularSearchKeyword p ORDER BY p.searchCount DESC LIMIT :limit")
+    List<PopularSearchKeyword> findTopKeywords(@Param("limit") int limit);
 
-    @Modifying
-    @Transactional
-    @Query("UPDATE PopularSearchKeyword p SET p.searchCount = p.searchCount + :count WHERE p.keyword = :keyword")
-    void incrementSearchCount(@Param("keyword") String keyword, @Param("count") int count);
+    Optional<PopularSearchKeyword> findByKeyword(String keyword);
 }

--- a/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
@@ -4,20 +4,28 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.swyp.dessertbee.common.entity.UserSearchHistory;
+import org.swyp.dessertbee.common.repository.PopularSearchKeywordRepository;
 import org.swyp.dessertbee.common.repository.UserSearchHistoryRepository;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class SearchService {
 
     private final UserSearchHistoryRepository searchHistoryRepository;
+    private final PopularSearchKeywordRepository popularSearchKeywordRepository;
+    private final StringRedisTemplate redisTemplate;
 
     private static final int MAX_RECENT_SEARCHES = 10;
+    private static final String POPULAR_SEARCH_KEY = "popular_search_keywords";
 
     public String removeTrailingSpaces(String input) {
         return input.replaceAll("\\s+$", ""); // 문자열 끝부분의 공백만 제거
@@ -61,5 +69,42 @@ public class SearchService {
                 .stream()
                 .map(UserSearchHistory::getKeyword)
                 .toList();
+    }
+
+
+    /** 인기 검색어 저장 (모든 사용자) */
+    public void savePopularSearch(String keyword) {
+        if (keyword == null || keyword.isBlank()) { // 공백 체크
+            return;
+        }
+
+        keyword = keyword.trim(); // 공백 제거
+        redisTemplate.opsForZSet().incrementScore(POPULAR_SEARCH_KEY, keyword, 1);
+    }
+
+
+    /** 인기 검색어 가져오기 */
+    public Set<String> getPopularSearches(int limit) {
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        return zSetOps.reverseRange(POPULAR_SEARCH_KEY, 0, limit - 1); // 상위 limit개 인기 검색어 가져오기
+    }
+
+    /** 인기 검색어 동기화 (Redis → MySQL) */
+    @Scheduled(fixedRate = 60000) // 1분마다 실행 (1분 = 60 * 1000 ms)
+    @Transactional
+    public void syncPopularSearchesToDB() {
+        Set<String> keywords = redisTemplate.opsForZSet().reverseRange(POPULAR_SEARCH_KEY, 0, 49);
+        if (keywords == null || keywords.isEmpty()) {
+            return;
+        }
+
+        for (String keyword : keywords) {
+            Double score = redisTemplate.opsForZSet().score(POPULAR_SEARCH_KEY, keyword);
+            if (score != null) {
+                popularSearchKeywordRepository.incrementSearchCount(keyword, score.intValue());
+            }
+            // 동기화된 검색어만 제거
+            redisTemplate.opsForZSet().remove(POPULAR_SEARCH_KEY, keyword);
+        }
     }
 }

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateMemberService.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateMemberService.java
@@ -34,7 +34,6 @@ public class MateMemberService {
     private final UserRepository userRepository;
     private final ImageService imageService;
     private final UserService userService;
-    private final UserServiceImpl userServiceImpl;
 
 
     /**
@@ -136,7 +135,7 @@ public class MateMemberService {
     @Transactional
     public void applyMate(UUID mateUuid) {
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
-        UserEntity user = userServiceImpl.getCurrentUser();
+        UserEntity user = userService.getCurrentUser();
 
         //mateId,userId  유효성 검사
         MateUserIds validate = validateMateAndUser(mateUuid, user.getUserUuid());
@@ -210,7 +209,7 @@ public class MateMemberService {
     public void cancelApplyMate(UUID mateUuid) {
 
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
-        UserEntity user = userServiceImpl.getCurrentUser();
+        UserEntity user = userService.getCurrentUser();
 
         //mateId,userId  유효성 검사
         MateUserIds validate = validateMateAndUser(mateUuid, user.getUserUuid());
@@ -387,7 +386,7 @@ public class MateMemberService {
     public void leaveMember (UUID mateUuid) {
 
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
-        UserEntity user = userServiceImpl.getCurrentUser();
+        UserEntity user = userService.getCurrentUser();
 
 
         //mateId,userId  유효성 검사

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyService.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyService.java
@@ -24,7 +24,7 @@ import org.swyp.dessertbee.community.mate.repository.MateRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.community.mate.exception.MateExceptions.*;
-import org.swyp.dessertbee.user.service.UserServiceImpl;
+import org.swyp.dessertbee.user.service.UserService;
 
 import java.util.List;
 import java.util.UUID;
@@ -42,13 +42,14 @@ public class MateReplyService {
     private final ReportRepository reportRepository;
     private final MateRepository mateRepository;
     private final ImageService imageService;
-    private final UserServiceImpl userServiceImpl;
+    private final UserService userService;
 
     /**
      * 디저트메이트 댓글 생성
      * */
     @Transactional
     public MateReplyResponse createReply(UUID mateUuid, MateReplyCreateRequest request) {
+
 
         //디저트 메이트 유효성 검사
         MateUserIds mateUserIds = validateMateAndUser(mateUuid, request.getUserUuid());
@@ -142,7 +143,7 @@ public class MateReplyService {
     public void deleteReply(UUID mateUuid, Long replyId) {
 
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
-        UserEntity user = userServiceImpl.getCurrentUser();
+        UserEntity user = userService.getCurrentUser();
 
         MateUserIds mateUserIds = validateMateAndUser(mateUuid, user.getUserUuid());
         Long mateId = mateUserIds.getMateId();

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/SavedMateService.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/SavedMateService.java
@@ -21,7 +21,7 @@ import org.swyp.dessertbee.store.store.entity.Store;
 import org.swyp.dessertbee.store.store.repository.StoreRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
-import org.swyp.dessertbee.user.service.UserServiceImpl;
+import org.swyp.dessertbee.user.service.UserService;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +38,7 @@ public class SavedMateService {
     private final MateMemberRepository mateMemberRepository;
     private final MateCategoryRepository mateCategoryRepository;
     private final ImageService imageService;
-    private final UserServiceImpl userServiceImpl;
+    private final UserService userService;
     private final StoreRepository storeRepository;
 
     /**
@@ -48,7 +48,7 @@ public class SavedMateService {
     public void saveMate(UUID mateUuid) {
 
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
-        UserEntity user = userServiceImpl.getCurrentUser();
+        UserEntity user = userService.getCurrentUser();
 
         Mate mate = mateRepository.findByMateUuidAndDeletedAtIsNull(mateUuid)
                 .orElseThrow(() -> new MateNotFoundException("존재하지 않는 디저트메이트입니다."));
@@ -81,7 +81,7 @@ public class SavedMateService {
     public void deleteSavedMate(UUID mateUuid) {
 
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
-        UserEntity user = userServiceImpl.getCurrentUser();
+        UserEntity user = userService.getCurrentUser();
 
         Long mateId = mateRepository.findMateIdByMateUuid(mateUuid)
                 .orElseThrow(() -> new MateNotFoundException("존재하지 않는 디저트메이트입니다."));
@@ -108,7 +108,7 @@ public class SavedMateService {
     public MatesPageResponse getSavedMates(Pageable pageable) {
 
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
-        UserEntity user = userServiceImpl.getCurrentUser();
+        UserEntity user = userService.getCurrentUser();
 
         Long userId = userRepository.findIdByUserUuid(user.getUserUuid());
 

--- a/src/main/java/org/swyp/dessertbee/config/RedisConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package org.swyp.dessertbee.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("localhost", 6379);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
@@ -19,7 +19,8 @@ public interface StoreReviewRepository extends JpaRepository<StoreReview, Long> 
     BigDecimal findAverageRatingByStoreId(@Param("storeId") Long storeId);
 
     /** 특정 가게에 존재하는 리뷰 목록 조회 **/
-    List<StoreReview> findByStoreIdAndDeletedAtIsNull(Long storeId);
+    @Query("SELECT sr FROM StoreReview sr WHERE sr.storeId = :storeId AND sr.deletedAt IS NULL ORDER BY sr.createdAt DESC")
+    List<StoreReview> findByStoreIdAndDeletedAtIsNull(@Param("storeId") Long storeId);
 
     Optional<StoreReview> findByReviewIdAndDeletedAtIsNull(Long reviewId);
 

--- a/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewService.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewService.java
@@ -113,8 +113,8 @@ public class StoreReviewService {
         review.setRating(request.getRating());
 
         // 이미지 처리
-        imageService.deleteImagesByRefId(ImageType.SHORT, reviewId);
         if (newImages != null && !newImages.isEmpty()) {
+            imageService.deleteImagesByRefId(ImageType.SHORT, reviewId);
             imageService.uploadAndSaveImages(newImages, ImageType.SHORT, reviewId, "short/" + review.getReviewId());
         }
 

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -68,6 +68,8 @@ public class StoreController {
             if (user != null) {
                 searchService.saveRecentSearch(user.getId(), searchKeyword);
             }
+            // 인증 여부와 관계없이 인기 검색어 저장
+            searchService.savePopularSearch(searchKeyword);
         }
 
         if (preferenceTagIds != null && !preferenceTagIds.isEmpty()) {

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
@@ -46,7 +46,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     """, nativeQuery = true)
     List<Store> findStoresByLocationAndTags(@Param("lat") Double lat,
                                            @Param("lng") Double lng,
-                                           @Param("radius") Double radius, @Param("preferenceNames") List<String> preferenceNames);
+                                           @Param("radius") Double radius, @Param("preferenceTagIds") List<Long> preferenceTagIds);
 
     // 반경 내 검색어에 맞는 가게 조회 메서드
     @Query(value = "SELECT DISTINCT s.* " +

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/StoreRepository.java
@@ -40,7 +40,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
             GROUP BY ss.store_id, sp.preference
         ) AS top_pref ON s.store_id = top_pref.store_id
         WHERE top_pref.rn <= 3
-          AND top_pref.preference IN (:preferenceNames)
+          AND top_pref.preference IN (:preferenceTagIds)
           AND ST_Distance_Sphere(point(:lng, :lat), point(s.longitude, s.latitude)) <= :radius
           AND s.deleted_at IS NULL
     """, nativeQuery = true)

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -198,14 +198,8 @@ public class StoreService {
             throw new BusinessException(ErrorCode.PREFERENCES_NOT_FOUND);
         }
 
-        // 존재하지 않는 preferenceTagId가 있는지 검증
-        List<String> preferenceNames = preferenceRepository.findPreferenceNamesByIds(preferenceTagIds);
-        if (preferenceNames.isEmpty()) {
-            throw new BusinessException(ErrorCode.PREFERENCES_NOT_FOUND);
-        }
-
         // 여러 태그 중 하나라도 매칭되는 가게를 조회
-        List<Store> stores = storeRepository.findStoresByLocationAndTags(lat, lng, radius, preferenceNames);
+        List<Store> stores = storeRepository.findStoresByLocationAndTags(lat, lng, radius, preferenceTagIds);
 
         return stores.stream()
                 .map(StoreMapResponse::fromEntity)
@@ -229,17 +223,17 @@ public class StoreService {
         }
 
         // 해당 사용자에게 취향(preference) 값이 존재하는지 확인
-        List<String> userPreferenceNames = user.getUserPreferences().stream()
-                .map(up -> up.getPreference().getPreferenceName())
+        List<Long> preferenceTagIds = user.getUserPreferences().stream()
+                .map(up -> up.getPreference().getId())
                 .distinct()
                 .collect(Collectors.toList());
 
-        if (userPreferenceNames.isEmpty()) {
+        if (preferenceTagIds.isEmpty()) {
             throw new BusinessException(ErrorCode.USER_PREFERENCES_NOT_FOUND);
         }
 
         // 사용자의 취향 태그 중 하나라도 매칭되는 가게 조회
-        List<Store> stores = storeRepository.findStoresByLocationAndTags(lng, lat, radius, userPreferenceNames);
+        List<Store> stores = storeRepository.findStoresByLocationAndTags(lng, lat, radius, preferenceTagIds);
 
         return stores.stream()
                 .map(StoreMapResponse::fromEntity)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,11 @@ spring:
           auth: true
           starttls:
             enable: true
+
+  data:
+    redis:
+      client-type: jedis
+
 logging:
   level:
     org:


### PR DESCRIPTION
## :hash: 연관된 이슈

> #196 

## :memo: 작업 내용

> 실시간 인기 검색어 기능 개선 및 데이터 동기화 로직 추가
> MySQL 동기화 로직 개선
> 1분마다 Redis 데이터를 MySQL과 동기화 (syncPopularSearchesToDB)
> 동기화 후 현재 검색어 데이터를 SYNCED_POPULAR_SEARCH_KEY에 저장하여 비교 가능하도록 개선

> 자정마다 MySQL로 데이터 이전 후 Redis 초기화
> Redis 인기 검색어 초기화 API 추가 (테스트용)

### 스크린샷

<img width="629" alt="image" src="https://github.com/user-attachments/assets/648f18b4-f201-4e62-90fe-a6c0d6a0c369" />

