### PR TITLE
[REFACTOR] 

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -12,9 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.dto.request.SignUpWithProfileRequest;
-import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.statistics.user.service.UserStatisticsAdminService;
 import org.swyp.dessertbee.auth.dto.request.PasswordResetRequest;
 import org.swyp.dessertbee.auth.dto.response.PasswordResetResponse;
@@ -217,7 +215,7 @@ public class AuthController {
             }
     )
     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공", content = @Content(schema = @Schema(implementation = TokenResponse.class)))
-    @ApiErrorResponses({ErrorCode.INVALID_CREDENTIALS, ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.EXPIRED_VERIFICATION_TOKEN, ErrorCode.DEVICE_ID_MISSING})
+    @ApiErrorResponses({ErrorCode.INVALID_CREDENTIALS, ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.DEVICE_ID_MISSING})
     @PostMapping("/token/refresh")
     public ResponseEntity<TokenResponse> refreshToken(
             @Parameter(description = "리프레시 토큰 (Bearer 형식)", required = true)
@@ -284,7 +282,7 @@ public class AuthController {
             }
     )
     @ApiResponse(responseCode = "200", description = "비밀번호 재설정 성공")
-    @ApiErrorResponses({ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.EXPIRED_VERIFICATION_TOKEN, ErrorCode.USER_NOT_FOUND})
+    @ApiErrorResponses({ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.USER_NOT_FOUND})
     @PostMapping("/password/reset")
     public ResponseEntity<PasswordResetResponse> resetPassword(
             @Parameter(description = "이메일 인증 토큰", required = true)

--- a/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/auth/exception/AuthExceptions.java
@@ -48,19 +48,6 @@ public class AuthExceptions {
     }
 
     /**
-     * 인증 토큰 만료 예외
-     */
-    public static class ExpiredVerificationTokenException extends BusinessException {
-        public ExpiredVerificationTokenException() {
-            super(ErrorCode.EXPIRED_VERIFICATION_TOKEN);
-        }
-
-        public ExpiredVerificationTokenException(String message) {
-            super(ErrorCode.EXPIRED_VERIFICATION_TOKEN, message);
-        }
-    }
-
-    /**
      * 비밀번호 불일치 예외
      */
     public static class PasswordMismatchException extends BusinessException {

--- a/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
@@ -213,12 +213,6 @@ public class TokenService {
                 throw new JwtTokenException(ErrorCode.INVALID_VERIFICATION_TOKEN, "유효하지 않은 리프레시 토큰입니다.");
             }
 
-            // 리프레시 토큰 만료 여부 KST 기준으로 확인
-            if (auth.getRefreshTokenExpiresAt().isBefore(LocalDateTime.now(KST))) {
-                log.warn("리프레시 토큰 검증 실패 - 만료된 토큰: {}, 디바이스: {}", email, deviceId);
-                throw new JwtTokenException(ErrorCode.EXPIRED_VERIFICATION_TOKEN, "리프레시 토큰이 만료되었습니다.");
-            }
-
             // 새로운 Access Token 생성
             List<String> roles = user.getUserRoles().stream()
                     .map(userRole -> userRole.getRole().getName().getRoleName())

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A001", "이미 등록된 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "A002", "이미 사용중인 닉네임입니다."),
     INVALID_VERIFICATION_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 인증 토큰입니다."),
-    EXPIRED_VERIFICATION_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "만료된 인증 토큰입니다."),
+    FORBIDDEN_OPERATION(HttpStatus.FORBIDDEN, "A004", "이 작업은 허용되지 않습니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "A005", "비밀번호가 일치하지 않습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A006", "잘못된 인증 정보입니다."),
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "A007", "인증에 실패했습니다."),
@@ -46,6 +46,7 @@ public enum ErrorCode {
     // Email
     EMAIL_SENDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E005", "이메일 발송에 실패했습니다."),
     TOO_MANY_VERIFICATION_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "E001", "너무 많은 인증 요청이 있었습니다. 잠시 후 다시 시도해주세요."),
+    EXPIRED_EMAIL_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED, "E002", "만료된 인증 코드입니다."),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -53,6 +53,7 @@ public enum ErrorCode {
     INVALID_USER_STATUS(HttpStatus.BAD_REQUEST, "U003", "유효하지 않은 사용자 상태입니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "U004", "해당 정보에 대한 접근 권한이 없습니다."),
     INVALID_USER_UUID(HttpStatus.BAD_REQUEST, "U005", "유효하지 않은 사용자 식별자입니다."),
+    OWNER_ROLE_MISSING_INFO(HttpStatus.BAD_REQUEST, "U006", "사장 권한을 부여하려면 이름과 전화번호 정보가 필요합니다."),
 
     // Preference
     PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 취향 태그입니다."),

--- a/src/main/java/org/swyp/dessertbee/config/RoleHierarchyConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/RoleHierarchyConfig.java
@@ -1,0 +1,31 @@
+package org.swyp.dessertbee.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.SecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.web.FilterInvocation;
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
+
+import static org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl.fromHierarchy;
+
+@Configuration
+@EnableMethodSecurity
+public class RoleHierarchyConfig {
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return fromHierarchy("""
+                ROLE_ADMIN > ROLE_OWNER
+                ROLE_OWNER > ROLE_USER
+                """);
+    }
+
+    @Bean
+    public SecurityExpressionHandler<FilterInvocation> expressionHandler() {
+        DefaultWebSecurityExpressionHandler handler = new DefaultWebSecurityExpressionHandler();
+        handler.setRoleHierarchy(roleHierarchy());
+        return handler;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -1,10 +1,12 @@
 package org.swyp.dessertbee.config;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import org.springframework.http.HttpMethod;
+
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -17,17 +19,13 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
+
 import org.swyp.dessertbee.auth.jwt.JWTFilter;
 import org.swyp.dessertbee.auth.jwt.JWTUtil;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.swyp.dessertbee.auth.repository.AuthRepository;
 import org.swyp.dessertbee.auth.service.CustomUserDetailsService;
-import org.swyp.dessertbee.user.repository.UserRepository;
 
-import java.util.Arrays;
-import java.util.Collections;
+import org.swyp.dessertbee.user.repository.UserRepository;
 
 /**
  * 스프링 시큐리티 설정 클래스

--- a/src/main/java/org/swyp/dessertbee/email/controller/EmailVerificationController.java
+++ b/src/main/java/org/swyp/dessertbee/email/controller/EmailVerificationController.java
@@ -68,7 +68,7 @@ public class EmailVerificationController {
     )
     @ApiErrorResponses({
             ErrorCode.INVALID_VERIFICATION_TOKEN,
-            ErrorCode.EXPIRED_VERIFICATION_TOKEN,
+            ErrorCode.EXPIRED_EMAIL_VERIFICATION_CODE,
             ErrorCode.INTERNAL_SERVER_ERROR
     })
     @PostMapping("/verify")

--- a/src/main/java/org/swyp/dessertbee/email/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/email/service/EmailVerificationServiceImpl.java
@@ -122,7 +122,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
             // 만료 여부 확인
             if (verification.isExpired()) {
                 log.warn("이메일 인증 실패 - 만료된 인증 코드, 이메일: {}", request.getEmail());
-                throw new BusinessException(ErrorCode.EXPIRED_VERIFICATION_TOKEN, "만료된 인증 코드입니다.");
+                throw new BusinessException(ErrorCode.EXPIRED_EMAIL_VERIFICATION_CODE, "만료된 인증 코드입니다.");
             }
 
             // 이미 검증된 코드인지 확인

--- a/src/main/java/org/swyp/dessertbee/role/service/UserRoleService.java
+++ b/src/main/java/org/swyp/dessertbee/role/service/UserRoleService.java
@@ -183,6 +183,18 @@ public class UserRoleService {
                     "ADMIN 권한은 부여할 수 없습니다.");
         }
 
+        // 사장 권한 부여 시도 여부 확인
+        boolean attemptToGrantOwner = roleNames.stream()
+                .anyMatch(role -> role.equals("ROLE_OWNER"));
+
+        // 사장 권한 부여 시 이름과 전화번호 유효성 검증
+        if (attemptToGrantOwner) {
+            if (user.getName() == null || user.getName().trim().isEmpty() ||
+                    user.getPhoneNumber() == null || user.getPhoneNumber().trim().isEmpty()) {
+                throw new BusinessException(ErrorCode.OWNER_ROLE_MISSING_INFO);
+            }
+        }
+
         // 현재 사용자가 이미 ADMIN 권한을 가지고 있는지 확인
         boolean hasAdminRole = hasUserRole(user, RoleType.ROLE_ADMIN);
 

--- a/src/main/java/org/swyp/dessertbee/role/service/UserRoleService.java
+++ b/src/main/java/org/swyp/dessertbee/role/service/UserRoleService.java
@@ -162,4 +162,46 @@ public class UserRoleService {
 
         return getUserRoles(user);
     }
+
+    /**
+     * 사용자의 역할(권한) 정보를 업데이트합니다.
+     * ROLE_ADMIN 권한은 부여할 수 없습니다.
+     */
+    @Transactional
+    public void updateUserRoles(UserEntity user, List<String> roleNames) {
+        // 역할이 null이거나 비어있으면 업데이트하지 않음
+        if (roleNames == null || roleNames.isEmpty()) {
+            return;
+        }
+
+        // ADMIN 권한 부여 시도 여부 확인
+        boolean attemptToGrantAdmin = roleNames.stream()
+                .anyMatch(role -> role.equals("ROLE_ADMIN"));
+
+        if (attemptToGrantAdmin) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_OPERATION,
+                    "ADMIN 권한은 부여할 수 없습니다.");
+        }
+
+        // 현재 사용자가 이미 ADMIN 권한을 가지고 있는지 확인
+        boolean hasAdminRole = hasUserRole(user, RoleType.ROLE_ADMIN);
+
+        // 요청된 역할 타입으로 변환
+        List<RoleType> requestedRoleTypes = roleNames.stream()
+                .map(RoleType::fromString)
+                .collect(Collectors.toList());
+
+        // ADMIN 권한이 있었다면 유지하기 위해 목록에 추가
+        if (hasAdminRole && !requestedRoleTypes.contains(RoleType.ROLE_ADMIN)) {
+            requestedRoleTypes.add(RoleType.ROLE_ADMIN);
+        }
+
+        // UserRoleService를 사용하여 역할 설정
+        setUserRoles(user, requestedRoleTypes);
+
+        log.info("사용자 역할 업데이트 완료 - 이메일: {}, 역할: {}",
+                user.getEmail(),
+                getUserRoles(user));
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
@@ -96,7 +96,7 @@ public class UserController {
                     schema = @Schema(implementation = UserDetailResponseDto.class)
             )
     )
-    @ApiErrorResponses({ErrorCode.UNAUTHORIZED_ACCESS, ErrorCode.INVALID_INPUT_VALUE, ErrorCode.DUPLICATE_NICKNAME})
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED_ACCESS, ErrorCode.INVALID_INPUT_VALUE, ErrorCode.DUPLICATE_NICKNAME, ErrorCode.FORBIDDEN_OPERATION})
     @PatchMapping(value="/me")
     public ResponseEntity<UserDetailResponseDto> updateMyInfo(@RequestBody @Valid UserUpdateRequestDto updateRequest) {
 

--- a/src/main/java/org/swyp/dessertbee/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/request/UserUpdateRequestDto.java
@@ -74,7 +74,7 @@ public class UserUpdateRequestDto {
 
     @Schema(
             description = "사용자 역할 목록 (ROLE_USER/ROLE_OWNER)",
-            example = "[\"ROLE_OWNER\"]",
+            example = "[\"ROLE_OWNER\", \"ROLE_USER\"]",
             nullable = true,
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )

--- a/src/main/java/org/swyp/dessertbee/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/request/UserUpdateRequestDto.java
@@ -72,10 +72,19 @@ public class UserUpdateRequestDto {
     )
     private String mbti;
 
+    @Schema(
+            description = "사용자 역할 목록 (ROLE_USER/ROLE_OWNER)",
+            example = "[\"ROLE_OWNER\"]",
+            nullable = true,
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private List<String> roles;
+
+
     @Builder
     public UserUpdateRequestDto(String nickname, List<Long> preferences, String name,
                                 String phoneNumber, String address, UserEntity.Gender gender,
-                                String mbti) {
+                                String mbti, List<String> roles) {
         this.nickname = nickname;
         this.preferences = preferences;
         this.name = name;
@@ -83,5 +92,6 @@ public class UserUpdateRequestDto {
         this.address = address;
         this.gender = gender;
         this.mbti = mbti;
+        this.roles = roles;
     }
 }

--- a/src/main/java/org/swyp/dessertbee/user/dto/response/UserDetailResponseDto.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/response/UserDetailResponseDto.java
@@ -52,16 +52,26 @@ public class UserDetailResponseDto extends UserResponseDto {
     )
     private Boolean isPreferencesSet;  // 선호도 설정 여부
 
+    @Schema(
+            description = "사용자 역할 목록 (ROLE_USER/ROLE_OWNER)",
+            example = "[\"ROLE_OWNER\"]",
+            nullable = true,
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private List<String> roles;
+
+
     @Builder(builderMethodName = "detailBuilder")
     public UserDetailResponseDto(String userUuid, String nickname, UserEntity.Gender gender,
                                  String profileImage, List<Long> preferences, String mbti,
                                  String email, String name, String phoneNumber, String address,
-                                 Boolean isPreferencesSet) {
+                                 Boolean isPreferencesSet, List<String> roles) {
         super(userUuid, nickname, gender, profileImage, preferences, mbti);
         this.email = email;
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.address = address;
         this.isPreferencesSet = isPreferencesSet;
+        this.roles = roles;
     }
 }


### PR DESCRIPTION
## :hash: 연관된 이슈
#276 
## :memo: 작업 내용
- RoleHierarchyImpl을 사용하여 코드 레벨에서도 계층적 권한 구조를 구현
  - ROLE_ADMIN > ROLE_OWNER > ROLE_USER 형태로 계층 정의
  - ADMIN 권한은 부여할 수 없도록 제한
- 자신의 역할, 권한을 조회하고 업데이트할 수 있는 기능 구현
  - 사용자 상세 정보에 역할 목록 포함
- 오류 코드 추가 및 변경 
  - 관리자 권한(ADMIN) 부여 시도와 같은 금지된 작업에 대한 오류 코드 추가
  - 이메일 인증 코드 만료를 명확히 구분하기 위한 오류 코드 추가

### 스크린샷 (선택)
<img width="463" alt="image" src="https://github.com/user-attachments/assets/ef91d21e-965b-476a-a1fa-f46b51d58d88" />