### PR TITLE
chore : 엔진엑스 스웨거 경로 제거, 스웨거 config에 prod 경로 대신 release경로 대치

### DIFF
--- a/nginx/conf/default.conf.template
+++ b/nginx/conf/default.conf.template
@@ -12,22 +12,6 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    location /swagger-ui/ {
-        proxy_pass http://app:8080/swagger-ui/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location /api-docs/ {
-        proxy_pass http://app:8080/api-docs/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     # 모든 요청에 대한 처리
     location / {
         # Spring Boot 애플리케이션으로 요청 프록시

--- a/src/main/java/org/swyp/dessertbee/config/SwaggerConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SwaggerConfig.java
@@ -41,10 +41,10 @@ public class SwaggerConfig {
                         .addSecuritySchemes("bearerAuth", securityScheme));
 
         // 프로덕션 환경에서만 서버 URL 설정 추가
-        if ("prod".equals(activeProfile) || "production".equals(activeProfile)) {
+        if ("release".equals(activeProfile)) {
             Server server = new Server();
-            server.setUrl("https://api.desserbee.com");
-            server.setDescription("Production Server");
+            server.setUrl("https://release.desserbee.com");
+            server.setDescription("Release Server");
             openAPI.servers(List.of(server));
         }
 


### PR DESCRIPTION
## :memo: 작업 내용
- 엔진엑스 스웨거 설정 제거
- swagger config 에서 기존 prod 환경에서 작동하던 주소를 release용으로 변경