### PR TITLE
[REFACTOR] store_top_tag 기반 store 추천 쿼리 성능 최적화

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/scheduler/SearchScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/common/scheduler/SearchScheduler.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.common.util;
+package org.swyp.dessertbee.common.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/org/swyp/dessertbee/common/scheduler/StoreTopTagScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/common/scheduler/StoreTopTagScheduler.java
@@ -1,0 +1,26 @@
+package org.swyp.dessertbee.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.swyp.dessertbee.store.store.service.StoreTopTagBatchService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StoreTopTagScheduler {
+
+    private final StoreTopTagBatchService storeTopTagBatchService;
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+    public void runTopTagBatch() {
+        try {
+            log.info("[스케줄러] store_top_tag 배치 시작");
+            storeTopTagBatchService.refreshStoreTopTags();
+            log.info("[스케줄러] store_top_tag 배치 종료");
+        } catch (Exception e) {
+            log.error("[스케줄러] store_top_tag 배치 실패", e);
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
@@ -116,8 +116,8 @@ public class StoreDetailResponse {
     @Schema(description = "특정 휴무일 정보", nullable = true)
     private List<HolidayResponse> holidays;
 
-    @Schema(description = "가게를 저장한 사용자들의 취향 태그 Top3", example = "[\"비건\", \"키토제닉\",\"락토프리\"]", nullable = true)
-    private List<String> topPreferences;
+    @Schema(description = "가게를 저장한 사용자들의 취향 태그 Top3", example = "[{\"tagId\":1,\"name\":\"비건\",\"rank\":1}]", nullable = true)
+    private List<TopPreferenceTagResponse> topPreferences;
 
     @Schema(description = "커뮤니티 리뷰 리스트", nullable = true)
     private List<ReviewSummaryResponse> communityReviews;
@@ -139,7 +139,7 @@ public class StoreDetailResponse {
                                                  List<MenuResponse> menus,
                                                  List<String> storeImages,
                                                  List<String> ownerPickImages,
-                                                 List<String> topPreferences,
+                                                 List<TopPreferenceTagResponse> topPreferences,
                                                  List<StoreReviewResponse> storeReviews,
                                                  List<String> tags,
                                                  List<String> storeLinks,

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSummaryResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSummaryResponse.java
@@ -54,8 +54,8 @@ public class StoreSummaryResponse {
     @Schema(description = "특정 휴무일 정보", nullable = true)
     private List<HolidayResponse> holidays;
 
-    @Schema(description = "가게를 저장한 사용자들의 취향 태그 Top3", example = "[\"비건\", \"키토제닉\",\"락토프리\"]", nullable = true)
-    private List<String> topPreferences;
+    @Schema(description = "가게를 저장한 사용자들의 취향 태그 Top3", example = "[{\"tagId\":1,\"name\":\"비건\",\"rank\":1}]", nullable = true)
+    private List<TopPreferenceTagResponse> topPreferences;
 
     @NotBlank
     @Schema(description = "가게 주소", example = "서울 마포구 양화로 23길 8")
@@ -84,7 +84,7 @@ public class StoreSummaryResponse {
                                                   List<HolidayResponse> holidays,
                                                   List<String> storeImages,
                                                   List<String> ownerPickImages,
-                                                  List<String> topPreferences) {
+                                                  List<TopPreferenceTagResponse> topPreferences) {
         return StoreSummaryResponse.builder()
                 .storeId(store.getStoreId())
                 .storeUuid(store.getStoreUuid())

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/TopPreferenceTagResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/TopPreferenceTagResponse.java
@@ -1,0 +1,7 @@
+package org.swyp.dessertbee.store.store.dto.response;
+
+public record TopPreferenceTagResponse(
+        Long tagId,
+        String name,
+        int rank
+) {}

--- a/src/main/java/org/swyp/dessertbee/store/store/entity/StoreTopTag.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/entity/StoreTopTag.java
@@ -1,0 +1,36 @@
+package org.swyp.dessertbee.store.store.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 가게를 저장한 사용자들의 취향 태그 Top3
+ */
+@Entity
+@Table(name = "store_top_tag")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoreTopTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
+
+    @Column(name = "tag_id", nullable = false)
+    private Long tagId;
+
+    @Column(name = "tag_rank", nullable = false)
+    private Integer tagRank;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/SavedStoreRepository.java
@@ -40,20 +40,6 @@ public interface SavedStoreRepository extends JpaRepository<SavedStore, Long> {
     @Transactional
     void deleteByUserStoreList(UserStoreList userStoreList);
 
-    /** 특정 가게를 저장한 사람들의 취향 태그 Top3 조회 */
-    @Query(value = """
-    SELECT p.preference_name, COUNT(sp.preference) AS preference_count
-    FROM saved_store_preferences sp
-    JOIN preference p ON sp.preference = p.id
-    WHERE sp.saved_store_id IN (
-        SELECT id FROM saved_store WHERE store_id = :storeId
-    )
-    GROUP BY p.preference_name
-    ORDER BY preference_count DESC
-    LIMIT 3
-""", nativeQuery = true)
-    List<Object[]> findTop3PreferencesByStoreId(@Param("storeId") Long storeId);
-
     /** 특정 가게를 저장한 사용자가 있다면 해당 SavedStore 엔티티 반환 */
     @Query("SELECT s FROM SavedStore s " +
             "JOIN s.userStoreList usl " +

--- a/src/main/java/org/swyp/dessertbee/store/store/repository/StoreTopTagRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/repository/StoreTopTagRepository.java
@@ -1,0 +1,56 @@
+package org.swyp.dessertbee.store.store.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.store.store.dto.response.TopPreferenceTagResponse;
+import org.swyp.dessertbee.store.store.entity.StoreTopTag;
+
+import java.util.List;
+
+public interface StoreTopTagRepository extends JpaRepository<StoreTopTag, Long> {
+
+    @Query(value = """
+    SELECT stt.tag_id AS tagId, st.name AS name, stt.tag_rank AS rank
+    FROM store_top_tag stt
+    JOIN store_tag st ON stt.tag_id = st.id
+    WHERE stt.store_id = :storeId
+      AND stt.tag_rank <= 3
+    ORDER BY stt.tag_rank ASC
+    """, nativeQuery = true)
+    List<TopPreferenceTagResponse> findTop3TagsByStoreId(@Param("storeId") Long storeId);
+
+    @Query(value = """
+    SELECT stt.tag_id AS tagId, st.name AS name, stt.tag_rank AS rank
+    FROM store_top_tag stt
+    JOIN store_tag st ON stt.tag_id = st.id
+    WHERE stt.store_id = :storeId
+      AND stt.tag_rank <= 11
+    ORDER BY stt.tag_rank ASC
+    """, nativeQuery = true)
+    List<TopPreferenceTagResponse> findAllTagsByStoreId(@Param("storeId") Long storeId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "TRUNCATE TABLE store_top_tag", nativeQuery = true)
+    void truncateStoreTopTag();
+
+    @Modifying
+    @Transactional
+    @Query(value = """
+        INSERT INTO store_top_tag (store_id, tag_id, tag_rank)
+        SELECT store_id, tag_id, tag_rank
+        FROM (
+            SELECT ss.store_id, sp.preference AS tag_id,
+                   ROW_NUMBER() OVER (PARTITION BY ss.store_id ORDER BY COUNT(*) DESC) AS tag_rank
+            FROM saved_store ss
+            JOIN saved_store_preferences sp ON ss.id = sp.saved_store_id
+            GROUP BY ss.store_id, sp.preference
+        ) ranked
+        WHERE tag_rank <= 11
+        """, nativeQuery = true)
+    void populateStoreTopTag();
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
@@ -50,8 +50,6 @@ import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.user.service.UserService;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -86,6 +84,7 @@ public class StoreServiceImpl implements StoreService {
     private final MenuRepository menuRepository;
     private final StoreNoticeService storeNoticeService;
     private final ApplicationEventPublisher eventPublisher;
+    private final StoreTopTagRepository storeTopTagRepository;
 
     /** 가게 등록 (이벤트, 쿠폰, 메뉴 + 이미지 포함) */
     @Override
@@ -525,12 +524,8 @@ public class StoreServiceImpl implements StoreService {
     /**
      * 가게의 Top3 취향 태그 조회 메서드
      */
-    private List<String> getTop3Preferences(Long storeId) {
-        List<Object[]> preferenceCounts = savedStoreRepository.findTop3PreferencesByStoreId(storeId);
-
-        return preferenceCounts.stream()
-                .map(result -> (String) result[0])
-                .toList();
+    private List<TopPreferenceTagResponse> getTop3Preferences(Long storeId) {
+        return storeTopTagRepository.findTop3TagsByStoreId(storeId);
     }
 
     /**
@@ -677,7 +672,7 @@ public class StoreServiceImpl implements StoreService {
             List<HolidayResponse> holidayResponses = getHolidaysResponse(storeId);
 
             // 가게 취향 태그 top3 조회
-            List<String> topPreferences = getTop3Preferences(storeId);
+            List<TopPreferenceTagResponse> topPreferences = storeTopTagRepository.findTop3TagsByStoreId(storeId);
 
             return StoreSummaryResponse.fromEntity(
                     store,
@@ -737,7 +732,7 @@ public class StoreServiceImpl implements StoreService {
             List<StoreNoticeResponse> noticeResponses = storeNoticeService.getNoticesByStoreUuid(storeUuid);
 
             // 가게 취향 태그 top3 조회
-            List<String> topPreferences = getTop3Preferences(storeId);
+            List<TopPreferenceTagResponse> topPreferences = getTop3Preferences(storeId);
 
             // 메뉴 리스트 조회
             List<MenuResponse> menus = menuService.getMenusByStore(storeUuid);

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreTopTagBatchService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreTopTagBatchService.java
@@ -1,0 +1,26 @@
+package org.swyp.dessertbee.store.store.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.store.store.repository.StoreTopTagRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreTopTagBatchService {
+
+    private final StoreTopTagRepository storeTopTagRepository;
+
+    @Transactional
+    public void refreshStoreTopTags() {
+        log.info("[배치] store_top_tag 초기화 시작");
+        storeTopTagRepository.truncateStoreTopTag();
+
+        log.info("[배치] store_top_tag 집계 및 저장 시작");
+        storeTopTagRepository.populateStoreTopTag();
+
+        log.info("[배치] store_top_tag 배치 완료");
+    }
+}


### PR DESCRIPTION
## :hash: 연관된 이슈

> #297 

## :memo: 작업 내용

> 기존 실시간 ROW_NUMBER 기반 추천 쿼리 제거
> `store_top_tag` 테이블을 활용한 거리 + 태그 기반 추천 쿼리로 변경 (`findStoresByLocationAndTopTags`)
> `StoreSummaryResponse`의 취향 태그 필드를 `List<TopPreferenceTagResponse>`로 확장
> 배치에서 최대 11개의 태그를 저장하도록 쿼리 수정
> 추후 Top11 태그 전체 조회를 위한 Repository 메서드(`findTopTagsByStoreId`) 추가
