### PR TITLE
[FIX] 검색 스케줄러 별도 처리

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/SearchService.java
@@ -38,4 +38,7 @@ public interface SearchService {
      * Redis 인기 검색어 데이터 초기화 (테스트용)
      */
     void clearPopularSearchCache();
+
+    void syncPopularSearchesToDB();                // 1분 동기화용
+    void midnightSyncPopularSearchesToDB();        // 자정 동기화용
 }

--- a/src/main/java/org/swyp/dessertbee/common/service/SearchServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/SearchServiceImpl.java
@@ -239,8 +239,7 @@ public class SearchServiceImpl implements SearchService {
     /**
      * 1분마다 MySQL에 Redis 데이터 동기화 (초기화 X)
      */
-    @Scheduled(fixedRate = 60000)
-    private void syncPopularSearchesToDB() {
+    public void syncPopularSearchesToDB() {
         try{
             // 자정 동기화 중이라면 실행하지 않음
             if (Boolean.TRUE.equals(redisTemplate.hasKey(SYNC_LOCK_KEY))) {
@@ -313,8 +312,7 @@ public class SearchServiceImpl implements SearchService {
     /**
      * 매일 자정 MySQL로 데이터 이전 후 Redis 초기화
      */
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    private void midnightSyncPopularSearchesToDB() {
+    public void midnightSyncPopularSearchesToDB() {
         log.info("자정 인기 검색어 백업 및 초기화 시작");
 
         // 락 설정

--- a/src/main/java/org/swyp/dessertbee/common/util/SearchScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/common/util/SearchScheduler.java
@@ -1,0 +1,23 @@
+package org.swyp.dessertbee.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.swyp.dessertbee.common.service.SearchService;
+
+@Service
+@RequiredArgsConstructor
+public class SearchScheduler {
+
+    private final SearchService searchService;
+
+    @Scheduled(fixedRate = 60000)
+    public void syncPopularSearchesToDB() {
+        searchService.syncPopularSearchesToDB();
+    }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void midnightSyncPopularSearchesToDB() {
+        searchService.midnightSyncPopularSearchesToDB();
+    }
+}


### PR DESCRIPTION
## :hash: 연관된 이슈

> #235 

## :memo: 작업 내용

> SearchScheduler 클래스 추가
> SearchServiceImpl의 동기화 메서드 범위를 public으로 변경
> SearchService에 동기화 메서드 구현체 추가
