### PR TITLE
[HOTFIX] 엔진엑스 설정에 스웨거 문서 경로 명시적 허용

### DIFF
--- a/nginx/conf/default.conf.template
+++ b/nginx/conf/default.conf.template
@@ -12,6 +12,22 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+    location /swagger-ui/ {
+        proxy_pass http://app:8080/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api-docs/ {
+        proxy_pass http://app:8080/api-docs/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # 모든 요청에 대한 처리
     location / {
         # Spring Boot 애플리케이션으로 요청 프록시

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,8 @@ springdoc:
   swagger-ui:
     path: /swagger-ui               # Swagger UI 경로 변경
     enabled: true                    # Swagger UI 활성화
+  paths-to-match:
+    - /api/** # /api/로 시작하는 모든 컨트롤러 엔드포인트가 Swagger 문서에 포함
 
 aws:
   s3:


### PR DESCRIPTION
## :memo: 작업 내용
- 엔진엑스에 스웨거 문서 경로 추가
- paths-to-match 설정 추가 