### PR TITLE
fix : trailing slash가 /api-docs 에러 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,7 @@ springdoc:
   swagger-ui:
     path: /swagger-ui               # Swagger UI 경로 변경
     enabled: true                    # Swagger UI 활성화
+    url: /api-docs
   paths-to-match:
     - /api/** # /api/로 시작하는 모든 컨트롤러 엔드포인트가 Swagger 문서에 포함
 


### PR DESCRIPTION
## :memo: 작업 내용
<img width="832" alt="image" src="https://github.com/user-attachments/assets/0f27d367-b417-403e-8fab-887a6d426280" />
- api-docs로 요청해도 -> api-docs/ 로 뒤에 슬래쉬를 강제로 달아버림.
- yml 설정에서 api-docs를 호출하도록 명시