### PR TITLE
[FEATURE] 프로필 이미지와 함께 가입되는 multipart 회원가입 api 개발

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/request/SignUpRequest.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.swyp.dessertbee.role.entity.RoleType;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
@@ -15,7 +16,7 @@ import java.util.List;
  * 회원가입 요청을 위한 DTO 클래스
  */
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SignUpRequest {

--- a/src/main/java/org/swyp/dessertbee/auth/dto/request/SignUpWithProfileRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/request/SignUpWithProfileRequest.java
@@ -1,0 +1,29 @@
+package org.swyp.dessertbee.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 프로필 이미지를 포함한 회원가입 요청을 위한 DTO 클래스
+ * SignUpRequest를 상속받아 프로필 이미지 필드만 추가
+ */
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class SignUpWithProfileRequest extends SignUpRequest {
+
+    @Schema(
+            description = "프로필 이미지 (JPG, JPEG, PNG, GIF 형식의 5MB 이하 파일만 허용)",
+            type = "string",
+            format = "binary",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private MultipartFile profileImage;  // 프로필 이미지
+}

--- a/src/main/java/org/swyp/dessertbee/auth/dto/response/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/response/LoginResponse.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.swyp.dessertbee.common.exception.ErrorResponse;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
 import java.util.UUID;
@@ -79,6 +80,22 @@ public class LoginResponse {
     )
     private String deviceId;        // 디바이스 식별자
 
+    @Schema(
+            description = "이미지 관련 오류 메시지 (이미지 업로드 실패 시에만 존재)",
+            implementation = ErrorResponse.class,
+            nullable = true,
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            example = """
+                {
+                  "status": 400,
+                  "code": "F004",
+                  "message": "지원하지 않는 파일 형식입니다.",
+                  "timestamp": "2025-04-15T02:45:12"
+                }
+            """
+    )
+    private ErrorResponse imageError;     // 이미지 오류 정보
+
     /**
      * 로그인 성공 응답 생성 (디바이스 ID 포함)
      * @param accessToken JWT 액세스 토큰
@@ -125,5 +142,4 @@ public class LoginResponse {
     public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl) {
         return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, null, false);
     }
-
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.auth.service;
 
+import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.request.LoginRequest;
 import org.swyp.dessertbee.auth.dto.response.LoginResponse;
 import org.swyp.dessertbee.auth.dto.response.PasswordResetResponse;
@@ -46,6 +47,18 @@ public interface AuthService {
      * @throws DuplicateEmailException 이메일 중복
      */
     LoginResponse signup(SignUpRequest request, String verificationToken, String deviceId);
+
+    /**
+     * 회원가입 처리 (프로필 이미지 포함)
+     * 이미지 유효성 검사를 수행하고 실패 시 비즈니스 예외를 발생시킴
+     *
+     * @param request 회원가입 요청 정보
+     * @param profileImage 프로필 이미지
+     * @param verificationToken 이메일 인증 토큰
+     * @param deviceId 디바이스 ID
+     * @return 회원가입 결과
+     */
+    LoginResponse signupWithProfileImage(SignUpRequest request, MultipartFile profileImage, String verificationToken, String deviceId);
 
     /**
      * 로그인 처리

--- a/src/main/java/org/swyp/dessertbee/common/service/ImageService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/ImageService.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -304,4 +305,32 @@ public class ImageService {
         return reviewUploadAndSaveImage(newFiles, refType, refId, folder);
 
     }
+
+    /**
+     * 프로필 이미지 유효성 검증
+     */
+    public void validateImage(MultipartFile file) {
+        // 1. 파일 타입 검증
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new BusinessException(ErrorCode.INVALID_FILE_TYPE, "이미지 파일만 업로드 가능합니다.");
+        }
+
+        // 2. 파일 크기 검증 (예: 5MB 제한)
+        long maxSizeBytes = 5 * 1024 * 1024; // 5MB
+        if (file.getSize() > maxSizeBytes) {
+            throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED, "이미지 크기는 5MB를 초과할 수 없습니다.");
+        }
+
+        // 3. 추가 이미지 형식 검증 (필요시)
+        String filename = file.getOriginalFilename();
+        if (filename != null) {
+            String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+            if (!Arrays.asList("jpg", "jpeg", "png", "gif").contains(extension)) {
+                throw new BusinessException(ErrorCode.INVALID_FILE_TYPE,
+                        "지원되지 않는 이미지 형식입니다. JPG, JPEG, PNG, GIF 형식만 지원합니다.");
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## :hash: 연관된 이슈
#320 

## :memo: 작업 내용
- 이미지 관련 예외처리 기능 개선
- LoginResponse: 이미지 오류 정보 필드 추가
  - ErrorResponse 타입 필드
- AuthServiceImpl: 이미지 처리 예외를 내부적으로 처리하여 회원가입은 성공 처리
  - 이미지 형식 오류, 크기 초과 등의 이유로 회원가입이 실패하지 않고 진행됨
  - validateImage() 및 updateImage() 호출을 try-catch로 감싸 예외를 처리


### 스크린샷 (선택)
<img width="488" alt="image" src="https://github.com/user-attachments/assets/2bd36c2f-7a42-4af5-8e5d-bde2f00126ef" />
<img width="480" alt="image" src="https://github.com/user-attachments/assets/31b0c4e5-f1c7-4635-8d97-89b7d4856724" />