### PR TITLE
[DOCS] 스웨거 인증 에러 코드 추가

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/annotation/ApiErrorResponses.java
+++ b/src/main/java/org/swyp/dessertbee/common/annotation/ApiErrorResponses.java
@@ -1,4 +1,19 @@
 package org.swyp.dessertbee.common.annotation;
 
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import java.lang.annotation.*;
+
+/**
+ * API 메서드에서 발생할 수 있는 에러 코드들을 명시하는 어노테이션
+ * 이 어노테이션을 사용해 선언된 에러 코드들은 Swagger 문서에 자동으로 에러 응답 예제로 추가됨
+ * 컨트롤러 메서드 위에 달면 됨.
+ *
+ * 사용 예는 아래와 같음.
+ * @ApiErrorResponses({ErrorCode.PASSWORD_MISMATCH, ErrorCode.USER_NOT_FOUND})
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
 public @interface ApiErrorResponses {
+    ErrorCode[] value();
 }

--- a/src/main/java/org/swyp/dessertbee/common/annotation/ApiErrorResponses.java
+++ b/src/main/java/org/swyp/dessertbee/common/annotation/ApiErrorResponses.java
@@ -1,0 +1,4 @@
+package org.swyp.dessertbee.common.annotation;
+
+public @interface ApiErrorResponses {
+}

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -86,6 +86,10 @@ public enum ErrorCode {
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "F004", "지원하지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F005", "파일 크기가 제한을 초과했습니다."),
 
+    // Image
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "I001", "이미지를 찾을 수 없습니다."),
+    IMAGE_REFERENCE_INVALID(HttpStatus.BAD_REQUEST, "I002", "잘못된 이미지 참조 정보입니다."),
+    IMAGE_FETCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "I003", "이미지 조회 중 오류가 발생했습니다."),
 
     //디저트메이트
     MATE_NOT_FOUND(HttpStatus.NOT_FOUND,"M001" ,"존재하지 않는 디저트메이트입니다." ),

--- a/src/main/java/org/swyp/dessertbee/config/SwaggerErrorResponseCustomizer.java
+++ b/src/main/java/org/swyp/dessertbee/config/SwaggerErrorResponseCustomizer.java
@@ -1,0 +1,4 @@
+package org.swyp.dessertbee.config;
+
+public class SwaggerErrorResponseCustomizer {
+}

--- a/src/main/java/org/swyp/dessertbee/config/SwaggerErrorResponseCustomizer.java
+++ b/src/main/java/org/swyp/dessertbee/config/SwaggerErrorResponseCustomizer.java
@@ -1,4 +1,94 @@
 package org.swyp.dessertbee.config;
 
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Swagger 문서의 에러 응답을 커스터마이징하는 설정 클래스
+ * ApiErrorResponses 어노테이션을 처리용도 에러 코드별 응답 예제를 Swagger 문서에 자동으로 추가
+ */
+
+@Configuration
 public class SwaggerErrorResponseCustomizer {
+
+    @Bean
+    public OperationCustomizer errorResponseOperationCustomizer() {
+        return (operation, handlerMethod) -> {
+            ApiErrorResponses annotation = AnnotationUtils.findAnnotation(handlerMethod.getMethod(), ApiErrorResponses.class);
+            if (annotation != null) {
+                for (ErrorCode errorCode : annotation.value()) {
+                    String status = String.valueOf(errorCode.getHttpStatus().value());
+                    ApiResponse response = getOrCreateApiResponse(operation, status);
+                    MediaType mediaType = getOrCreateMediaType(response);
+                    Map<String, Example> examples = getOrCreateExamples(mediaType);
+                    // 에러 코드의 enum 이름을 key로 사용
+                    examples.put(errorCode.name(), createErrorExample(errorCode));
+                }
+            }
+            return operation;
+        };
+    }
+
+    /**
+     * 지정된 상태 코드에 대한 ApiResponse 객체를 가져오거나 새로 생성한다.
+     */
+    private ApiResponse getOrCreateApiResponse(Operation operation, String status) {
+        ApiResponse apiResponse = operation.getResponses().get(status);
+        if (apiResponse == null) {
+            apiResponse = new ApiResponse().description("에러 응답");
+            apiResponse.setContent(new Content());
+            operation.getResponses().addApiResponse(status, apiResponse);
+        }
+        return apiResponse;
+    }
+
+    /**
+     * ApiResponse에서 MediaType 객체를 가져오거나 새로 생성
+     */
+    private MediaType getOrCreateMediaType(ApiResponse response) {
+        Content content = response.getContent();
+        MediaType mediaType = content.get("application/json");
+        if (mediaType == null) {
+            mediaType = new MediaType();
+            content.addMediaType("application/json", mediaType);
+        }
+        return mediaType;
+    }
+
+    /**
+     * MediaType에서 examples 맵을 가져오거나 새로 생성
+     */
+    private Map<String, Example> getOrCreateExamples(MediaType mediaType) {
+        Map<String, Example> examples = mediaType.getExamples();
+        if (examples == null) {
+            examples = new HashMap<>();
+            mediaType.setExamples(examples);
+        }
+        return examples;
+    }
+
+    /**
+     * 에러 코드에 대한 예제 객체를 생성
+     */
+    private Example createErrorExample(ErrorCode errorCode) {
+        Map<String, Object> example = new LinkedHashMap<>();
+        example.put("status", errorCode.getHttpStatus().value());
+        example.put("code", errorCode.getCode());
+        example.put("message", errorCode.getMessage());
+        // API 문서에서는 고정된 예시 값 사용 권장 (여기서는 현재 시간 사용)
+        example.put("timestamp", "2025-03-21T22:28:10.174078");
+        return new Example().value(example);
+    }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,3 +16,10 @@ spring:
 app:    # 추가
   client:    # 추가
     redirect-url: "https://desserbee.com"    # 추가
+springdoc:
+  api-docs:
+    path: /api-docs          # OpenAPI 문서 엔드포인트
+  swagger-ui:
+    path: /swagger-ui         # Swagger UI 접근 경로
+    enabled: true
+    url: https://api.desserbee.com/api-docs


### PR DESCRIPTION
## :hash: 연관된 이슈
#215 
## :memo: 작업 내용
- 에러 코드를 통해서 스웨거에 에러 문서를 삽입할 수 있도록 `ApiErrorResponses ` 생성, `SwaggerErrorResponseCustomizer` 생성
- 이미지 에러 처리 추가 `getImagesByTypeAndId`

### 스크린샷 (선택)
<img width="1095" alt="image" src="https://github.com/user-attachments/assets/4e26dab9-d87a-4581-991d-369337a11f12" />

## :speech_balloon: 리뷰 요구사항(선택)
- 스웨거 문서에 에러 처리하는 방법에 대해서 의문이 있으시다면 알려주세요!
