### PR TITLE
[DOCS] Oauth 스웨거 문서 적용 

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.BadRequestException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
@@ -22,7 +21,6 @@ import org.swyp.dessertbee.auth.service.AuthService;
 import jakarta.validation.Valid;
 import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
 import org.swyp.dessertbee.common.exception.ErrorCode;
-import org.swyp.dessertbee.common.exception.ErrorResponse;
 
 
 @Tag(name = "Authentication", description = "인증 관련 API")
@@ -35,13 +33,7 @@ public class AuthController {
     private final AuthService authService;
 
     @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "회원가입 성공",
-                    content = @Content(schema = @Schema(implementation = LoginResponse.class))
-            ),
-    })
+    @ApiResponse( responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class)))
     @ApiErrorResponses({ErrorCode.PASSWORD_MISMATCH, ErrorCode.DUPLICATE_NICKNAME, ErrorCode.DUPLICATE_EMAIL, ErrorCode.IMAGE_REFERENCE_INVALID, ErrorCode.IMAGE_FETCH_ERROR})
     @PostMapping("/signup")
     public ResponseEntity<LoginResponse> signup(

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -1,5 +1,9 @@
 package org.swyp.dessertbee.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -7,6 +11,8 @@ import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.oauth2.OAuthCodeRequest;
 import org.swyp.dessertbee.auth.service.OAuthService;
+import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 
 /**
  * OAuth 인증을 처리하는 컨트롤러
@@ -23,6 +29,9 @@ public class OAuthController {
     /**
      * OAuth 인가 코드로 로그인 처리 (POST 요청)
      */
+    @Operation(summary = "OAuth 회원가입, 로그인", description = "OAuth로 새로운 사용자 등록 및 로그인")
+    @ApiResponse( responseCode = "200", description = "로그인 및 회원가입 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class)))
+    @ApiErrorResponses({ErrorCode.INVALID_INPUT_VALUE, ErrorCode.AUTHENTICATION_FAILED, ErrorCode.INVALID_PROVIDER, ErrorCode.DUPLICATE_NICKNAME})
     @PostMapping("/callback")
     public ResponseEntity<LoginResponse> oauthCallback(
             @RequestBody OAuthCodeRequest request) {

--- a/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
@@ -116,15 +116,7 @@ public class AuthExceptions {
     /**
      * OAuth 인증 서비스 오류 예외
      */
-    public static class OAuthAuthenticationException extends BusinessException {
-        public OAuthAuthenticationException() {
-            super(ErrorCode.AUTHENTICATION_FAILED);
-        }
 
-        public OAuthAuthenticationException(String message) {
-            super(ErrorCode.AUTHENTICATION_FAILED, message);
-        }
-    }
 
     /**
      * JWT 토큰 오류 예외

--- a/src/main/java/org/swyp/dessertbee/auth/exception/OAuthExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/auth/exception/OAuthExceptions.java
@@ -1,0 +1,28 @@
+package org.swyp.dessertbee.auth.exception;
+
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+
+public class OAuthExceptions {
+
+    public static class InvalidProviderException extends BusinessException {
+        public InvalidProviderException() {
+            super(ErrorCode.INVALID_PROVIDER);
+        }
+
+        public InvalidProviderException(String message) {
+            super(ErrorCode.INVALID_PROVIDER, message);
+        }
+    }
+
+    public static class OAuthAuthenticationException extends BusinessException {
+        public OAuthAuthenticationException() {
+            super(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        public OAuthAuthenticationException(String message) {
+            super(ErrorCode.AUTHENTICATION_FAILED, message);
+        }
+    }
+
+}

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -24,6 +24,8 @@ import org.swyp.dessertbee.role.repository.RoleRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.auth.exception.AuthExceptions.*;
+import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
+
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -8,7 +8,7 @@ import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.enums.AuthProvider;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
-
+import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
 /**
  * OAuth 인증 처리를 담당하는 공통 서비스
  */
@@ -35,23 +35,20 @@ public class OAuthService {
             AuthProvider provider = AuthProvider.fromString(providerName);
 
             if (provider == null) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE,
-                        "지원하지 않는 OAuth 제공자입니다: " + providerName);
+                throw new InvalidProviderException("OAuth 제공자가 입력되지 않았습니다.");
             }
 
             // enum을 사용하여 적절한 서비스 호출
             return switch (provider) {
                 case KAKAO -> kakaoOAuthService.processKakaoLogin(code);
                 // 추후 다른 OAuth 제공자 추가
-                default -> throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE,
-                        "아직 구현되지 않은 OAuth 제공자입니다: " + provider.getProviderName());
+                default -> throw new InvalidProviderException("아직 구현되지 않은 OAuth 제공자입니다: " + provider.getProviderName());
             };
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
             log.error("OAuth 로그인 처리 중 오류 발생 - 제공자: {}", providerName, e);
-            throw new BusinessException(ErrorCode.AUTHENTICATION_FAILED,
-                    "OAuth 로그인 처리 중 오류가 발생했습니다.");
+            throw new OAuthAuthenticationException("OAuth 로그인 처리 중 오류가 발생했습니다.");
         }
     }
 }

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -28,6 +28,9 @@ public enum ErrorCode {
     AUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A008", "인증 서비스 처리 중 오류가 발생했습니다."),
     OAUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A008", "소셜 인증 서비스 처리 중 오류가 발생했습니다."),
 
+    // OAuth
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "O001", "지원되지 않는 OAuth 제공자입니다."),
+
 
     // JWT
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "J001", "유효하지 않은 JWT 서명입니다."),


### PR DESCRIPTION
## :hash: 연관된 이슈
#215 

## :memo: 작업 내용
- OAuth 에러 코드 검토 및 정리
- Swagger 문서에 OAuth 등록 
- Auth Controller에서 쓸모없는 import 제거 및 코드 정리

### 스크린샷 (선택)
<img width="490" alt="image" src="https://github.com/user-attachments/assets/0821dd9c-8081-4552-9d7f-fc82a5c17e0a" />