### PR TITLE
[CHORE] 도커 세팅 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,75 +1,98 @@
-name: Deploy DesserBee Application
+name: Deploy DessertBee Application
 
 on:
   push:
-    branches: [ main, dev ]  # main 또는 dev 브랜치에 푸시될 때만 실행
+    branches: [ main, dev ]
   workflow_dispatch:
 
 jobs:
   build-and-deploy:
-    # 작업 실행 환경 : 깃허브에서 빌드하고 자르파일만 넣기 위함입니다~
     runs-on: ubuntu-latest
 
     steps:
+
+      # GitHub 저장소 코드 체크아웃
       - name: Checkout code
         uses: actions/checkout@v3
+
+      # Java 17 설치
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
+
+      # gradlew에 실행 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
+      # Gradle 빌드
       - name: Build with Gradle
         run: ./gradlew build -x test
 
-      # 빌드된 자르 파일을 EC2 인스턴스로 전송
-      - name: Deploy to EC2
+      # 푸시를 위한 Docker Hub 로그인
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Docker 이미지 빌드 및 푸시
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/dessertbee:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/dessertbee:${{ github.sha }}
+
+      # docker-compose 파일을 EC2 인스턴스로 전송
+      - name: Transfer docker-compose file to EC2
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "build/libs/dessertBee-0.0.1-SNAPSHOT.jar"
-          target: "/home/ec2-user"
-          strip_components: 2  # 경로에서 처음 2개 컴포넌트(build/libs/) 제거하고 파일만 전송
+          source: "docker-compose.prod.yml"
+          target: "/home/ec2-user/app"
 
-      - name: Execute deployment commands
+      # EC2에 SSH 접속 후 Docker 환경 구성 및 애플리케이션 실행
+      - name: Deploy to EC2 and run Docker Compose
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          script: | 
-            # 애플리케이션 중지
-            echo "Stopping application..."
-            sudo systemctl stop myapp.service
-            
-            # 필요한 디렉토리 구조 확인 및 생성
-            if [ ! -d "/home/ec2-user/backend" ]; then
-              echo "Creating backend directory..."
-              mkdir -p /home/ec2-user/backend
+          script: |
+            # Docker 설치
+            if ! command -v docker &> /dev/null; then
+              sudo yum update -y
+              sudo amazon-linux-extras install docker -y
+              sudo systemctl start docker
+              sudo systemctl enable docker
+              sudo usermod -aG docker ec2-user
             fi
-                        
-            # systemd 설정 변경 감지를 위한 데몬 리로드
-            echo "Reloading systemd daemon..."
-            sudo systemctl daemon-reload
-            
-            # 애플리케이션 시작
-            echo "Starting application..."
-            sudo systemctl start myapp.service
-            
-            # 서비스 상태 확인 (로그 목적)
-            echo "Checking service status..."
-            sudo systemctl status myapp.service
-            
-            # 시스템 부팅 시 서비스 자동 시작 설정
-            if ! sudo systemctl is-enabled myapp.service; then
-              echo "Enabling service to start on boot..."
-              sudo systemctl enable myapp.service
+
+            # Docker Compose 설치
+            if ! command -v docker-compose &> /dev/null; then
+              sudo curl -L "https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+              sudo chmod +x /usr/local/bin/docker-compose
+              sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
             fi
-            
-            # 배포 완료 메시지와 타임스탬프 출력
+
+            cd /home/ec2-user/app
+
+            # .env 파일 작성
+            echo "${{ secrets.ENV_PROD }}" > .env
+
+            # Docker Hub 로그인
+            echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+            # Docker 이미지 pull 및 Compose 실행
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/dessertbee:latest
+            docker-compose -f docker-compose.prod.yml down
+            docker-compose -f docker-compose.prod.yml up -d
+
             echo "Deployment completed at $(date)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# 빌드 스테이지
+FROM gradle:8.6-jdk17 AS build
+WORKDIR /app
+COPY build.gradle settings.gradle ./
+COPY gradlew gradlew.bat ./
+COPY gradle ./gradle
+COPY src ./src
+RUN ./gradlew build --no-daemon -x test
+
+# 실행 스테이지
+FROM eclipse-temurin:17-jre-jammy
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar desserbeeApp.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "desserbeeApp.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -70,3 +70,6 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+jar {
+    archiveFileName = "desserbeeApp.jar"
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  app:
+    image: your-dockerhub-username/dessertbee:latest  # GitHub Actions에서 자동 치환할 거라서 냅두면 됩니다요
+    container_name: dessertbee-app
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_PORT=6379
+    env_file:
+      - .env
+    depends_on:
+      - redis
+    restart: always
+
+  redis:
+    image: redis:7.0
+    container_name: dessertbee-redis
+    ports:
+      - "6379:6379"
+    restart: always

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import org.swyp.dessertbee.common.exception.ErrorCode;
  * OAuth 인증을 처리하는 컨트롤러
  * 프론트엔드에서 받은 인가 코드로 OAuth 인증 처리
  */
+@Tag(name = "OAuth", description = "소셜 인증 관련 API")
 @RestController
 @RequestMapping("/api/auth/oauth2")
 @RequiredArgsConstructor

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -45,8 +45,6 @@ public enum ErrorCode {
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
-    USER_DELETED(HttpStatus.GONE, "U002", "탈퇴한 사용자입니다."),
-    INVALID_USER_STATUS(HttpStatus.BAD_REQUEST, "U003", "유효하지 않은 사용자 상태입니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "U004", "해당 정보에 대한 접근 권한이 없습니다."),
     INVALID_USER_UUID(HttpStatus.BAD_REQUEST, "U005", "유효하지 않은 사용자 식별자입니다."),
 
@@ -90,7 +88,6 @@ public enum ErrorCode {
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F005", "파일 크기가 제한을 초과했습니다."),
 
     // Image
-    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "I001", "이미지를 찾을 수 없습니다."),
     IMAGE_REFERENCE_INVALID(HttpStatus.BAD_REQUEST, "I002", "잘못된 이미지 참조 정보입니다."),
     IMAGE_FETCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "I003", "이미지 조회 중 오류가 발생했습니다."),
 


### PR DESCRIPTION
## :hash: 연관된 이슈
#171 

## :memo: 작업 내용
- 기존 systemd + JAR 배포에서 Docker 기반 배포 방식으로 전환
- Gradle 빌드 → Docker 이미지 빌드 & 푸시 → EC2 배포
- .env 파일은 GitHub Secrets(ENV_PROD)에서 자동 생성
- EC2에선 docker-compose.prod.yml로 앱 + Redis 컨테이너 실행
## :speech_balloon: 리뷰 요구사항(선택)
- 도커/컴포즈 구성 방식에서 개선점 있으면 피드백 부탁드립니다.
- workflow의 처리나 배포 과정 중 불필요한 부분이 있을까요?