### PR TITLE
[REFACTOR] 로그인 리팩토링 및 유저 컨트롤러 완료 상태 명시

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -100,7 +100,7 @@ public class AuthController {
             )  @Valid @RequestBody LoginRequest request,
             @Parameter(hidden = true) @RequestHeader(value = "X-Device-ID", required = false) String deviceId
     ) {
-        LoginResponse loginResponse = authService.login(request, deviceId);
+        LoginResponse loginResponse = authService.login(request, deviceId, false);
         return ResponseEntity.ok(loginResponse);
     }
 
@@ -206,7 +206,7 @@ public class AuthController {
             )  @Valid @RequestBody LoginRequest request,
             @Parameter(hidden = true) @RequestHeader(value = "X-Device-ID", required = false) String deviceId
     ) {
-        LoginResponse loginResponse = authService.devLogin(request, deviceId);
+        LoginResponse loginResponse = authService.login(request, deviceId, true);
         return ResponseEntity.ok(loginResponse);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
@@ -74,6 +74,20 @@ public class AuthExceptions {
     }
 
     /**
+     * 비밀번호 불일치 예외
+     */
+    public static class InvalidPasswordException extends BusinessException {
+        public InvalidPasswordException() {
+            super(ErrorCode.INVALID_PASSWORD);
+        }
+
+        public InvalidPasswordException(String message) {
+            super(ErrorCode.INVALID_PASSWORD, message);
+        }
+    }
+
+
+    /**
      * 잘못된 인증 정보 예외
      * 로그인 실패, 인증 실패 등에 사용
      */

--- a/src/main/java/org/swyp/dessertbee/auth/jwt/JWTUtil.java
+++ b/src/main/java/org/swyp/dessertbee/auth/jwt/JWTUtil.java
@@ -36,10 +36,7 @@ public class JWTUtil {
     private final long EMAIL_VERIFICATION_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L;
 
     @Getter
-    private final long SHORT_ACCESS_TOKEN_EXPIRE = 24 * 60 * 60 * 1000L;       // 1일
-    @Getter
-    private final long LONG_ACCESS_TOKEN_EXPIRE = 3 * 24 * 60 * 60 * 1000L;   // 3일
-
+    private final long ACCESS_TOKEN_EXPIRE = 30 * 60 * 1000L;   // 30분
     @Getter
     private final long SHORT_REFRESH_TOKEN_EXPIRE = 10 * 24 * 60 * 60 * 1000L;   // 10일
     @Getter
@@ -68,9 +65,8 @@ public class JWTUtil {
     /**
      * Access Token 생성
      */
-    public String createAccessToken(UUID userUuid, List<String> roles, boolean keepLoggedIn) {
-        long expireTime = keepLoggedIn ? LONG_ACCESS_TOKEN_EXPIRE : SHORT_ACCESS_TOKEN_EXPIRE;
-        return buildToken(TokenType.ACCESS, userUuid, roles, null, null, accessTokenSecretKey, expireTime);
+    public String createAccessToken(UUID userUuid, List<String> roles) {
+        return buildToken(TokenType.ACCESS, userUuid, roles, null, null, accessTokenSecretKey, ACCESS_TOKEN_EXPIRE);
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -52,7 +52,7 @@ public interface AuthService {
      * @return 로그인 응답 정보
      * @throws InvalidCredentialsException 잘못된 인증 정보
      */
-    LoginResponse login(LoginRequest request, String deviceId);
+    LoginResponse login(LoginRequest request, String deviceId, boolean isDev);
 
     /**
      * 비밀번호 재설정
@@ -68,12 +68,4 @@ public interface AuthService {
      * @return 로그아웃 응답 정보
      */
     LogoutResponse logout(String token, String deviceId);
-
-    /**
-     * 개발 환경용 로그인 처리
-     * @param request 로그인 요청 정보
-     * @return 로그인 응답 정보
-     * @throws InvalidCredentialsException 잘못된 인증 정보
-     */
-    LoginResponse devLogin(LoginRequest request, String deviceId);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -200,12 +200,12 @@ public class AuthServiceImpl implements AuthService {
     public LoginResponse devLogin(LoginRequest request, String deviceId) {
         try {
             // 1. 사용자 조회
-            UserEntity user = userService.findUserByEmail(request.getEmail());
+            UserEntity user = userService.findUserByEmail(request.getEmail(), ErrorCode.INVALID_EMAIL);
 
             // 2. 비밀번호 검증
             if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-                log.warn("개발 로그인 실패 - 비밀번호 불일치: {}", request.getEmail());
-                throw new InvalidCredentialsException("비밀번호가 올바르지 않습니다.");
+                log.warn("로그인 실패 - 비밀번호 인증 실패: {}", request.getEmail());
+                throw new InvalidPasswordException();
             }
 
             // 3. 사용자 권한 조회
@@ -237,8 +237,8 @@ public class AuthServiceImpl implements AuthService {
             // 8. 로그인 응답 생성
             return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, usedDeviceId, isPreferenceSet);
 
-        } catch (InvalidCredentialsException e) {
-            log.warn("개발 로그인 실패 - 이메일: {}, 사유: {}", request.getEmail(), e.getMessage());
+        } catch (BusinessException e) {
+            log.warn("로그인 실패 - 이메일: {}, 사유: {}", request.getEmail(), e.getMessage());
             throw e;
         } catch (Exception e) {
             log.error("개발 로그인 처리 중 오류 발생 - 이메일: {}", request.getEmail(), e);

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -26,6 +26,7 @@ import org.swyp.dessertbee.role.service.UserRoleService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.user.service.UserService;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -104,8 +105,7 @@ public class AuthServiceImpl implements AuthService {
             List<String> roles;
             if (request.getRole() == null) {
                 roles = userRoleService.ensureDefaultRole(user);
-            }
-            else {
+            } else {
                 roles = userRoleService.setUserRoles(user, Collections.singletonList(request.getRole()));
             }
 
@@ -117,13 +117,15 @@ public class AuthServiceImpl implements AuthService {
             String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), false);
             long expiresIn = jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
 
-
             // Refresh Token 저장 및 디바이스 ID 처리
             String usedDeviceId = saveRefreshToken(user.getUserUuid(), refreshToken, "local", null, deviceId);
 
             log.info("회원가입 완료 - 이메일: {}", request.getEmail());
 
-            String profileImageUrl = imageService.getImagesByTypeAndId(ImageType.PROFILE, user.getId()).stream().findFirst().orElse(null);
+            String profileImageUrl = imageService.getImagesByTypeAndId(ImageType.PROFILE, user.getId())
+                    .stream()
+                    .findFirst()
+                    .orElse(null);
 
             return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, usedDeviceId);
 
@@ -139,129 +141,87 @@ public class AuthServiceImpl implements AuthService {
     /**
      * 로그인 처리
      * 1. 사용자 인증
-     * 2. JWT 토큰 생성
+     * 2. 권한 확인 및 기본 역할 부여
+     * 3. JWT 토큰 생성
+     * 4. 리프레시 토큰 저장, 프로필 이미지 조회, 선호도 확인 후 응답 생성
+     *
+     * @param request 로그인 요청 정보
+     * @param deviceId 디바이스 ID
+     * @param isDev 개발 환경 로그인 여부
+     * @return 로그인 응답
      */
     @Override
     @Transactional
-    public LoginResponse login(LoginRequest request, String deviceId) {
+    public LoginResponse login(LoginRequest request, String deviceId, boolean isDev) {
         try {
-            // 1. 사용자 조회
-            UserEntity user = userService.findUserByEmail(request.getEmail(), ErrorCode.INVALID_EMAIL);
+            // 1. 사용자 인증
+            UserEntity user = authenticateUser(request);
 
-            // 2. 비밀번호 검증
-            if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-                log.warn("로그인 실패 - 비밀번호 인증 실패: {}", request.getEmail());
-                throw new InvalidPasswordException();
+            // 2. 사용자 권한 확인 및 기본 역할 부여
+            List<String> roles = determineUserRoles(user);
+
+            // 3. 토큰 생성 (개발 모드 여부에 따라 다른 토큰 생성)
+            String accessToken;
+            String refreshToken;
+            long expiresIn;
+
+            if (isDev) {
+                // 개발용 짧은 유효기간 토큰
+                accessToken = jwtUtil.createDevAccessToken(user.getUserUuid(), roles);
+                refreshToken = jwtUtil.createDevRefreshToken(user.getUserUuid());
+                expiresIn = 180; // 3분 = 180초
+                log.info("개발 로그인 성공 - 이메일: {}, 토큰 만료시간: {}초", request.getEmail(), expiresIn);
+            } else {
+                // 일반 토큰
+                boolean keepLoggedIn = request.isKeepLoggedIn();
+                TokenPair tokenPair = createTokenPair(user, roles, keepLoggedIn);
+                accessToken = tokenPair.getAccessToken();
+                refreshToken = tokenPair.getRefreshToken();
+                expiresIn = tokenPair.getExpiresIn();
             }
 
-            // 3. 사용자 권한 조회
-            List<String> roles = userRoleService.getUserRoles(user);
-            if (roles.isEmpty()) {
-                // 역할이 비었다면 기본 역할 부여
-                roles = userRoleService.ensureDefaultRole(user);
-            }
+            // 4. 리프레시 토큰 저장
+            String usedDeviceId = saveRefreshToken(user, refreshToken, deviceId);
 
-            // 4. Access Token, Refresh Token 생성
-            boolean keepLoggedIn = request.isKeepLoggedIn();
-            String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles, keepLoggedIn);
-            String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), keepLoggedIn);
-            long expiresIn = keepLoggedIn ?
-                    jwtUtil.getLONG_ACCESS_TOKEN_EXPIRE() :
-                    jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
+            // 5. 프로필 이미지 조회
+            String profileImageUrl = getProfileImage(user);
 
-            // 5. Refresh Token 저장 및 디바이스 ID 처리
-            String usedDeviceId = saveRefreshToken(user.getUserUuid(), refreshToken, "local", null, deviceId);
-
-            // 6. 프로필 이미지
-            String profileImageUrl = imageService.getImagesByTypeAndId(ImageType.PROFILE, user.getId()).stream().findFirst().orElse(null);
-
-            // 7. 선호도 설정 여부 파악
+            // 6. 선호도 설정 여부 확인
             boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
 
-            // 8. 로그인 응답 생성
-            return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, usedDeviceId, isPreferenceSet);
-
+            // 7. 로그인 응답 생성
+            return LoginResponse.success(
+                    accessToken,
+                    refreshToken,
+                    expiresIn,
+                    user,
+                    profileImageUrl,
+                    usedDeviceId,
+                    isPreferenceSet
+            );
         } catch (BusinessException e) {
             log.warn("로그인 실패 - 이메일: {}, 사유: {}", request.getEmail(), e.getMessage());
             throw e;
         } catch (Exception e) {
             log.error("로그인 처리 중 오류 발생 - 이메일: {}", request.getEmail(), e);
             throw new AuthServiceException("로그인 처리 중 오류가 발생했습니다.");
-
-        }
-    }
-
-    /**
-     * 개발 환경용 로그인 처리
-     * 일반 로그인과 동일하지만 토큰 유효 시간이 매우 짧음 (3~5분)
-     */
-    @Override
-    @Transactional
-    public LoginResponse devLogin(LoginRequest request, String deviceId) {
-        try {
-            // 1. 사용자 조회
-            UserEntity user = userService.findUserByEmail(request.getEmail(), ErrorCode.INVALID_EMAIL);
-
-            // 2. 비밀번호 검증
-            if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-                log.warn("로그인 실패 - 비밀번호 인증 실패: {}", request.getEmail());
-                throw new InvalidPasswordException();
-            }
-
-            // 3. 사용자 권한 조회
-            List<String> roles = userRoleService.getUserRoles(user);
-            if (roles.isEmpty()) {
-                // 역할이 비었다면 기본 역할 부여
-                roles = userRoleService.ensureDefaultRole(user);
-            }
-
-            // 4. 개발용 짧은 유효기간의 Access Token, Refresh Token 생성 (3~5분)
-            String accessToken = jwtUtil.createDevAccessToken(user.getUserUuid(), roles);
-            String refreshToken = jwtUtil.createDevRefreshToken(user.getUserUuid());
-
-            // 개발 환경용 토큰 만료 시간 (3분 = 180초)
-            long expiresIn = 180;
-
-            // 5. Refresh Token 저장 및 디바이스 ID 처리
-            String usedDeviceId = saveRefreshToken(user.getUserUuid(), refreshToken, "local", null, deviceId);
-
-            // 6. 프로필 이미지
-            List<String> profileImages = imageService.getImagesByTypeAndId(ImageType.PROFILE, user.getId());
-            String profileImageUrl = profileImages.isEmpty() ? null : profileImages.get(0);
-
-            // 7. 선호도 설정 여부 파악
-            boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
-
-            log.info("개발 로그인 성공 - 이메일: {}, 토큰 만료시간: {}초", request.getEmail(), expiresIn);
-
-            // 8. 로그인 응답 생성
-            return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, usedDeviceId, isPreferenceSet);
-
-        } catch (BusinessException e) {
-            log.warn("로그인 실패 - 이메일: {}, 사유: {}", request.getEmail(), e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            log.error("개발 로그인 처리 중 오류 발생 - 이메일: {}", request.getEmail(), e);
-            throw new AuthServiceException("개발 로그인 처리 중 오류가 발생했습니다.");
         }
     }
 
     /**
      * 비밀번호 재설정
-     * 이메일 인증이 완료된 사용자의 비밀번호 변경
-     *
-     * 1. 이메일 검증 토큰에서 사용자 이메일 추출
-     * 2. 사용자 존재 확인
-     * 3. 새 비밀번호 암호화 및 업데이트
-     * 4. 기존 토큰 무효화 (로그아웃)
+     * 이메일 인증이 완료된 사용자의 비밀번호 변경 후 기존 토큰 무효화
      */
     @Override
     @Transactional
     public void resetPassword(PasswordResetRequest request, String verificationToken) {
         try {
-
             // 토큰 유효성 검사
-            emailVerificationService.validateEmailVerificationToken(verificationToken, request.getEmail(), EmailVerificationPurpose.PASSWORD_RESET);
+            emailVerificationService.validateEmailVerificationToken(
+                    verificationToken,
+                    request.getEmail(),
+                    EmailVerificationPurpose.PASSWORD_RESET
+            );
 
             // 사용자 조회
             UserEntity user = userService.findUserByEmail(request.getEmail());
@@ -285,35 +245,28 @@ public class AuthServiceImpl implements AuthService {
     }
 
     /**
-     * 로그아웃 처리
-     * 사용자의 리프레시 토큰을 무효화
-     *
-     * 1. 액세스 토큰에서 이메일 추출
-     * 2. 리프레시 토큰 무효화
-     *
-     * @param accessToken 액세스 토큰
-     * @return 로그아웃 응답
+     * 로그아웃 처리 - 사용자의 리프레시 토큰 무효화
      */
     @Transactional
     @Override
     public LogoutResponse logout(String accessToken, String deviceId) {
-        // 토큰이 없는 경우도 로그아웃 성공으로 처리
+        // 토큰이 없는 경우에도 로그아웃 성공으로 처리
         if (accessToken == null || accessToken.trim().isEmpty()) {
             log.info("토큰 없이 로그아웃 요청 - 성공으로 처리");
             return LogoutResponse.success();
         }
 
         try {
-            // 토큰 파싱 시도
+            // 액세스 토큰 파싱
             UUID userUuid = jwtUtil.getUserUuid(accessToken, true);
 
             try {
                 if (deviceId != null && !deviceId.isEmpty()) {
-                    // 특정 디바이스의 리프레시 토큰만 무효화
+                    // 특정 디바이스의 리프레시 토큰 무효화
                     tokenService.revokeRefreshTokenByDevice(userUuid, deviceId);
                     log.info("로그아웃 성공 - UUID: {}, 디바이스: {}", userUuid, deviceId);
                 } else {
-                    // 디바이스 ID가 없는 경우 모든 기기에서 로그아웃
+                    // 디바이스 ID가 없으면 모든 기기에서 로그아웃
                     tokenService.revokeRefreshToken(userUuid);
                     log.info("모든 기기에서 로그아웃 성공 - UUID: {}", userUuid);
                 }
@@ -327,7 +280,83 @@ public class AuthServiceImpl implements AuthService {
             log.warn("유효하지 않은 토큰으로 로그아웃 시도 - 성공으로 처리: {}", e.getMessage());
         }
 
-        // 모든 경우에 로그아웃 성공 응답
         return LogoutResponse.success();
+    }
+
+    /**
+     * 사용자 인증: 이메일로 사용자 조회 후 비밀번호 검증
+     */
+    private UserEntity authenticateUser(LoginRequest request) {
+        UserEntity user = userService.findUserByEmail(request.getEmail(), ErrorCode.INVALID_EMAIL);
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            log.warn("로그인 실패 - 비밀번호 인증 실패: {}", request.getEmail());
+            throw new InvalidPasswordException();
+        }
+        return user;
+    }
+
+    /**
+     * 사용자 권한 조회 및 기본 역할 부여
+     */
+    private List<String> determineUserRoles(UserEntity user) {
+        List<String> roles = userRoleService.getUserRoles(user);
+        if (roles.isEmpty()) {
+            roles = userRoleService.ensureDefaultRole(user);
+        }
+        return roles;
+    }
+
+    /**
+     * Access Token, Refresh Token 및 만료시간 생성
+     */
+    private TokenPair createTokenPair(UserEntity user, List<String> roles, boolean keepLoggedIn) {
+        String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles, keepLoggedIn);
+        String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), keepLoggedIn);
+        long expiresIn = keepLoggedIn ? jwtUtil.getLONG_ACCESS_TOKEN_EXPIRE() : jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
+        return new TokenPair(accessToken, refreshToken, expiresIn);
+    }
+
+    /**
+     * 리프레시 토큰 저장 및 디바이스 ID 처리
+     */
+    private String saveRefreshToken(UserEntity user, String refreshToken, String deviceId) {
+        return tokenService.saveRefreshToken(user.getUserUuid(), refreshToken, "local", null, deviceId);
+    }
+
+    /**
+     * 프로필 이미지 URL 조회
+     */
+    private String getProfileImage(UserEntity user) {
+        return imageService.getImagesByTypeAndId(ImageType.PROFILE, user.getId())
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * 토큰 생성 결과를 담는 도메인 객체
+     */
+    private static class TokenPair {
+        private final String accessToken;
+        private final String refreshToken;
+        private final long expiresIn;
+
+        public TokenPair(String accessToken, String refreshToken, long expiresIn) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+            this.expiresIn = expiresIn;
+        }
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public String getRefreshToken() {
+            return refreshToken;
+        }
+
+        public long getExpiresIn() {
+            return expiresIn;
+        }
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -17,6 +17,7 @@ import org.swyp.dessertbee.auth.exception.AuthExceptions.*;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
 import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.service.ImageService;
 import org.swyp.dessertbee.email.entity.EmailVerificationPurpose;
 import org.swyp.dessertbee.email.service.EmailVerificationService;
@@ -145,12 +146,12 @@ public class AuthServiceImpl implements AuthService {
     public LoginResponse login(LoginRequest request, String deviceId) {
         try {
             // 1. 사용자 조회
-            UserEntity user = userService.findUserByEmail(request.getEmail());
+            UserEntity user = userService.findUserByEmail(request.getEmail(), ErrorCode.INVALID_EMAIL);
 
             // 2. 비밀번호 검증
             if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-                log.warn("로그인 실패 - 비밀번호 불일치: {}", request.getEmail());
-                throw new PasswordMismatchException("비밀번호가 올바르지 않습니다.");
+                log.warn("로그인 실패 - 비밀번호 인증 실패: {}", request.getEmail());
+                throw new InvalidPasswordException();
             }
 
             // 3. 사용자 권한 조회
@@ -180,7 +181,7 @@ public class AuthServiceImpl implements AuthService {
             // 8. 로그인 응답 생성
             return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, usedDeviceId, isPreferenceSet);
 
-        } catch (InvalidCredentialsException e) {
+        } catch (BusinessException e) {
             log.warn("로그인 실패 - 이메일: {}, 사유: {}", request.getEmail(), e.getMessage());
             throw e;
         } catch (Exception e) {

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.auth.service;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -175,9 +176,9 @@ public class AuthServiceImpl implements AuthService {
                 // 일반 토큰
                 boolean keepLoggedIn = request.isKeepLoggedIn();
                 TokenPair tokenPair = createTokenPair(user, roles, keepLoggedIn);
-                accessToken = tokenPair.getAccessToken();
-                refreshToken = tokenPair.getRefreshToken();
-                expiresIn = tokenPair.getExpiresIn();
+                accessToken = tokenPair.accessToken();
+                refreshToken = tokenPair.refreshToken();
+                expiresIn = tokenPair.expiresIn();
             }
 
             // 4. 리프레시 토큰 저장
@@ -334,29 +335,9 @@ public class AuthServiceImpl implements AuthService {
     }
 
     /**
-     * 토큰 생성 결과를 담는 도메인 객체
-     */
-    private static class TokenPair {
-        private final String accessToken;
-        private final String refreshToken;
-        private final long expiresIn;
+         * 토큰 생성 결과를 담는 도메인 객체
+         */
+        private record TokenPair(String accessToken, String refreshToken, long expiresIn) {
 
-        public TokenPair(String accessToken, String refreshToken, long expiresIn) {
-            this.accessToken = accessToken;
-            this.refreshToken = refreshToken;
-            this.expiresIn = expiresIn;
-        }
-
-        public String getAccessToken() {
-            return accessToken;
-        }
-
-        public String getRefreshToken() {
-            return refreshToken;
-        }
-
-        public long getExpiresIn() {
-            return expiresIn;
-        }
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -113,9 +113,9 @@ public class AuthServiceImpl implements AuthService {
             userRepository.save(user);
 
             // Access Token, Refresh Token 생성
-            String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles, false);
+            String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles);
             String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), false);
-            long expiresIn = jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
+            long expiresIn = jwtUtil.getACCESS_TOKEN_EXPIRE();
 
             // Refresh Token 저장 및 디바이스 ID 처리
             String usedDeviceId = saveRefreshToken(user.getUserUuid(), refreshToken, "local", null, deviceId);
@@ -310,9 +310,9 @@ public class AuthServiceImpl implements AuthService {
      * Access Token, Refresh Token 및 만료시간 생성
      */
     private TokenPair createTokenPair(UserEntity user, List<String> roles, boolean keepLoggedIn) {
-        String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles, keepLoggedIn);
+        String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles);
         String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), keepLoggedIn);
-        long expiresIn = keepLoggedIn ? jwtUtil.getLONG_ACCESS_TOKEN_EXPIRE() : jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
+        long expiresIn = jwtUtil.getACCESS_TOKEN_EXPIRE();
         return new TokenPair(accessToken, refreshToken, expiresIn);
     }
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -163,9 +163,9 @@ public class KakaoOAuthService {
 
         // 토큰 발급
         boolean keepLoggedIn = false; // 기본값
-        String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles, keepLoggedIn);
+        String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles);
         String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), keepLoggedIn);
-        long expiresIn = jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE();
+        long expiresIn = jwtUtil.getACCESS_TOKEN_EXPIRE();
 
         // 리프레시 토큰 저장 (디바이스 ID 관리 포함)
         String usedDeviceId = tokenService.saveRefreshToken(

--- a/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
@@ -224,8 +224,7 @@ public class TokenService {
                     .map(userRole -> userRole.getRole().getName().getRoleName())
                     .collect(Collectors.toList());
 
-            boolean keepLoggedIn = false; // 로그인 유지 여부 (추후 프론트엔드에서 전달받아야 한다.)
-            String newAccessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles, keepLoggedIn);
+            String newAccessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles);
 
             // 마지막 로그인 시간 업데이트
             auth.updateRefreshToken(auth.getRefreshToken(), auth.getRefreshTokenExpiresAt());
@@ -236,7 +235,7 @@ public class TokenService {
             return TokenResponse.builder()
                     .accessToken(newAccessToken)
                     .tokenType("Bearer")
-                    .expiresIn(jwtUtil.getSHORT_ACCESS_TOKEN_EXPIRE())
+                    .expiresIn(jwtUtil.getACCESS_TOKEN_EXPIRE())
                     .deviceId(deviceId)  // 응답에 디바이스 ID 포함
                     .build();
         }

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
     AUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A010", "인증 서비스 처리 중 오류가 발생했습니다."),
     OAUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A011", "소셜 인증 서비스 처리 중 오류가 발생했습니다."),
     DEVICE_ID_MISSING(HttpStatus.BAD_REQUEST, "A012", "디바이스 ID가 제공되지 않았습니다."),
-
+    INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "A013", "이메일을 다시 확인해주세요."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "A014", "비밀번호를 다시 입력해주세요."),
     // OAuth
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "O001", "지원되지 않는 OAuth 제공자입니다."),
 

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
@@ -21,9 +21,6 @@ import org.swyp.dessertbee.user.dto.response.UserResponseDto;
 import org.swyp.dessertbee.user.dto.request.UserUpdateRequestDto;
 import org.swyp.dessertbee.user.service.UserService;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * 사용자 정보 조회 관련 컨트롤러
  */
@@ -41,7 +38,7 @@ public class UserController {
      * @return 사용자 상세 정보
      */
     @Operation(
-            summary = "현재 사용자 정보 조회",
+            summary = "현재 사용자 정보 조회 (completed)",
             description = "현재 로그인된 사용자의 상세 정보를 반환합니다."
     )
     @ApiResponse(
@@ -65,7 +62,7 @@ public class UserController {
      * @return 사용자 기본 정보
      */
     @Operation(
-            summary = "특정 사용자 정보 조회",
+            summary = "특정 사용자 정보 조회 (completed)",
             description = "UUID로 특정 사용자의 기본 정보를 조회합니다."
     )
     @ApiResponse(
@@ -88,7 +85,7 @@ public class UserController {
      * @return 사용자 상세 정보
      */
     @Operation(
-            summary = "사용자 정보 수정",
+            summary = "사용자 정보 수정 (completed)",
             description = "현재 로그인된 사용자의 정보를 수정합니다."
     )
     @ApiResponse(
@@ -111,7 +108,7 @@ public class UserController {
      * 회원 탈퇴 처리
      */
     @Operation(
-            summary = "회원 탈퇴",
+            summary = "회원 탈퇴 (completed)",
             description = "현재 로그인된 사용자의 계정을 비활성화합니다."
     )
     @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
@@ -128,7 +125,7 @@ public class UserController {
      * @return 사용 가능 여부
      */
     @Operation(
-            summary = "닉네임 중복 검사",
+            summary = "닉네임 중복 검사 (completed)",
             description = "닉네임 사용 가능 여부를 확인합니다."
     )
     @ApiResponse(
@@ -156,7 +153,7 @@ public class UserController {
      * @return 업데이트된 사용자 정보
      */
     @Operation(
-            summary = "프로필 이미지 업데이트",
+            summary = "프로필 이미지 업데이트 (completed)",
             description = "사용자의 프로필 이미지를 업로드합니다."
     )
     @ApiResponse(

--- a/src/main/java/org/swyp/dessertbee/user/service/UserService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserService.java
@@ -2,6 +2,7 @@ package org.swyp.dessertbee.user.service;
 
 import org.apache.catalina.User;
 import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.user.dto.response.UserDetailResponseDto;
 import org.swyp.dessertbee.user.dto.response.UserResponseDto;
 import org.swyp.dessertbee.user.dto.request.UserUpdateRequestDto;
@@ -59,6 +60,7 @@ public interface UserService {
     UserEntity validateUser(String email);
 
     UserEntity findUserByEmail(String email);
+    UserEntity findUserByEmail(String email, ErrorCode errorCode);
 
     UserEntity findByUserUuid(UUID userUuid);
 

--- a/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
@@ -317,6 +317,15 @@ public class UserServiceImpl implements UserService {
                 });
     }
 
+    public UserEntity findUserByEmail(String email, ErrorCode errorCode) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.warn("로그인 실패 - 존재하지 않는 이메일: {}", email);
+                    return new BusinessException(errorCode);
+                });
+    }
+
+
     @Override
     public UserEntity findByUserUuid(UUID userUuid) {
         return userRepository.findByUserUuid(userUuid)


### PR DESCRIPTION
## :hash: 연관된 이슈
#266 
## :memo: 작업 내용
- 로그인 리팩토링
  - 에러 명시 
    - 비밀번호 검증 에러
    - 이메일 검증 에러
  - SRP, OCP 원칙 적용
- 토큰 리팩토링
  - keepLoggined는 리프레시 토큰에만 적용
  - 액세스 토큰 수명 1일 -> 30분으로 감소
- 유저 컨트롤러 스웨거
  -  completed 상태 명시로 완료 여부 표시
### 스크린샷 (선택)
<img width="639" alt="스크린샷 2025-04-07 오후 4 55 26" src="https://github.com/user-attachments/assets/2e82e2ae-0287-4411-bf0e-80a9fd329c7b" />
<img width="792" alt="스크린샷 2025-04-07 오후 4 55 13" src="https://github.com/user-attachments/assets/053da593-2a14-41e2-990f-1e7bb5d26b66" />
<img width="572" alt="image" src="https://github.com/user-attachments/assets/65574348-7318-4f3f-a0c2-8b7871d3d355" />
