### PR TITLE
[FEATURE] 유저별 최근 검색어 삭제 API 구현 (+etc)

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.common.controller;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -7,6 +8,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.common.dto.PopularSearchResponse;
 import org.swyp.dessertbee.common.dto.UserSearchHistoryDto;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.service.SearchService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.service.UserService;
@@ -38,7 +41,11 @@ public class SearchController {
     public ResponseEntity<Void> deleteRecentSearch(@PathVariable Long searchId) {
         UserEntity user = userService.getCurrentUser();
 
-        searchService.deleteRecentSearch(user.getId(), searchId);
+        boolean deleted = searchService.deleteRecentSearch(user.getId(), searchId);
+        if (!deleted) {
+            throw new BusinessException(ErrorCode.SEARCH_KEYWORD_NOT_FOUND);
+        }
+
         return ResponseEntity.noContent().build();
     }
 
@@ -48,7 +55,11 @@ public class SearchController {
     public ResponseEntity<Void> deleteAllRecentSearches() {
         UserEntity user = userService.getCurrentUser();
 
-        searchService.deleteAllRecentSearches(user.getId());
+        boolean deleted = searchService.deleteAllRecentSearches(user.getId());
+        if (!deleted) {
+            throw new BusinessException(ErrorCode.SEARCH_KEYWORD_DELETE_ERROR);
+        }
+
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -3,6 +3,7 @@ package org.swyp.dessertbee.common.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.common.dto.PopularSearchResponse;
 import org.swyp.dessertbee.common.dto.UserSearchHistoryDto;
@@ -22,36 +23,30 @@ public class SearchController {
     private final UserService userService;
 
     /** 최근 검색어 조회 API */
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/recent")
     public ResponseEntity<List<UserSearchHistoryDto>> getRecentSearches() {
         UserEntity user = userService.getCurrentUser();
-        if (user == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
 
         List<UserSearchHistoryDto> recentSearches = searchService.getRecentSearches(user.getId());
         return ResponseEntity.ok(recentSearches);
     }
 
     /** 특정 검색어 삭제 */
+    @PreAuthorize("isAuthenticated()")
     @DeleteMapping("/recent/{searchId}")
     public ResponseEntity<Void> deleteRecentSearch(@PathVariable Long searchId) {
         UserEntity user = userService.getCurrentUser();
-        if (user == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
 
         searchService.deleteRecentSearch(user.getId(), searchId);
         return ResponseEntity.noContent().build();
     }
 
     /** 모든 검색어 삭제 */
+    @PreAuthorize("isAuthenticated()")
     @DeleteMapping("/recent/all")
     public ResponseEntity<Void> deleteAllRecentSearches() {
         UserEntity user = userService.getCurrentUser();
-        if (user == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
 
         searchService.deleteAllRecentSearches(user.getId());
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/SearchController.java
@@ -3,11 +3,9 @@ package org.swyp.dessertbee.common.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.common.dto.PopularSearchResponse;
+import org.swyp.dessertbee.common.dto.UserSearchHistoryDto;
 import org.swyp.dessertbee.common.service.SearchService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.service.UserService;
@@ -25,14 +23,38 @@ public class SearchController {
 
     /** 최근 검색어 조회 API */
     @GetMapping("/recent")
-    public ResponseEntity<List<String>> getRecentSearches() {
+    public ResponseEntity<List<UserSearchHistoryDto>> getRecentSearches() {
         UserEntity user = userService.getCurrentUser();
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        List<String> recentSearches = searchService.getRecentSearches(user.getId());
+        List<UserSearchHistoryDto> recentSearches = searchService.getRecentSearches(user.getId());
         return ResponseEntity.ok(recentSearches);
+    }
+
+    /** 특정 검색어 삭제 */
+    @DeleteMapping("/recent/{searchId}")
+    public ResponseEntity<Void> deleteRecentSearch(@PathVariable Long searchId) {
+        UserEntity user = userService.getCurrentUser();
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        searchService.deleteRecentSearch(user.getId(), searchId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** 모든 검색어 삭제 */
+    @DeleteMapping("/recent/all")
+    public ResponseEntity<Void> deleteAllRecentSearches() {
+        UserEntity user = userService.getCurrentUser();
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        searchService.deleteAllRecentSearches(user.getId());
+        return ResponseEntity.noContent().build();
     }
 
     /** 실시간 인기 검색어 조회 API (이전 검색 횟수 차이 + 업데이트 시간 포함) */

--- a/src/main/java/org/swyp/dessertbee/common/dto/UserSearchHistoryDto.java
+++ b/src/main/java/org/swyp/dessertbee/common/dto/UserSearchHistoryDto.java
@@ -1,0 +1,19 @@
+package org.swyp.dessertbee.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.swyp.dessertbee.common.entity.UserSearchHistory;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserSearchHistoryDto {
+    private Long id;
+    private String keyword;
+    private LocalDateTime createdAt;
+
+    public static UserSearchHistoryDto fromEntity(UserSearchHistory entity) {
+        return new UserSearchHistoryDto(entity.getId(), entity.getKeyword(), entity.getCreatedAt());
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -51,6 +51,10 @@ public enum ErrorCode {
     PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 취향 태그입니다."),
     USER_PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P002", "취향을 등록하지 않은 사용자입니다."),
 
+    // Search Keyword
+    SEARCH_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "K001", "해당 검색 기록을 찾을 수 없습니다."),
+    SEARCH_KEYWORD_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "K002", "검색 기록 삭제에 실패했습니다."),
+
     // Store
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 가게입니다."),
     STORE_CREATION_FAILED(HttpStatus.BAD_REQUEST, "S002", "가게 생성에 실패했습니다."),
@@ -104,11 +108,7 @@ public enum ErrorCode {
     //커뮤니티 리뷰
     COMMUNITY_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001" , "존재하지 않는 리뷰입니다." ),
     IMAGE_INDEX_NOT_FOUND(HttpStatus.BAD_REQUEST, "R02", "요청된 이미지 인덱스가 이미지 파일 수보다 적습니다."),
-    DUPLICATE_DELETE_IMAGE_IDS(HttpStatus.BAD_REQUEST,"R03" , "중복된 이미지 삭제 ID가 존재합니다."),
-
-    // 검색어
-    SEARCH_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "K001", "해당 검색 기록을 찾을 수 없습니다."),
-    SEARCH_KEYWORD_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "K002", "검색 기록 삭제에 실패했습니다.");
+    DUPLICATE_DELETE_IMAGE_IDS(HttpStatus.BAD_REQUEST,"R03" , "중복된 이미지 삭제 ID가 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -104,8 +104,11 @@ public enum ErrorCode {
     //커뮤니티 리뷰
     COMMUNITY_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001" , "존재하지 않는 리뷰입니다." ),
     IMAGE_INDEX_NOT_FOUND(HttpStatus.BAD_REQUEST, "R02", "요청된 이미지 인덱스가 이미지 파일 수보다 적습니다."),
-    DUPLICATE_DELETE_IMAGE_IDS(HttpStatus.BAD_REQUEST,"R03" , "중복된 이미지 삭제 ID가 존재합니다.");
+    DUPLICATE_DELETE_IMAGE_IDS(HttpStatus.BAD_REQUEST,"R03" , "중복된 이미지 삭제 ID가 존재합니다."),
 
+    // 검색어
+    SEARCH_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "K001", "해당 검색 기록을 찾을 수 없습니다."),
+    SEARCH_KEYWORD_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "K002", "검색 기록 삭제에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/swyp/dessertbee/common/repository/UserSearchHistoryRepository.java
+++ b/src/main/java/org/swyp/dessertbee/common/repository/UserSearchHistoryRepository.java
@@ -31,10 +31,10 @@ public interface UserSearchHistoryRepository extends JpaRepository<UserSearchHis
     @Modifying
     @Transactional
     @Query("DELETE FROM UserSearchHistory h WHERE h.userId = :userId AND h.id = :searchId")
-    void deleteByUserIdAndId(Long userId, Long searchId);
+    int deleteByUserIdAndId(Long userId, Long searchId);
 
     @Modifying
     @Transactional
     @Query("DELETE FROM UserSearchHistory h WHERE h.userId = :userId")
-    void deleteByUserId(Long userId);
+    int deleteByUserId(Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/common/repository/UserSearchHistoryRepository.java
+++ b/src/main/java/org/swyp/dessertbee/common/repository/UserSearchHistoryRepository.java
@@ -27,4 +27,14 @@ public interface UserSearchHistoryRepository extends JpaRepository<UserSearchHis
     @Transactional
     @Query("DELETE FROM UserSearchHistory h WHERE h.userId = :userId AND h.id NOT IN :searchIds")
     void deleteByUserIdAndIdNotIn(Long userId, List<Long> searchIds);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM UserSearchHistory h WHERE h.userId = :userId AND h.id = :searchId")
+    void deleteByUserIdAndId(Long userId, Long searchId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM UserSearchHistory h WHERE h.userId = :userId")
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
@@ -92,13 +92,15 @@ public class SearchService {
     }
 
     @Transactional
-    public void deleteRecentSearch(Long userId, Long searchId) {
-        searchHistoryRepository.deleteByUserIdAndId(userId, searchId);
+    public boolean deleteRecentSearch(Long userId, Long searchId) {
+        int deletedCount = searchHistoryRepository.deleteByUserIdAndId(userId, searchId);
+        return deletedCount > 0;
     }
 
     @Transactional
-    public void deleteAllRecentSearches(Long userId) {
-        searchHistoryRepository.deleteByUserId(userId);
+    public boolean deleteAllRecentSearches(Long userId) {
+        int deletedCount = searchHistoryRepository.deleteByUserId(userId);
+        return deletedCount > 0;
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.swyp.dessertbee.common.dto.PopularSearchResponse;
+import org.swyp.dessertbee.common.dto.UserSearchHistoryDto;
 import org.swyp.dessertbee.common.entity.PopularSearchKeyword;
 import org.swyp.dessertbee.common.entity.UserSearchHistory;
 import org.swyp.dessertbee.common.repository.PopularSearchKeywordRepository;
@@ -79,15 +80,25 @@ public class SearchService {
     }
 
     /** 최근 검색어 조회 */
-    public List<String> getRecentSearches(Long userId) {
+    public List<UserSearchHistoryDto> getRecentSearches(Long userId) {
         if (userId == null) {
             return Collections.emptyList(); // 로그인되지 않은 경우 빈 리스트 반환
         }
 
         return searchHistoryRepository.findTop10ByUserIdOrderByCreatedAtDesc(userId)
                 .stream()
-                .map(UserSearchHistory::getKeyword)
+                .map(UserSearchHistoryDto::fromEntity)
                 .toList();
+    }
+
+    @Transactional
+    public void deleteRecentSearch(Long userId, Long searchId) {
+        searchHistoryRepository.deleteByUserIdAndId(userId, searchId);
+    }
+
+    @Transactional
+    public void deleteAllRecentSearches(Long userId) {
+        searchHistoryRepository.deleteByUserId(userId);
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
@@ -26,4 +26,7 @@ public interface StoreReviewRepository extends JpaRepository<StoreReview, Long> 
 
     @Query("SELECT r.reviewId FROM StoreReview r WHERE r.reviewUuid = :reviewUuid")
     Long findReviewIdByReviewUuid(@Param("reviewUuid") UUID reviewUuid);
+
+    @Query("SELECT COUNT(r) FROM StoreReview r WHERE r.storeId = :storeId AND r.deletedAt IS NULL")
+    int countByStoreIdAndDeletedAtIsNull(@Param("storeId") Long storeId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/UserStoreController.java
@@ -9,10 +9,9 @@ import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.store.store.dto.response.SavedStoreResponse;
+import org.swyp.dessertbee.store.store.dto.response.StoreListLocationResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListSimpleResponse;
-import org.swyp.dessertbee.store.store.entity.SavedStore;
-import org.swyp.dessertbee.store.store.entity.UserStoreList;
 import org.swyp.dessertbee.store.store.service.UserStoreService;
 
 import java.util.List;
@@ -82,6 +81,14 @@ public class UserStoreController {
         } catch (IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.INVALID_STORE_UUID);
         }
+    }
+
+    /** 리스트별 저장된 가게 위치 조회 */
+    @Operation(summary = "저장 리스트 내 가게 위치 조회", description = "특정 리스트에 저장된 가게들의 storeId, name, latitude, longitude, listId, iconColorId를 반환합니다.")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
+    @GetMapping("/lists/{listId}/stores/locations")
+    public ResponseEntity<List<StoreListLocationResponse>> getStoresByListId(@PathVariable Long listId) {
+        return ResponseEntity.ok(userStoreService.getStoresByListId(listId));
     }
 
     /** 리스트별 저장된 가게 조회 */

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/SavedStoreResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/SavedStoreResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -17,6 +18,8 @@ public class SavedStoreResponse {
     private String listName;
     private String storeName;
     private String storeAddress;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
     private List<String> imageUrls;
     private List<Long> userPreferences;
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreListLocationResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreListLocationResponse.java
@@ -1,0 +1,17 @@
+package org.swyp.dessertbee.store.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+public class StoreListLocationResponse {
+    private Long listId;
+    private Long iconColorId;
+    private Long storeId;
+    private String name;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreMapResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreMapResponse.java
@@ -20,11 +20,11 @@ public class StoreMapResponse {
     private Double latitude;
     private Double longitude;
     private List<StoreOperatingHour> operatingHours; // 운영 시간
-    private int totalReviewCount; // 총 리뷰 수
+    private int shortReviewCount; // 한줄 리뷰 개수
     private List<String> tags; // 태그 리스트
     private String storeImage; // 대표 이미지 (첫 번째 이미지)
 
-    public static StoreMapResponse fromEntity(Store store, List<StoreOperatingHour> operatingHours, int totalReviewCount, List<String> tags, List<String> storeImages) {
+    public static StoreMapResponse fromEntity(Store store, List<StoreOperatingHour> operatingHours, int shortReviewCount, List<String> tags, List<String> storeImages) {
         return StoreMapResponse.builder()
                 .storeId(store.getStoreId())
                 .storeUuid(store.getStoreUuid())
@@ -33,7 +33,7 @@ public class StoreMapResponse {
                 .latitude(store.getLatitude().doubleValue())
                 .longitude(store.getLongitude().doubleValue())
                 .operatingHours(operatingHours)
-                .totalReviewCount(totalReviewCount)
+                .shortReviewCount(shortReviewCount)
                 .tags(tags)
                 .storeImage(storeImages != null && !storeImages.isEmpty() ? storeImages.get(0) : null)
                 .build();

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreMapResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreMapResponse.java
@@ -4,7 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import org.swyp.dessertbee.store.store.entity.Store;
+import org.swyp.dessertbee.store.store.entity.StoreOperatingHour;
 
+import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -17,8 +19,12 @@ public class StoreMapResponse {
     private String address;
     private Double latitude;
     private Double longitude;
+    private List<StoreOperatingHour> operatingHours; // 운영 시간
+    private int totalReviewCount; // 총 리뷰 수
+    private List<String> tags; // 태그 리스트
+    private String storeImage; // 대표 이미지 (첫 번째 이미지)
 
-    public static StoreMapResponse fromEntity(Store store) {
+    public static StoreMapResponse fromEntity(Store store, List<StoreOperatingHour> operatingHours, int totalReviewCount, List<String> tags, List<String> storeImages) {
         return StoreMapResponse.builder()
                 .storeId(store.getStoreId())
                 .storeUuid(store.getStoreUuid())
@@ -26,6 +32,10 @@ public class StoreMapResponse {
                 .address(store.getAddress())
                 .latitude(store.getLatitude().doubleValue())
                 .longitude(store.getLongitude().doubleValue())
+                .operatingHours(operatingHours)
+                .totalReviewCount(totalReviewCount)
+                .tags(tags)
+                .storeImage(storeImages != null && !storeImages.isEmpty() ? storeImages.get(0) : null)
                 .build();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.store.store.dto.response.StoreListLocationResponse;
 import org.swyp.dessertbee.store.store.entity.SavedStore;
 import org.swyp.dessertbee.store.store.entity.Store;
 import org.swyp.dessertbee.store.store.entity.UserStoreList;
@@ -16,6 +17,17 @@ import java.util.Optional;
 public interface SavedStoreRepository extends JpaRepository<SavedStore, Long> {
     List<SavedStore> findByUserStoreList(UserStoreList userStoreList);
     Optional<SavedStore> findByUserStoreListAndStore(UserStoreList userStoreList, Store store);
+
+    @Query("""
+        SELECT new org.swyp.dessertbee.store.store.dto.response.StoreListLocationResponse(
+            usl.id, usl.iconColorId, s.storeId, s.name, s.latitude, s.longitude
+        )
+        FROM SavedStore ss
+        JOIN ss.userStoreList usl
+        JOIN ss.store s
+        WHERE usl.id = :listId
+    """)
+    List<StoreListLocationResponse> findStoresByListId(Long listId);
 
     /** 여러 저장 리스트에 포함된 모든 가게 조회 */
     List<SavedStore> findByUserStoreListIn(List<UserStoreList> userStoreLists);

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/StoreTagRelationRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/StoreTagRelationRepository.java
@@ -18,8 +18,8 @@ public interface StoreTagRelationRepository extends JpaRepository<StoreTagRelati
     List<StoreTagRelation> findByStore(Store store);
 
     // 가게 ID를 기반으로 태그 목록 조회
-    @Query("SELECT t.name FROM StoreTagRelation str JOIN str.tag t WHERE str.store.storeUuid = :storeUuid")
-    List<String> findTagNamesByStoreId(@Param("storeUuid") UUID storeUuid);
+    @Query("SELECT t.name FROM StoreTagRelation str JOIN str.tag t WHERE str.store.storeId = :storeId")
+    List<String> findTagNamesByStoreId(@Param("storeId") Long storeId);
 
     @Transactional
     @Modifying

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -58,7 +58,6 @@ public class StoreService {
     private final SavedStoreRepository savedStoreRepository;
     private final MateCategoryRepository mateCategoryRepository;
     private final MateRepository mateRepository;
-    private final PreferenceRepository preferenceRepository;
     private final ImageService imageService;
     private final MenuService menuService;
     private final UserRepository userRepository;
@@ -188,7 +187,7 @@ public class StoreService {
         List<Store> stores = storeRepository.findStoresByLocation(lat, lng, radius);
 
         return stores.stream()
-                .map(StoreMapResponse::fromEntity)
+                .map(this::convertToStoreMapResponse)
                 .collect(Collectors.toList());
     }
 
@@ -202,7 +201,7 @@ public class StoreService {
         List<Store> stores = storeRepository.findStoresByLocationAndTags(lat, lng, radius, preferenceTagIds);
 
         return stores.stream()
-                .map(StoreMapResponse::fromEntity)
+                .map(this::convertToStoreMapResponse)
                 .collect(Collectors.toList());
     }
 
@@ -211,7 +210,7 @@ public class StoreService {
         List<Store> stores = storeRepository.findStoresByLocationAndKeyword(lat, lng, radius, searchKeyword);
 
         return stores.stream()
-                .map(StoreMapResponse::fromEntity)
+                .map(this::convertToStoreMapResponse)
                 .collect(Collectors.toList());
     }
 
@@ -236,8 +235,18 @@ public class StoreService {
         List<Store> stores = storeRepository.findStoresByLocationAndTags(lng, lat, radius, preferenceTagIds);
 
         return stores.stream()
-                .map(StoreMapResponse::fromEntity)
+                .map(this::convertToStoreMapResponse)
                 .collect(Collectors.toList());
+    }
+
+    /** Store 엔티티를 StoreMapResponse DTO로 변환 */
+    private StoreMapResponse convertToStoreMapResponse(Store store) {
+        List<StoreOperatingHour> operatingHours = storeOperatingHourRepository.findByStoreId(store.getStoreId()); // 변환 없이 그대로 전달
+        int totalReviewCount = storeReviewRepository.countByStoreIdAndDeletedAtIsNull(store.getStoreId());
+        List<String> tags = storeTagRelationRepository.findTagNamesByStoreId(store.getStoreId());
+        List<String> storeImages = imageService.getImagesByTypeAndId(ImageType.STORE, store.getStoreId());
+
+        return StoreMapResponse.fromEntity(store, operatingHours, totalReviewCount, tags, storeImages);
     }
 
     /** 가게 간략 정보 조회 */
@@ -248,7 +257,7 @@ public class StoreService {
 
         List<String> storeImages = imageService.getImagesByTypeAndId(ImageType.STORE, storeId);
         List<String> ownerPickImages = imageService.getImagesByTypeAndId(ImageType.OWNERPICK, storeId);
-        List<String> tags = storeTagRelationRepository.findTagNamesByStoreId(storeUuid);
+        List<String> tags = storeTagRelationRepository.findTagNamesByStoreId(storeId);
 
         // 운영 시간
         List<StoreOperatingHour> operatingHours = storeOperatingHourRepository.findByStoreId(storeId);
@@ -306,7 +315,7 @@ public class StoreService {
         List<String> ownerPickImages = imageService.getImagesByTypeAndId(ImageType.OWNERPICK, storeId);
 
         // 태그 조회
-        List<String> tags = storeTagRelationRepository.findTagNamesByStoreId(storeUuid);
+        List<String> tags = storeTagRelationRepository.findTagNamesByStoreId(storeId);
 
         // 운영 시간
         List<StoreOperatingHour> operatingHours = storeOperatingHourRepository.findByStoreId(storeId);

--- a/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
@@ -7,9 +7,6 @@ import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.service.ImageService;
-import org.swyp.dessertbee.preference.entity.PreferenceEntity;
-import org.swyp.dessertbee.preference.entity.UserPreferenceEntity;
-import org.swyp.dessertbee.preference.repository.PreferenceRepository;
 import org.swyp.dessertbee.store.store.dto.response.SavedStoreResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListSimpleResponse;
@@ -173,6 +170,8 @@ public class UserStoreService {
                 list.getListName(),
                 store.getName(),
                 store.getAddress(),
+                store.getLatitude(),
+                store.getLongitude(),
                 imageService.getImagesByTypeAndId(ImageType.STORE, store.getStoreId()),
                 savedStore.getUserPreferences()
         );
@@ -193,6 +192,8 @@ public class UserStoreService {
                         .listName(list.getListName())
                         .storeName(savedStore.getStore().getName())
                         .storeAddress(savedStore.getStore().getAddress())
+                        .latitude(savedStore.getStore().getLatitude())
+                        .longitude(savedStore.getStore().getLongitude())
                         .imageUrls(imageService.getImagesByTypeAndId(ImageType.STORE, savedStore.getStore().getStoreId()))
                         .userPreferences(savedStore.getUserPreferences())
                         .build())

--- a/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/UserStoreService.java
@@ -8,6 +8,7 @@ import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.store.store.dto.response.SavedStoreResponse;
+import org.swyp.dessertbee.store.store.dto.response.StoreListLocationResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListResponse;
 import org.swyp.dessertbee.store.store.dto.response.UserStoreListSimpleResponse;
 import org.swyp.dessertbee.store.store.entity.SavedStore;
@@ -175,6 +176,11 @@ public class UserStoreService {
                 imageService.getImagesByTypeAndId(ImageType.STORE, store.getStoreId()),
                 savedStore.getUserPreferences()
         );
+    }
+
+    /** 리스트별 저장된 가게들의 위도, 경도 조회 */
+    public List<StoreListLocationResponse> getStoresByListId(Long listId) {
+        return savedStoreRepository.findStoresByListId(listId);
     }
 
     /** 리스트별 저장된 가게 조회 */


### PR DESCRIPTION
## :hash: 연관된 이슈

> #202 

## :memo: 작업 내용

> 최근 검색어 조회용 dto 생성 (id, 검색날짜 포함)
> 유저별 최근 검색어 개별 삭제 api
> 유저별 최근 검색어 전체 삭제 api
> 저장된 가게 리스트 위도, 경도 필드 추가
> 반경 내 가게 검색 api 응답 데이터 추가 -> operatingHours, totalReviewCount, tags, storeImages(중 첫번째)
> 저장 리스트 내 가게들의 위도, 경도 조회 api 추가

### 스크린샷

<img width="565" alt="image" src="https://github.com/user-attachments/assets/c1fb4a9e-26cd-4b7f-853f-928d73b7d1d5" />

