### PR TITLE
[FIX] 디바이스 ID 발급을 통한 토큰 갱신 에러 처리

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -153,7 +153,7 @@ public class AuthController {
             }
     )
     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공", content = @Content(schema = @Schema(implementation = TokenResponse.class)))
-    @ApiErrorResponses({ErrorCode.INVALID_CREDENTIALS, ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.EXPIRED_VERIFICATION_TOKEN})
+    @ApiErrorResponses({ErrorCode.INVALID_CREDENTIALS, ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.EXPIRED_VERIFICATION_TOKEN, ErrorCode.DEVICE_ID_MISSING})
     @PostMapping("/token/refresh")
     public ResponseEntity<TokenResponse> refreshToken(
             @Parameter(description = "리프레시 토큰 (Bearer 형식)", required = true)

--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -38,12 +40,14 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<LoginResponse> signup(
             @RequestHeader("X-Email-Verification-Token") String verificationToken,
-            @Valid @RequestBody SignUpRequest request
+            @Valid @RequestBody SignUpRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse
     ) {
         log.debug("회원가입 요청: {}", request.getEmail());
 
         // 회원가입 처리
-        LoginResponse signupResponse = authService.signup(request, verificationToken);
+        LoginResponse signupResponse = authService.signup(request, verificationToken, httpRequest, httpResponse);
         return ResponseEntity.ok(signupResponse);
     }
 
@@ -54,9 +58,11 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(
             @Parameter(description = "로그인 정보", required = true)
-            @Valid @RequestBody LoginRequest request
+            @Valid @RequestBody LoginRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse
     ) {
-        LoginResponse loginResponse = authService.login(request);
+        LoginResponse loginResponse = authService.login(request, httpRequest, httpResponse);
         return ResponseEntity.ok(loginResponse);
     }
 
@@ -65,10 +71,13 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(
             @Parameter(description = "JWT 액세스 토큰", required = true)
-            @RequestHeader("Authorization") String authHeader) {
+            @RequestHeader("Authorization") String authHeader,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse
+    ) {
         // Bearer 접두사 제거
         String accessToken = authHeader.substring(7);
-        LogoutResponse logoutResponse = authService.logout(accessToken);
+        LogoutResponse logoutResponse = authService.logout(accessToken, httpRequest, httpResponse);
 
         return ResponseEntity.ok(logoutResponse);
     }
@@ -93,13 +102,15 @@ public class AuthController {
     @PostMapping("/token/refresh")
     public ResponseEntity<TokenResponse> refreshToken(
             @Parameter(description = "리프레시 토큰 (Bearer 형식)", required = true)
-            @RequestHeader("Authorization") String authHeader) {
+            @RequestHeader("Authorization") String authHeader,
+            HttpServletRequest httpRequest
+    ) {
 
         // Bearer 접두사 제거하여 토큰만 추출
         String refreshToken = authHeader.substring(7);
         log.debug("리프레시 토큰 추출 성공");
 
-        TokenResponse tokenResponse = authService.refreshAccessToken(refreshToken);
+        TokenResponse tokenResponse = authService.refreshAccessToken(refreshToken, httpRequest);
         return ResponseEntity.ok(tokenResponse);
     }
 
@@ -115,11 +126,12 @@ public class AuthController {
     @PostMapping("/dev/login")
     public ResponseEntity<LoginResponse> devlogin(
             @Parameter(description = "로그인 정보", required = true)
-            @Valid @RequestBody LoginRequest request
+            @Valid @RequestBody LoginRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse
     ) {
-        LoginResponse loginResponse = authService.devLogin(request);
+        LoginResponse loginResponse = authService.devLogin(request, httpRequest, httpResponse);
         return ResponseEntity.ok(loginResponse);
     }
-
 }
 

--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
     private final AuthService authService;
 
     @Operation(
-            summary = "회원가입",
+            summary = "회원가입 (completed)",
             description = "새로운 사용자를 등록합니다. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
             parameters = {
                     @Parameter(
@@ -70,7 +70,7 @@ public class AuthController {
 
 
     @Operation(
-            summary = "로그인",
+            summary = "로그인 (completed)",
             description = "이메일과 비밀번호로 로그인합니다. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
             parameters = {
                     @Parameter(
@@ -101,7 +101,7 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "로그아웃",
+            summary = "로그아웃 (completed)",
             description = "현재 로그인된 사용자를 로그아웃합니다. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 해당 디바이스의 세션만 종료합니다. 하지만 X-Device-ID 헤더를 전달받지 못한 경우에는 해당 유저가 가지고 있는 모든 리프레시 토큰을 무효화합니다.",
             parameters = {
                     @Parameter(
@@ -133,7 +133,7 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "토큰 재발급",
+            summary = "토큰 재발급 (completed)",
             description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
             parameters = {
                     @Parameter(
@@ -166,7 +166,7 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "DEV 로그인",
+            summary = "DEV 로그인 (completed)",
             description = "개발용 로그인. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
             parameters = {
                     @Parameter(

--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package org.swyp.dessertbee.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,7 +19,6 @@ import org.swyp.dessertbee.auth.dto.TokenResponse;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.logout.LogoutResponse;
-import org.swyp.dessertbee.auth.dto.passwordreset.PasswordResetRequest;
 import org.swyp.dessertbee.auth.dto.signup.SignUpRequest;
 import org.swyp.dessertbee.auth.service.AuthService;
 import jakarta.validation.Valid;
@@ -34,104 +35,202 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
-    @ApiResponse( responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class)))
-    @ApiErrorResponses({ErrorCode.PASSWORD_MISMATCH, ErrorCode.DUPLICATE_NICKNAME, ErrorCode.DUPLICATE_EMAIL, ErrorCode.IMAGE_REFERENCE_INVALID, ErrorCode.IMAGE_FETCH_ERROR})
+    @Operation(
+            summary = "회원가입",
+            description = "새로운 사용자를 등록합니다. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "X-Device-ID",
+                            description = "디바이스 식별자 (앱 환경에서 사용). 없을 경우 서버에서 생성됩니다.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    ),
+                    @Parameter(
+                            name = "deviceId",
+                            description = "디바이스 식별자 쿠키 (웹 환경에서 사용). Nginx에서 X-Device-ID 헤더로 변환됩니다.",
+                            in = ParameterIn.COOKIE,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    )
+            }
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "회원가입 성공",
+            content = @Content(schema = @Schema(implementation = LoginResponse.class)),
+            headers = {
+                    @Header(
+                            name = "Set-Cookie",
+                            description = "디바이스 식별자 쿠키 (웹 환경용)",
+                            schema = @Schema(type = "string", example = "deviceId=abc123; Path=/; HttpOnly; Secure; SameSite=None")
+                    )
+            }
+    )
+    @ApiErrorResponses({ErrorCode.PASSWORD_MISMATCH, ErrorCode.DUPLICATE_NICKNAME, ErrorCode.DUPLICATE_EMAIL})
     @PostMapping("/signup")
     public ResponseEntity<LoginResponse> signup(
             @RequestHeader("X-Email-Verification-Token") String verificationToken,
             @Valid @RequestBody SignUpRequest request,
-            HttpServletRequest httpRequest,
-            HttpServletResponse httpResponse
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) HttpServletResponse httpResponse
     ) {
         log.debug("회원가입 요청: {}", request.getEmail());
-
-        // 회원가입 처리
         LoginResponse signupResponse = authService.signup(request, verificationToken, httpRequest, httpResponse);
         return ResponseEntity.ok(signupResponse);
     }
 
 
-    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
-    @ApiResponse( responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class)))
-    @ApiErrorResponses({ErrorCode.PASSWORD_MISMATCH, ErrorCode.IMAGE_REFERENCE_INVALID, ErrorCode.IMAGE_FETCH_ERROR, ErrorCode.USER_NOT_FOUND})
+    @Operation(
+            summary = "로그인",
+            description = "이메일과 비밀번호로 로그인합니다. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "X-Device-ID",
+                            description = "디바이스 식별자 (앱 환경에서 사용). 없을 경우 서버에서 생성됩니다.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    ),
+                    @Parameter(
+                            name = "deviceId",
+                            description = "디바이스 식별자 쿠키 (웹 환경에서 사용). Nginx에서 X-Device-ID 헤더로 변환됩니다.",
+                            in = ParameterIn.COOKIE,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    )
+            }
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그인 성공",
+            content = @Content(schema = @Schema(implementation = LoginResponse.class)),
+            headers = {
+                    @Header(
+                            name = "Set-Cookie",
+                            description = "디바이스 식별자 쿠키 (웹 환경용)",
+                            schema = @Schema(type = "string", example = "deviceId=abc123; Path=/; HttpOnly; Secure; SameSite=None")
+                    )
+            }
+    )
+    @ApiErrorResponses({ErrorCode.PASSWORD_MISMATCH, ErrorCode.USER_NOT_FOUND})
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(
-            @Parameter(description = "로그인 정보", required = true)
-            @Valid @RequestBody LoginRequest request,
-            HttpServletRequest httpRequest,
-            HttpServletResponse httpResponse
+            @Parameter(description = "로그인 정보", required = true) @Valid @RequestBody LoginRequest request,
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) HttpServletResponse httpResponse
     ) {
         LoginResponse loginResponse = authService.login(request, httpRequest, httpResponse);
         return ResponseEntity.ok(loginResponse);
     }
 
-    @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃합니다.")
-    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 로그인된 사용자를 로그아웃합니다. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 해당 디바이스의 세션만 종료합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "X-Device-ID",
+                            description = "디바이스 식별자 (앱 환경에서 사용)",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    ),
+                    @Parameter(
+                            name = "deviceId",
+                            description = "디바이스 식별자 쿠키 (웹 환경에서 사용). Nginx에서 X-Device-ID 헤더로 변환됩니다.",
+                            in = ParameterIn.COOKIE,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    )
+            }
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그아웃 성공",
+            headers = {
+                    @Header(
+                            name = "Set-Cookie",
+                            description = "디바이스 식별자 쿠키 삭제 (웹 환경용)",
+                            schema = @Schema(type = "string", example = "deviceId=; Path=/; HttpOnly; Secure; Max-Age=0")
+                    )
+            }
+    )
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(
             @Parameter(description = "JWT 액세스 토큰", required = true)
             @RequestHeader("Authorization") String authHeader,
-            HttpServletRequest httpRequest,
-            HttpServletResponse httpResponse
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) HttpServletResponse httpResponse
     ) {
-        // Bearer 접두사 제거
         String accessToken = authHeader.substring(7);
         LogoutResponse logoutResponse = authService.logout(accessToken, httpRequest, httpResponse);
-
         return ResponseEntity.ok(logoutResponse);
     }
 
-    @Operation(summary = "비밀번호 재설정", description = "이메일 인증 후 비밀번호를 재설정합니다.")
-    @ApiResponse(responseCode = "200", description = "비밀번호 재설정 성공")
-    @ApiErrorResponses({ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.INVALID_VERIFICATION_TOKEN})
-    @PostMapping("/password/reset")
-    public ResponseEntity<?> resetPassword(
-            @Parameter(description = "이메일 인증 토큰", required = true)
-            @RequestHeader("X-Email-Verification-Token") String verificationToken,
-            @Parameter(description = "비밀번호 재설정 정보", required = true)
-            @Valid @RequestBody PasswordResetRequest request
-    ) {
-        authService.resetPassword(request, verificationToken);
-        return ResponseEntity.ok().build();
-    }
-
-    @Operation(summary = "토큰 재발급", description = "Authorization 헤더의 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
+    @Operation(
+            summary = "토큰 재발급",
+            description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "X-Device-ID",
+                            description = "디바이스 식별자 (앱 환경에서 사용)",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    ),
+                    @Parameter(
+                            name = "deviceId",
+                            description = "디바이스 식별자 쿠키 (웹 환경에서 사용). Nginx에서 X-Device-ID 헤더로 변환됩니다.",
+                            in = ParameterIn.COOKIE,
+                            schema = @Schema(type = "string"),
+                            required = true
+                    )
+            }
+    )
     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공", content = @Content(schema = @Schema(implementation = TokenResponse.class)))
     @ApiErrorResponses({ErrorCode.INVALID_CREDENTIALS, ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.EXPIRED_VERIFICATION_TOKEN})
     @PostMapping("/token/refresh")
     public ResponseEntity<TokenResponse> refreshToken(
             @Parameter(description = "리프레시 토큰 (Bearer 형식)", required = true)
             @RequestHeader("Authorization") String authHeader,
-            HttpServletRequest httpRequest
+            @Parameter(hidden = true) HttpServletRequest httpRequest
     ) {
-
-        // Bearer 접두사 제거하여 토큰만 추출
         String refreshToken = authHeader.substring(7);
-        log.debug("리프레시 토큰 추출 성공");
-
         TokenResponse tokenResponse = authService.refreshAccessToken(refreshToken, httpRequest);
         return ResponseEntity.ok(tokenResponse);
     }
 
-    @Operation(summary = "DEV 로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @Operation(
+            summary = "DEV 로그인",
+            description = "개발용 로그인. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "X-Device-ID",
+                            description = "디바이스 식별자 (앱 환경에서 사용)",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    ),
+                    @Parameter(
+                            name = "deviceId",
+                            description = "디바이스 식별자 쿠키 (웹 환경에서 사용)",
+                            in = ParameterIn.COOKIE,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    )
+            }
+    )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "로그인 성공",
-                    content = @Content(schema = @Schema(implementation = LoginResponse.class))
-            ),
+            @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PostMapping("/dev/login")
     public ResponseEntity<LoginResponse> devlogin(
-            @Parameter(description = "로그인 정보", required = true)
-            @Valid @RequestBody LoginRequest request,
-            HttpServletRequest httpRequest,
-            HttpServletResponse httpResponse
+            @Parameter(description = "로그인 정보", required = true) @Valid @RequestBody LoginRequest request,
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) HttpServletResponse httpResponse
     ) {
         LoginResponse loginResponse = authService.devLogin(request, httpRequest, httpResponse);
         return ResponseEntity.ok(loginResponse);
     }
 }
-

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -3,13 +3,10 @@ package org.swyp.dessertbee.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -56,28 +53,17 @@ public class OAuthController {
                     )
             }
     )
-    @ApiResponse(
-            responseCode = "200",
-            description = "로그인 및 회원가입 성공",
-            content = @Content(schema = @Schema(implementation = LoginResponse.class)),
-            headers = {
-                    @Header(
-                            name = "Set-Cookie",
-                            description = "디바이스 식별자 쿠키 (웹 환경용)",
-                            schema = @Schema(type = "string", example = "deviceId=abc123; Path=/; HttpOnly; Secure; SameSite=None")
-                    )
-            }
-    )
+    @ApiResponse( responseCode = "200", description = "로그인 및 회원가입 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class)))
     @ApiErrorResponses({ErrorCode.INVALID_INPUT_VALUE, ErrorCode.AUTHENTICATION_FAILED, ErrorCode.INVALID_PROVIDER, ErrorCode.DUPLICATE_NICKNAME})
     @PostMapping("/callback")
     public ResponseEntity<LoginResponse> oauthCallback(
             @RequestBody OAuthCodeRequest request,
-            HttpServletRequest httpRequest,
-            HttpServletResponse httpResponse) {
+            @Parameter(hidden = true) @RequestHeader(value = "X-Device-ID", required = false) String deviceId
+            ) {
 
         log.info("OAuth 인가 코드 수신 - 제공자: {}", request.getProvider());
         LoginResponse loginResponse = oAuthService.processOAuthLogin(
-                request.getCode(), request.getProvider(), httpRequest, httpResponse);
+                request.getCode(), request.getProvider(), deviceId);
 
         return ResponseEntity.ok(loginResponse);
     }

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -1,6 +1,9 @@
 package org.swyp.dessertbee.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,8 +36,38 @@ public class OAuthController {
     /**
      * OAuth 인가 코드로 로그인 처리 (POST 요청)
      */
-    @Operation(summary = "OAuth 회원가입, 로그인", description = "OAuth로 새로운 사용자 등록 및 로그인")
-    @ApiResponse( responseCode = "200", description = "로그인 및 회원가입 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class)))
+    @Operation(
+            summary = "OAuth 회원가입, 로그인",
+            description = "OAuth로 새로운 사용자 등록 및 로그인. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "X-Device-ID",
+                            description = "디바이스 식별자 (앱 환경에서 사용). 없을 경우 서버에서 생성됩니다.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    ),
+                    @Parameter(
+                            name = "deviceId",
+                            description = "디바이스 식별자 쿠키 (웹 환경에서 사용). Nginx에서 X-Device-ID 헤더로 변환됩니다.",
+                            in = ParameterIn.COOKIE,
+                            schema = @Schema(type = "string"),
+                            required = false
+                    )
+            }
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그인 및 회원가입 성공",
+            content = @Content(schema = @Schema(implementation = LoginResponse.class)),
+            headers = {
+                    @Header(
+                            name = "Set-Cookie",
+                            description = "디바이스 식별자 쿠키 (웹 환경용)",
+                            schema = @Schema(type = "string", example = "deviceId=abc123; Path=/; HttpOnly; Secure; SameSite=None")
+                    )
+            }
+    )
     @ApiErrorResponses({ErrorCode.INVALID_INPUT_VALUE, ErrorCode.AUTHENTICATION_FAILED, ErrorCode.INVALID_PROVIDER, ErrorCode.DUPLICATE_NICKNAME})
     @PostMapping("/callback")
     public ResponseEntity<LoginResponse> oauthCallback(

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -34,7 +34,7 @@ public class OAuthController {
      * OAuth 인가 코드로 로그인 처리 (POST 요청)
      */
     @Operation(
-            summary = "OAuth 회원가입, 로그인",
+            summary = "OAuth 회원가입, 로그인 (completed)",
             description = "OAuth로 새로운 사용자 등록 및 로그인. 앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.",
             parameters = {
                     @Parameter(

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -36,11 +38,13 @@ public class OAuthController {
     @ApiErrorResponses({ErrorCode.INVALID_INPUT_VALUE, ErrorCode.AUTHENTICATION_FAILED, ErrorCode.INVALID_PROVIDER, ErrorCode.DUPLICATE_NICKNAME})
     @PostMapping("/callback")
     public ResponseEntity<LoginResponse> oauthCallback(
-            @RequestBody OAuthCodeRequest request) {
+            @RequestBody OAuthCodeRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse) {
 
         log.info("OAuth 인가 코드 수신 - 제공자: {}", request.getProvider());
         LoginResponse loginResponse = oAuthService.processOAuthLogin(
-                request.getCode(), request.getProvider());
+                request.getCode(), request.getProvider(), httpRequest, httpResponse);
 
         return ResponseEntity.ok(loginResponse);
     }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/TokenResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/TokenResponse.java
@@ -9,4 +9,5 @@ public class TokenResponse {
     private String accessToken;
     private String tokenType;
     private long expiresIn;
+    private String deviceId;
 }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/login/LoginResponse.java
@@ -26,32 +26,53 @@ public class LoginResponse {
     private String nickname;        // 사용자 닉네임
     private String profileImageUrl; // 프로필 이미지
     private boolean isPreferenceSet; // 사용자 선호도 설정 여부
+    private String deviceId;        // 디바이스 식별자
 
     /**
-     * 로그인 성공 응답 생성
+     * 로그인 성공 응답 생성 (디바이스 ID 포함)
      * @param accessToken JWT 액세스 토큰
-     * @param expiresIn 액세스 토큰 만료 시간 (파라미터 추가됨)
+     * @param refreshToken JWT 리프레시 토큰
+     * @param expiresIn 액세스 토큰 만료 시간
      * @param user 사용자 엔티티
+     * @param profileImageUrl 프로필 이미지 URL
+     * @param deviceId 디바이스 식별자
+     * @param isPreferenceSet 선호도 설정 여부
      * @return 로그인 응답 객체
      */
-    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl, boolean isPreferenceSet) {
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl, String deviceId, boolean isPreferenceSet) {
         return LoginResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .tokenType("Bearer") // 토큰 타입 설정 (추가됨)
-                .expiresIn(expiresIn) // 만료 시간 설정 (추가됨)
+                .tokenType("Bearer")
+                .expiresIn(expiresIn)
                 .userUuid(user.getUserUuid())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileImageUrl(profileImageUrl)
-                .isPreferenceSet(isPreferenceSet) // 선호도 설정 여부
+                .deviceId(deviceId)
+                .isPreferenceSet(isPreferenceSet)
                 .build();
     }
 
     /**
-     * 회원가입을 위한 오버로딩 메서드
+     * 선호도 설정 제외하고 디바이스 ID 포함 응답 생성
+     */
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl, String deviceId) {
+        return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, deviceId, false);
+    }
+
+    /**
+     * 디바이스 ID 없이 선호도 설정 포함
+     */
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl, boolean isPreferenceSet) {
+        return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, null, isPreferenceSet);
+    }
+
+    /**
+     * 디바이스 ID, 선호도 설정 모두 없음
      */
     public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl) {
-        return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, false);
+        return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, null, false);
     }
+
 }

--- a/src/main/java/org/swyp/dessertbee/auth/entity/AuthEntity.java
+++ b/src/main/java/org/swyp/dessertbee/auth/entity/AuthEntity.java
@@ -17,6 +17,10 @@ import java.time.LocalDateTime;
                 @UniqueConstraint(
                         name = "uk_auth_provider_provider_id",
                         columnNames = {"provider", "provider_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_auth_user_provider_device",
+                        columnNames = {"user_id", "provider", "device_id"}
                 )
         }
 )
@@ -40,6 +44,9 @@ public class AuthEntity {
 
     @Column(name = "provider_id", length = 255)
     private String providerId;
+
+    @Column(name = "device_id", length = 64)
+    private String deviceId;
 
     @Column(name = "refresh_token", columnDefinition = "TEXT")
     private String refreshToken;
@@ -71,5 +78,9 @@ public class AuthEntity {
 
     public void updateProviderId(String providerId) {
         this.providerId = providerId;
+    }
+
+    public void updateDeviceId(String deviceId) {
+        this.deviceId = deviceId;
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
@@ -114,11 +114,6 @@ public class AuthExceptions {
     }
 
     /**
-     * OAuth 인증 서비스 오류 예외
-     */
-
-
-    /**
      * JWT 토큰 오류 예외
      */
     public static class JwtTokenException extends BusinessException {
@@ -131,4 +126,16 @@ public class AuthExceptions {
         }
     }
 
+    /**
+     * 디바이스 ID 누락 예외
+     */
+    public static class DeviceIdMissingException extends BusinessException {
+        public DeviceIdMissingException() {
+            super(ErrorCode.DEVICE_ID_MISSING);
+        }
+
+        public DeviceIdMissingException(String message) {
+            super(ErrorCode.DEVICE_ID_MISSING, message);
+        }
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
+++ b/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
@@ -6,8 +6,15 @@ import org.swyp.dessertbee.user.entity.UserEntity;
 
 import java.util.Optional;
 import java.util.List;
+import java.util.UUID;
 
 public interface AuthRepository extends JpaRepository<AuthEntity, Integer> {
+    /**
+     * 사용자와 인증 제공자로 인증 정보 조회
+     * @param user 사용자 엔티티
+     * @param provider 인증 제공자 (예: local, google 등)
+     * @return 해당 조건에 맞는 인증 정보
+     */
     Optional<AuthEntity> findByUserAndProvider(Optional<UserEntity> user, String provider);
 
     /**
@@ -16,4 +23,30 @@ public interface AuthRepository extends JpaRepository<AuthEntity, Integer> {
      * @return 사용자의 모든 인증 정보 목록
      */
     List<AuthEntity> findAllByUser(UserEntity user);
+
+    /**
+     * 사용자, 공급자, 디바이스 ID로 인증 정보 찾기
+     * @param user 사용자 엔티티
+     * @param provider 인증 제공자 (예: local, google 등)
+     * @param deviceId 디바이스 식별자
+     * @return 해당 조건에 맞는 인증 정보
+     */
+    Optional<AuthEntity> findByUserAndProviderAndDeviceId(UserEntity user, String provider, String deviceId);
+
+    /**
+     * 사용자 UUID, 공급자, 디바이스 ID로 인증 정보 찾기
+     * @param userUuid 사용자 UUID
+     * @param provider 인증 제공자
+     * @param deviceId 디바이스 식별자
+     * @return 해당 조건에 맞는 인증 정보
+     */
+    Optional<AuthEntity> findByUser_UserUuidAndProviderAndDeviceId(UUID userUuid, String provider, String deviceId);
+
+    /**
+     * 특정 사용자 및 디바이스의 인증 정보 삭제 (로그아웃 시 사용)
+     * @param userUuid 사용자 UUID
+     * @param provider 인증 제공자
+     * @param deviceId 디바이스 식별자
+     */
+    void deleteByUser_UserUuidAndProviderAndDeviceId(UUID userUuid, String provider, String deviceId);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
+++ b/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
@@ -49,4 +49,12 @@ public interface AuthRepository extends JpaRepository<AuthEntity, Integer> {
      * @param deviceId 디바이스 식별자
      */
     void deleteByUser_UserUuidAndProviderAndDeviceId(UUID userUuid, String provider, String deviceId);
+
+    /**
+     * 사용자와 디바이스 ID로 인증 정보 찾기 (프로바이더에 관계없이)
+     * @param user 사용자 엔티티
+     * @param deviceId 디바이스 식별자
+     * @return 해당 조건에 맞는 인증 정보
+     */
+    Optional<AuthEntity> findByUserAndDeviceId(UserEntity user, String deviceId);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
+++ b/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
@@ -1,6 +1,8 @@
 package org.swyp.dessertbee.auth.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.swyp.dessertbee.auth.entity.AuthEntity;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
@@ -57,4 +59,13 @@ public interface AuthRepository extends JpaRepository<AuthEntity, Integer> {
      * @return 해당 조건에 맞는 인증 정보
      */
     Optional<AuthEntity> findByUserAndDeviceId(UserEntity user, String deviceId);
+
+    /**
+     * 사용자 UUID와 활성 상태로 인증 정보 존재 여부 확인
+     * @param userUuid 사용자 UUID
+     * @param active 활성 상태
+     * @return 존재 여부
+     */
+    @Query("SELECT COUNT(a) > 0 FROM AuthEntity a WHERE a.user.userUuid = :userUuid AND a.active = :active")
+    boolean existsByUserUuidAndActive(@Param("userUuid") UUID userUuid, @Param("active") boolean active);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package org.swyp.dessertbee.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.swyp.dessertbee.auth.dto.login.LoginRequest;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.dto.TokenResponse;
@@ -18,15 +20,20 @@ public interface AuthService {
      * 리프레시 토큰을 저장하거나 업데이트
      * @param userUuid 사용자 uuid
      * @param refreshToken 리프레시 토큰
+     * @param provider 인증 제공자 (local, kakao 등)
+     * @param providerId 제공자별 식별자 (소셜 로그인의 경우)
+     * @param request HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
+     * @param response HTTP 응답 객체 (디바이스 ID 쿠키 설정용)
      */
-    void saveRefreshToken(UUID userUuid, String refreshToken);
+    void saveRefreshToken(UUID userUuid, String refreshToken, String provider, String providerId, HttpServletRequest request, HttpServletResponse response);
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰 발급
      * @param refreshToken 리프레시 토큰
+     * @param request HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
      * @return 새로운 액세스 토큰 응답
      */
-    TokenResponse refreshAccessToken(String refreshToken);
+    TokenResponse refreshAccessToken(String refreshToken, HttpServletRequest request);
 
     /**
      * 리프레시 토큰 무효화 (로그아웃)
@@ -38,20 +45,23 @@ public interface AuthService {
      * 회원가입 처리
      * @param request 회원가입 요청 정보
      * @param verificationToken 이메일 인증 토큰
+     * @param httpRequest HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
+     * @param httpResponse HTTP 응답 객체 (디바이스 ID 쿠키 설정용)
      * @return 회원가입 결과
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
      * @throws DuplicateEmailException 이메일 중복
      */
-    LoginResponse signup(SignUpRequest request, String verificationToken);
-
+    LoginResponse signup(SignUpRequest request, String verificationToken, HttpServletRequest httpRequest, HttpServletResponse httpResponse);
 
     /**
      * 로그인 처리
      * @param request 로그인 요청 정보
+     * @param httpRequest HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
+     * @param httpResponse HTTP 응답 객체 (디바이스 ID 쿠키 설정용)
      * @return 로그인 응답 정보
      * @throws InvalidCredentialsException 잘못된 인증 정보
      */
-    LoginResponse login(LoginRequest request);
+    LoginResponse login(LoginRequest request, HttpServletRequest httpRequest, HttpServletResponse httpResponse);
 
     /**
      * 비밀번호 재설정
@@ -63,11 +73,20 @@ public interface AuthService {
 
     /**
      * 로그아웃 처리
-     * @param token 로그인 요청 정보
+     * @param token 액세스 토큰
+     * @param request HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
+     * @param response HTTP 응답 객체 (디바이스 ID 쿠키 삭제용)
+     * @return 로그아웃 응답 정보
+     */
+    LogoutResponse logout(String token, HttpServletRequest request, HttpServletResponse response);
+
+    /**
+     * 개발 환경용 로그인 처리
+     * @param request 로그인 요청 정보
+     * @param httpRequest HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
+     * @param httpResponse HTTP 응답 객체 (디바이스 ID 쿠키 설정용)
      * @return 로그인 응답 정보
      * @throws InvalidCredentialsException 잘못된 인증 정보
      */
-    LogoutResponse logout(String token);
-
-    LoginResponse devLogin(LoginRequest request);
+    LoginResponse devLogin(LoginRequest request, HttpServletRequest httpRequest, HttpServletResponse httpResponse);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -22,18 +22,15 @@ public interface AuthService {
      * @param refreshToken 리프레시 토큰
      * @param provider 인증 제공자 (local, kakao 등)
      * @param providerId 제공자별 식별자 (소셜 로그인의 경우)
-     * @param request HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
-     * @param response HTTP 응답 객체 (디바이스 ID 쿠키 설정용)
      */
-    void saveRefreshToken(UUID userUuid, String refreshToken, String provider, String providerId, HttpServletRequest request, HttpServletResponse response);
+    String saveRefreshToken(UUID userUuid, String refreshToken, String provider, String providerId, String deviceId);
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰 발급
      * @param refreshToken 리프레시 토큰
-     * @param request HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
      * @return 새로운 액세스 토큰 응답
      */
-    TokenResponse refreshAccessToken(String refreshToken, HttpServletRequest request);
+    TokenResponse refreshAccessToken(String refreshToken, String deviceId);
 
     /**
      * 리프레시 토큰 무효화 (로그아웃)
@@ -45,23 +42,19 @@ public interface AuthService {
      * 회원가입 처리
      * @param request 회원가입 요청 정보
      * @param verificationToken 이메일 인증 토큰
-     * @param httpRequest HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
-     * @param httpResponse HTTP 응답 객체 (디바이스 ID 쿠키 설정용)
      * @return 회원가입 결과
      * @throws InvalidVerificationTokenException 유효하지 않은 인증 토큰
      * @throws DuplicateEmailException 이메일 중복
      */
-    LoginResponse signup(SignUpRequest request, String verificationToken, HttpServletRequest httpRequest, HttpServletResponse httpResponse);
+    LoginResponse signup(SignUpRequest request, String verificationToken, String deviceId);
 
     /**
      * 로그인 처리
      * @param request 로그인 요청 정보
-     * @param httpRequest HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
-     * @param httpResponse HTTP 응답 객체 (디바이스 ID 쿠키 설정용)
      * @return 로그인 응답 정보
      * @throws InvalidCredentialsException 잘못된 인증 정보
      */
-    LoginResponse login(LoginRequest request, HttpServletRequest httpRequest, HttpServletResponse httpResponse);
+    LoginResponse login(LoginRequest request, String deviceId);
 
     /**
      * 비밀번호 재설정
@@ -74,19 +67,15 @@ public interface AuthService {
     /**
      * 로그아웃 처리
      * @param token 액세스 토큰
-     * @param request HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
-     * @param response HTTP 응답 객체 (디바이스 ID 쿠키 삭제용)
      * @return 로그아웃 응답 정보
      */
-    LogoutResponse logout(String token, HttpServletRequest request, HttpServletResponse response);
+    LogoutResponse logout(String token, String deviceId);
 
     /**
      * 개발 환경용 로그인 처리
      * @param request 로그인 요청 정보
-     * @param httpRequest HTTP 요청 객체 (디바이스 ID 쿠키 읽기용)
-     * @param httpResponse HTTP 응답 객체 (디바이스 ID 쿠키 설정용)
      * @return 로그인 응답 정보
      * @throws InvalidCredentialsException 잘못된 인증 정보
      */
-    LoginResponse devLogin(LoginRequest request, HttpServletRequest httpRequest, HttpServletResponse httpResponse);
+    LoginResponse devLogin(LoginRequest request, String deviceId);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -1,5 +1,7 @@
 package org.swyp.dessertbee.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -58,7 +60,7 @@ public class KakaoOAuthService {
      * 인가 코드로 카카오 로그인 처리
      */
     @Transactional
-    public LoginResponse processKakaoLogin(String code) {
+    public LoginResponse processKakaoLogin(String code, HttpServletRequest request, HttpServletResponse response) {
         try {
             log.info("카카오 로그인 처리 시작 - 인가 코드: {}", code);
 
@@ -70,7 +72,7 @@ public class KakaoOAuthService {
             OAuth2Response userInfo = getKakaoUserInfo(accessToken);
             log.info("카카오 사용자 정보 획득 성공 - 이메일: {}", userInfo.getEmail());
             // 3. 사용자 정보로 회원가입/로그인 처리
-            return processUserLogin(userInfo);
+            return processUserLogin(userInfo, request, response);
 
         } catch (Exception e) {
             log.error("카카오 로그인 처리 중 오류 발생", e);
@@ -151,7 +153,7 @@ public class KakaoOAuthService {
     /**
      * OAuth 사용자 정보로 로그인 처리 (회원가입 또는 로그인)
      */
-    private LoginResponse processUserLogin(OAuth2Response oauth2Response) {
+    private LoginResponse processUserLogin(OAuth2Response oauth2Response, HttpServletRequest request, HttpServletResponse response) {
         // 이메일로 사용자 조회
         UserEntity user = userRepository.findByEmail(oauth2Response.getEmail())
                 .orElseGet(() -> registerNewUser(oauth2Response));
@@ -167,12 +169,14 @@ public class KakaoOAuthService {
         String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), keepLoggedIn);
         long expiresIn = jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
 
-        // 리프레시 토큰 저장
+        // 리프레시 토큰 저장 (디바이스 ID 관리 포함)
         tokenService.saveRefreshToken(
                 user.getUserUuid(),
                 refreshToken,
                 oauth2Response.getProvider(),
-                oauth2Response.getProviderId()
+                oauth2Response.getProviderId(),
+                request,
+                response
         );
 
         // 프로필 이미지 조회

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -1,5 +1,7 @@
 package org.swyp.dessertbee.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -7,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.swyp.dessertbee.auth.dto.login.LoginResponse;
 import org.swyp.dessertbee.auth.enums.AuthProvider;
 import org.swyp.dessertbee.common.exception.BusinessException;
-import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
 /**
  * OAuth 인증 처리를 담당하는 공통 서비스
@@ -29,7 +30,7 @@ public class OAuthService {
      * @return 로그인 응답 (JWT 토큰 포함)
      */
     @Transactional
-    public LoginResponse processOAuthLogin(String code, String providerName) {
+    public LoginResponse processOAuthLogin(String code, String providerName, HttpServletRequest request, HttpServletResponse response) {
         try {
             // 문자열을 AuthProvider enum으로 변환
             AuthProvider provider = AuthProvider.fromString(providerName);
@@ -40,7 +41,7 @@ public class OAuthService {
 
             // enum을 사용하여 적절한 서비스 호출
             return switch (provider) {
-                case KAKAO -> kakaoOAuthService.processKakaoLogin(code);
+                case KAKAO -> kakaoOAuthService.processKakaoLogin(code, request, response);
                 // 추후 다른 OAuth 제공자 추가
                 default -> throw new InvalidProviderException("아직 구현되지 않은 OAuth 제공자입니다: " + provider.getProviderName());
             };

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -30,7 +30,7 @@ public class OAuthService {
      * @return 로그인 응답 (JWT 토큰 포함)
      */
     @Transactional
-    public LoginResponse processOAuthLogin(String code, String providerName, HttpServletRequest request, HttpServletResponse response) {
+    public LoginResponse processOAuthLogin(String code, String providerName, String deviceId) {
         try {
             // 문자열을 AuthProvider enum으로 변환
             AuthProvider provider = AuthProvider.fromString(providerName);
@@ -41,7 +41,7 @@ public class OAuthService {
 
             // enum을 사용하여 적절한 서비스 호출
             return switch (provider) {
-                case KAKAO -> kakaoOAuthService.processKakaoLogin(code, request, response);
+                case KAKAO -> kakaoOAuthService.processKakaoLogin(code, deviceId);
                 // 추후 다른 OAuth 제공자 추가
                 default -> throw new InvalidProviderException("아직 구현되지 않은 OAuth 제공자입니다: " + provider.getProviderName());
             };

--- a/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
@@ -195,7 +195,7 @@ public class TokenService {
             // 디바이스 ID 확인
             if (deviceId == null || deviceId.isEmpty()) {
                 log.warn("리프레시 토큰 검증 실패 - 디바이스 ID 없음: {}", email);
-                throw new JwtTokenException(ErrorCode.INVALID_CREDENTIALS, "디바이스 ID가 제공되지 않았습니다.");
+                throw new DeviceIdMissingException();
             }
 
             // 디바이스 ID로 인증 정보 조회

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -23,10 +23,11 @@ public enum ErrorCode {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "A005", "비밀번호가 일치하지 않습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A006", "잘못된 인증 정보입니다."),
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "A007", "인증에 실패했습니다."),
-    SIGNUP_RESTRICTED_DELETED_ACCOUNT(HttpStatus.FORBIDDEN, "A007", "탈퇴한 계정은 30일 이후에 재가입이 가능합니다."),
-    ROLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "U010", "해당 권한으로는 접근이 불가합니다."),
-    AUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A008", "인증 서비스 처리 중 오류가 발생했습니다."),
-    OAUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A008", "소셜 인증 서비스 처리 중 오류가 발생했습니다."),
+    SIGNUP_RESTRICTED_DELETED_ACCOUNT(HttpStatus.FORBIDDEN, "A008", "탈퇴한 계정은 30일 이후에 재가입이 가능합니다."),
+    ROLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "A009", "해당 권한으로는 접근이 불가합니다."),
+    AUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A010", "인증 서비스 처리 중 오류가 발생했습니다."),
+    OAUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A011", "소셜 인증 서비스 처리 중 오류가 발생했습니다."),
+    DEVICE_ID_MISSING(HttpStatus.BAD_REQUEST, "A012", "디바이스 ID가 제공되지 않았습니다."),
 
     // OAuth
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "O001", "지원되지 않는 OAuth 제공자입니다."),

--- a/src/main/java/org/swyp/dessertbee/common/util/CookieUtil.java
+++ b/src/main/java/org/swyp/dessertbee/common/util/CookieUtil.java
@@ -1,31 +1,36 @@
 package org.swyp.dessertbee.common.util;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * 쿠키 관련 유틸리티 클래스
  */
 public class CookieUtil {
 
-    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-    private static final String REFRESH_TOKEN_PATH = "/api/auth/token/refresh";
+    private static final String DEVICE_ID_COOKIE_NAME = "deviceId";
+    private static final String DEVICE_ID_PATH = "/";  // 디바이스 ID는 모든 경로에서 접근 가능하도록 설정
 
     /**
-     * 리프레시 토큰을 HTTP-only 쿠키로 설정
+     * 디바이스 ID를 HTTP-only 쿠키로 설정
      *
      * @param response HTTP 응답 객체
-     * @param refreshToken 리프레시 토큰
+     * @param deviceId 디바이스 ID
      * @param maxAge 쿠키 만료 시간 (초)
      */
-    public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken, long maxAge) {
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+    public static void addDeviceIdCookie(HttpServletResponse response, String deviceId, long maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(DEVICE_ID_COOKIE_NAME, deviceId)
                 .httpOnly(true)        // JavaScript에서 접근 불가능
                 .secure(true)          // HTTPS 환경에서만 전송
-                .sameSite("None")      // 크로스 사이트 요청 허용 (Strict에서 None으로 변경)
+                .sameSite("None")      // 크로스 사이트 요청 허용
                 .domain(".desserbee.com") // 모든 desserbee.com 서브도메인에서 쿠키 공유 가능하도록 설정
-                .path(REFRESH_TOKEN_PATH) // 토큰 갱신 엔드포인트에서만 사용
+                .path(DEVICE_ID_PATH)   // 모든 경로에서 사용 가능
                 .maxAge(maxAge)        // 쿠키 만료 시간 (초)
                 .build();
 
@@ -33,20 +38,48 @@ public class CookieUtil {
     }
 
     /**
-     * 리프레시 토큰 쿠키 삭제
+     * 디바이스 ID 쿠키 삭제
      *
      * @param response HTTP 응답 객체
      */
-    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+    public static void deleteDeviceIdCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(DEVICE_ID_COOKIE_NAME, "")
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("None")        // 크로스 사이트 요청 허용
-                .domain(".desserbee.com") // 모든 desserbee.com 서브도메인에서 쿠키 공유 가능하도록 설정
-                .path(REFRESH_TOKEN_PATH)
+                .sameSite("None")
+                .domain(".desserbee.com")
+                .path(DEVICE_ID_PATH)
                 .maxAge(0)  // 즉시 만료
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    /**
+     * 요청에서 쿠키 가져오기
+     *
+     * @param request HTTP 요청
+     * @param name 쿠키 이름
+     * @return 쿠키 (Optional)
+     */
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * 새로운 디바이스 ID 생성
+     *
+     * @return 생성된 디바이스 ID
+     */
+    public static String generateDeviceId() {
+        return UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -22,6 +22,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.swyp.dessertbee.auth.jwt.JWTFilter;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.swyp.dessertbee.auth.repository.AuthRepository;
 import org.swyp.dessertbee.auth.service.CustomUserDetailsService;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
@@ -39,13 +40,11 @@ import java.util.Collections;
 public class SecurityConfig {
 
     private final JWTUtil jwtUtil;
-
-//    @Value("${spring.graphql.cors.allowed-origins}")
-//    private String corsAllowedOrigins;
+    private final AuthRepository authRepository;
 
     @Bean
     public JWTFilter jwtFilter() {
-        return new JWTFilter(jwtUtil);
+        return new JWTFilter(jwtUtil, authRepository);
     }
 
     @Bean
@@ -87,39 +86,11 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .anonymous(Customizer.withDefaults());
-//        // CORS 설정 추가
-//        http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
         // CORS 설정 비활성화 (NGINX에서 처리)
         http.cors(AbstractHttpConfigurer::disable);
 
         return http.build();
     }
-
-
-//    /**
-//     * CORS 설정
-//     */
-//    @Bean
-//    public CorsConfigurationSource corsConfigurationSource() {
-//        CorsConfiguration configuration = new CorsConfiguration();
-//
-//        // allowedOrigins를 yml 설정값에서 가져와서 설정
-//        String[] origins = corsAllowedOrigins.split(",");
-//        configuration.setAllowedOrigins(Arrays.asList(origins)); // 명시적으로 허용할 도메인 지정
-//
-//        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-//        configuration.setAllowedHeaders(Arrays.asList("Origin", "Content-Type", "Accept", "Authorization", "X-Email-Verification-Token"));
-//        configuration.setAllowCredentials(true); // 쿠키를 포함한 크로스 도메인 요청 허용
-//        configuration.setMaxAge(3600L);
-//
-//        // 노출할 헤더 설정 - Set-Cookie도 포함
-//        configuration.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie","X-Email-Verification-Token"));
-//
-//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-//        source.registerCorsConfiguration("/**", configuration);
-//
-//        return source;
-//    }
 
     /**
      * 비밀번호 인코더 설정

--- a/src/main/java/org/swyp/dessertbee/preference/controller/PreferenceController.java
+++ b/src/main/java/org/swyp/dessertbee/preference/controller/PreferenceController.java
@@ -31,7 +31,7 @@ public class PreferenceController {
      * @return HTTP 200 OK와 함께 선호도 정보 리스트 반환
      * @apiNote GET /api/preferences
      */
-    @Operation(summary = "모든 선호도 조회", description = "시스템에 등록된 모든 선호도 정보를 조회합니다.")
+    @Operation(summary = "모든 선호도 조회 (completed)", description = "시스템에 등록된 모든 선호도 정보를 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "선호도 조회 성공",

--- a/src/main/java/org/swyp/dessertbee/user/controller/MbtiController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/MbtiController.java
@@ -26,7 +26,7 @@ public class MbtiController {
     /**
      * 모든 MBTI 정보를 조회하는 API 엔드포인트
      */
-    @Operation(summary = "모든 MBTI 조회", description = "시스템에 등록된 모든 MBTI 정보를 조회합니다.")
+    @Operation(summary = "모든 MBTI 조회 (completed)", description = "시스템에 등록된 모든 MBTI 정보를 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "MBTI 조회 성공",
@@ -44,7 +44,7 @@ public class MbtiController {
      * 특정 ID의 MBTI 정보를 조회하는 API 엔드포인트
      * @param id MBTI ID
      */
-    @Operation(summary = "ID로 MBTI 조회", description = "특정 ID의 MBTI 정보를 조회합니다.")
+    @Operation(summary = "ID로 MBTI 조회 (completed)", description = "특정 ID의 MBTI 정보를 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "MBTI 조회 성공",
@@ -66,7 +66,7 @@ public class MbtiController {
      * MBTI 유형으로 MBTI 정보를 조회하는 API 엔드포인트
      * @param mbtiType MBTI 유형 문자열
      */
-    @Operation(summary = "유형으로 MBTI 조회", description = "MBTI 유형(예: ENFP, INTJ)으로 MBTI 정보를 조회합니다.")
+    @Operation(summary = "유형으로 MBTI 조회 (completed)", description = "MBTI 유형(예: ENFP, INTJ)으로 MBTI 정보를 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "MBTI 조회 성공",


### PR DESCRIPTION
## :hash: 연관된 이슈
#227 
## :memo: 작업 내용
- 로그아웃 
  - 디바이스 ID 를 명시하지 않았다면 모든 기기의 리프레시 토큰 비활성화
  - JWT 필터를 통해 모든 기기의 리프레시 토큰이 비활성화 되어 있다면 현재 로그인 된 유저의 액세스 토큰이 만료되지 않았더라도 401 에러
  - 디바이스 ID 를 명시한다면 해당 디바이스 ID의 리프레시 토큰만 비활성화, 액세스 토큰은 해당 다비이스의 클라이언트에서 무효화 실시
- 로그인 
  - 로그인 시 디바이스 ID를 전달받지 못한다면 서버에서 생성 후 발급, 
  - 로그인 시 디바이스 ID를 전달받았다면 해당 디바이스의 리프레시 토큰 갱신
- 토큰 갱신
  - 무조건 특정 디바이스 ID를 명시해야 토큰 갱신 가능 
  - 디바이스 ID를 명시하지 않으면 400 에러처리

### 스크린샷 (선택)
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/9a96f98c-7d85-4a1c-8775-69c902eaddb0" />
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/dee4c887-2687-4592-981e-6fe11314e856" />