### PR TITLE
[Feature] 디저트메이트 인원 기능 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
     implementation 'software.amazon.awssdk:netty-nio-client:2.20.86'
 
     implementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -159,6 +159,7 @@ public enum ErrorCode {
     DUPLICATION_SAVED_MATE(HttpStatus.CONFLICT, "M017", "이미 저장된 디저트메이트입니다."),
     MATE_NOT_REPORTED(HttpStatus.NOT_FOUND, "M018" , "신고되지 않은 디저트메이트입니다." ),
     MATE_REPLY_NOT_REPORTED(HttpStatus.NOT_FOUND, "M019" , "신고되지 않은 디저트메이트 댓글입니다." ),
+    MATE_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "M020", "최대 수용 인원 초과입니다." ),
 
     //커뮤니티 리뷰
     COMMUNITY_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001" , "존재하지 않는 리뷰입니다." ),

--- a/src/main/java/org/swyp/dessertbee/community/mate/controller/MateController.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/controller/MateController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -43,10 +44,11 @@ public class MateController{
     @ApiErrorResponses({ErrorCode.USER_NOT_FOUND})
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<MateDetailResponse> createMate(@RequestPart("request")  MateCreateRequest request,
-                                                         @RequestPart(value = "mateImage", required = false) MultipartFile mateImage) {
+                                                         @RequestPart(value = "mateImage", required = false) MultipartFile mateImage,
+                                                         HttpServletRequest httpRequest) {
 
 
-        MateDetailResponse response = mateService.createMate(request, mateImage);
+        MateDetailResponse response = mateService.createMate(request, mateImage, httpRequest);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/src/main/java/org/swyp/dessertbee/community/mate/dto/request/MateCreateRequest.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/dto/request/MateCreateRequest.java
@@ -31,6 +31,9 @@ public class MateCreateRequest {
     @Schema(description = "디저트메이트 수용 인원", example = "2")
     private Long capacity;
 
+    @Schema(description = "디저트메이트 연결할 가게 id(앱에서만 필수)", example = "11")
+    private Long storeId;
+
     @NotBlank(message = "디저트메이트 제목을 작성해주세요.")
     @Schema(description = "디저트메이트 제목 작성", example = "저랑 같이 홍대 빵지순례할 사람 찾습니다.")
     private String title;

--- a/src/main/java/org/swyp/dessertbee/community/mate/dto/request/MateCreateRequest.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/dto/request/MateCreateRequest.java
@@ -27,6 +27,10 @@ public class MateCreateRequest {
     @Schema(description = "디저트메이트 카테고리", example = "1")
     private Long mateCategoryId;
 
+    @NotBlank(message = "디저트메이트 수용 인원을 선택해주세요.")
+    @Schema(description = "디저트메이트 수용 인원", example = "2")
+    private Long capacity;
+
     @NotBlank(message = "디저트메이트 제목을 작성해주세요.")
     @Schema(description = "디저트메이트 제목 작성", example = "저랑 같이 홍대 빵지순례할 사람 찾습니다.")
     private String title;

--- a/src/main/java/org/swyp/dessertbee/community/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/dto/response/MateDetailResponse.java
@@ -37,6 +37,10 @@ public class MateDetailResponse {
     private Long capacity;
 
     @NotBlank
+    @Schema(description = "디저트메이트 현재 참여 인원", example = "1")
+    private Long currentMemberCount;
+
+    @NotBlank
     @Schema(description = "디저트메이트 작성하는 사람 닉네임", example = "디저비1")
     private String nickname;
 
@@ -106,6 +110,7 @@ public class MateDetailResponse {
                 .title(mate.getTitle())
                 .content(mate.getContent())
                 .capacity(mate.getCapacity())
+                .currentMemberCount(mate.getCurrentMemberCount())
                 .recruitYn(mate.getRecruitYn())
                 .mateImage(mateImage)
                 .mateCategory(category)

--- a/src/main/java/org/swyp/dessertbee/community/mate/dto/response/MateDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/dto/response/MateDetailResponse.java
@@ -32,6 +32,10 @@ public class MateDetailResponse {
     @Schema(description = "디저트메이트 작성하는 사람 uuid", example = "19a40ec1-ac92-419e-aa2b-0fcfcbd42447")
     private UUID userUuid;
 
+    @NotBlank(message = "디저트메이트 수용 인원을 선택해주세요.")
+    @Schema(description = "디저트메이트 수용 인원", example = "2")
+    private Long capacity;
+
     @NotBlank
     @Schema(description = "디저트메이트 작성하는 사람 닉네임", example = "디저비1")
     private String nickname;
@@ -101,6 +105,7 @@ public class MateDetailResponse {
                 .profileImage(profileImage)
                 .title(mate.getTitle())
                 .content(mate.getContent())
+                .capacity(mate.getCapacity())
                 .recruitYn(mate.getRecruitYn())
                 .mateImage(mateImage)
                 .mateCategory(category)

--- a/src/main/java/org/swyp/dessertbee/community/mate/entity/Mate.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/entity/Mate.java
@@ -40,6 +40,9 @@ public class Mate {
     @Column(name = "capacity", nullable = false)
     private Long capacity;
 
+    @Column(name = "current_member_count")
+    private Long currentMemberCount;
+
     @Column(name = "store_id")
     private Long storeId;
 
@@ -92,6 +95,13 @@ public class Mate {
             this.longitude = store.getLongitude();
             this.address = store.getAddress();
         }
+    }
+    public void updateRecruitYn(boolean recruitYn) {
+        this.recruitYn = recruitYn;
+    }
+
+    public void updateCurrentMemberCount(Long currentMemberCount) {
+        this.currentMemberCount = currentMemberCount;
     }
 
     public void softDelete(){

--- a/src/main/java/org/swyp/dessertbee/community/mate/entity/Mate.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/entity/Mate.java
@@ -37,6 +37,9 @@ public class Mate {
     @Column(name = "user_id")
     private Long userId;
 
+    @Column(name = "capacity", nullable = false)
+    private Long capacity;
+
     @Column(name = "store_id")
     private Long storeId;
 

--- a/src/main/java/org/swyp/dessertbee/community/mate/exception/MateExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/exception/MateExceptions.java
@@ -192,4 +192,18 @@ public class MateExceptions {
             super(ErrorCode.MATE_REPLY_NOT_REPORTED, message);
         }
     }
+
+    /**(HTTP code 500) server error - Ports are not available: exposing port TCP 0.0.0.0:6379 -> 127.0.0.1:0: listen tcp 0.0.0.0:6379: bind: address already in use
+     * 디저트메이트 수용인원 제한 예외
+     * */
+    public static class MateCapacityExceededException extends BusinessException {
+
+        public MateCapacityExceededException(){
+            super(ErrorCode.MATE_CAPACITY_EXCEEDED);
+        }
+
+        public MateCapacityExceededException(String message) {
+         super(ErrorCode.MATE_CAPACITY_EXCEEDED, message);
+        }
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/community/mate/repository/MateMemberRepository.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/repository/MateMemberRepository.java
@@ -41,4 +41,7 @@ public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
             "AND m.deletedAt IS NULL " +
             "AND m.applyStatus = 'APPROVED' AND m.grade = 'NORMAL'")
     List<MateMember> findByMateIdAndDeletedAtIsNullAndApplyStatusAndGrade_Normal(Long mateId, MateApplyStatus mateApplyStatus, MateMemberGrade mateMemberGrade);
+
+    @Query("SELECT COUNT(m) FROM MateMember  m WHERE m.mateId = :mateId AND m.deletedAt IS NULL")
+    Long countByMateId(Long mateId);
 }

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateMemberServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateMemberServiceImpl.java
@@ -305,7 +305,7 @@ public class MateMemberServiceImpl implements MateMemberService {
             }
 
             // capacity와 딱 맞아지면 모집 마감 처리
-            if (mate.getCurrentMemberCount().equals(mate.getCapacity())) {
+            if ((mate.getCurrentMemberCount() +1 ) == mate.getCapacity()) {
                 mate.updateRecruitYn(false);
             }
 

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateService.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.community.mate.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.community.mate.dto.request.MateCreateRequest;
@@ -14,7 +15,7 @@ import java.util.UUID;
 public interface MateService {
 
     /** 메이트 등록 */
-    MateDetailResponse createMate(MateCreateRequest request, MultipartFile mateImage);
+    MateDetailResponse createMate(MateCreateRequest request, MultipartFile mateImage, HttpServletRequest httpRequest);
 
     /** 메이트 상세 정보 */
     MateDetailResponse getMateDetail(UUID mateUuid);

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
@@ -83,6 +83,7 @@ public class MateServiceImpl implements MateService {
                             .title(request.getTitle())
                             .content(request.getContent())
                             .capacity(request.getCapacity())
+                            .currentMemberCount(1L)
                             .recruitYn(Boolean.TRUE.equals(request.getRecruitYn()))
                             .placeName(request.getPlace().getPlaceName())
                             .latitude(request.getPlace().getLatitude())

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
@@ -58,6 +58,9 @@ public class MateServiceImpl implements MateService {
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
         UserEntity user = userService.getCurrentUser();
 
+        if(request.getCapacity() > 5){
+            throw new MateCapacityExceededException("최대 수용 인원 초과입니다.");
+        }
 
         try {
             userService.findById(user.getId());
@@ -71,6 +74,7 @@ public class MateServiceImpl implements MateService {
             // store가 null이면 storeId는 null, 아니면 store.getStoreId() 할당
             Long storeId = (store != null) ? store.getStoreId() : null;
 
+
             Mate mate = mateRepository.save(
                     Mate.builder()
                             .userId(user.getId())
@@ -78,6 +82,7 @@ public class MateServiceImpl implements MateService {
                             .mateCategoryId(request.getMateCategoryId())
                             .title(request.getTitle())
                             .content(request.getContent())
+                            .capacity(request.getCapacity())
                             .recruitYn(Boolean.TRUE.equals(request.getRecruitYn()))
                             .placeName(request.getPlace().getPlaceName())
                             .latitude(request.getPlace().getLatitude())


### PR DESCRIPTION
## :hash: 연관된 이슈

> 292

## :memo: 작업 내용

> 디저트메이트 생성 시 인원 제한 기능 추가
> 멤버 수락 시 수용 인원만큼 모으면 바로 모집 마감 되도록 수정
> 멤버 강퇴 시 수용 인원보다 적어지면 바로 모집 가능하도록 수정
> 웹,앱 버전 관리를 위해 스웨거 전역 Platform-Type 헤더 설정 추가
> 디저트메이트 생성 시 앱은 StoreId를 넘겨주고 웹은 장소명을 넘겨줘서 해당 값들로 서비스 내 가게 연결하도록 수정


## :speech_balloon: 리뷰 요구사항(선택)

> 헤더로 Platform-Type 넘어오는거 테스트로는 나눠져서 코드가 실행하는 걸 확인 했는데 혹시 각자 맡으신 부분에서 설정 오류가 생길 수도 있을 법한 곳 체크해주셨으면 좋겠습니다!
