### PR TITLE
[FEATURE] 가게 통계 기간별 조회 스케줄러

### DIFF
--- a/src/main/java/org/swyp/dessertbee/statistics/common/scheduler/StoreStatisticsScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/common/scheduler/StoreStatisticsScheduler.java
@@ -1,0 +1,76 @@
+package org.swyp.dessertbee.statistics.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.statistics.store.entity.StoreStatistics;
+import org.swyp.dessertbee.statistics.store.repostiory.StoreStatisticsRepository;
+import org.swyp.dessertbee.statistics.store.repostiory.StoreStatisticsSummaryRepository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 매일 자정에 실행되어 가게별 주간/월간 통계를 요약 저장
+ * 기준일: 오늘 - 1일 (어제까지의 통계 데이터 집계)
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreStatisticsScheduler {
+
+    private final StoreStatisticsRepository statisticsRepository;
+    private final StoreStatisticsSummaryRepository summaryRepository;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정
+    @Transactional
+    public void summarizeStatistics() {
+        log.info("[통계 요약] 주간/월간 집계 시작");
+
+        List<Long> storeIds = statisticsRepository.findAllStoreIds();
+
+        for (Long storeId : storeIds) {
+            LocalDate today = LocalDate.now();
+
+            // 자정 스케줄러 실행 시 오늘 데이터는 없을 것이기 때문에 어제까지를 기준으로 데이터 집계
+            LocalDate targetDate = today.minusDays(1);
+
+            // 주간
+            summarizePeriod(storeId, targetDate.minusDays(6), targetDate, "WEEK");
+            // 월간
+            summarizePeriod(storeId, targetDate.minusDays(29), targetDate, "MONTH");
+        }
+
+        log.info("[통계 요약] 집계 완료");
+    }
+
+    private void summarizePeriod(Long storeId, LocalDate startDate, LocalDate endDate, String periodType) {
+        List<StoreStatistics> stats = statisticsRepository
+                .findByStoreIdAndDeletedAtIsNullAndStatDateBetweenOrderByStatDateAsc(storeId, startDate, endDate);
+
+        if (stats.isEmpty()) return;
+
+        summaryRepository.upsertSummary(
+                storeId,
+                periodType,
+                startDate,
+                endDate,
+                stats.stream().mapToInt(StoreStatistics::getViews).sum(),
+                stats.stream().mapToInt(StoreStatistics::getSaves).sum(),
+                stats.stream().mapToInt(StoreStatistics::getStoreReviewCount).sum(),
+                stats.stream().mapToInt(StoreStatistics::getCommunityReviewCount).sum(),
+                stats.stream().mapToInt(StoreStatistics::getDessertMateCount).sum(),
+                stats.stream().mapToInt(StoreStatistics::getCouponUseCount).sum(),
+                stats.stream()
+                        .map(StoreStatistics::getAverageRating)
+                        .filter(Objects::nonNull)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add)
+                        .divide(new BigDecimal(stats.size()), 1, RoundingMode.HALF_UP)
+        );
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/statistics/common/scheduler/StoreStatisticsScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/common/scheduler/StoreStatisticsScheduler.java
@@ -6,6 +6,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.swyp.dessertbee.statistics.store.entity.StoreStatistics;
+import org.swyp.dessertbee.statistics.store.entity.enums.PeriodType;
 import org.swyp.dessertbee.statistics.store.repostiory.StoreStatisticsRepository;
 import org.swyp.dessertbee.statistics.store.repostiory.StoreStatisticsSummaryRepository;
 
@@ -41,15 +42,15 @@ public class StoreStatisticsScheduler {
             LocalDate targetDate = today.minusDays(1);
 
             // 주간
-            summarizePeriod(storeId, targetDate.minusDays(6), targetDate, "WEEK");
+            summarizePeriod(storeId, targetDate.minusDays(6), targetDate, PeriodType.WEEK);
             // 월간
-            summarizePeriod(storeId, targetDate.minusDays(29), targetDate, "MONTH");
+            summarizePeriod(storeId, targetDate.minusDays(29), targetDate, PeriodType.MONTH);
         }
 
         log.info("[통계 요약] 집계 완료");
     }
 
-    private void summarizePeriod(Long storeId, LocalDate startDate, LocalDate endDate, String periodType) {
+    private void summarizePeriod(Long storeId, LocalDate startDate, LocalDate endDate, PeriodType periodType) {
         List<StoreStatistics> stats = statisticsRepository
                 .findByStoreIdAndDeletedAtIsNullAndStatDateBetweenOrderByStatDateAsc(storeId, startDate, endDate);
 
@@ -57,7 +58,7 @@ public class StoreStatisticsScheduler {
 
         summaryRepository.upsertSummary(
                 storeId,
-                periodType,
+                periodType.name(),
                 startDate,
                 endDate,
                 stats.stream().mapToInt(StoreStatistics::getViews).sum(),

--- a/src/main/java/org/swyp/dessertbee/statistics/store/entity/CouponUseLog.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/entity/CouponUseLog.java
@@ -22,9 +22,9 @@ public class CouponUseLog {
 
     private Long storeId;
 
+    private UUID couponUuid;
+
     private UUID userUuid;
 
     private LocalDateTime usedAt;
-
-    private String couponCode; // todo: 쿠폰 식별자 역할 (미정)
 }

--- a/src/main/java/org/swyp/dessertbee/statistics/store/entity/StoreStatistics.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/entity/StoreStatistics.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.statistics.store.entity;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -8,56 +9,78 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+/**
+ * 일 단위의 통계 데이터를 저장
+ * (원본 로그 기반)
+ */
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "store_statistics")
+@Table(name = "store_statistics", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"store_id", "stat_date"})
+})
 public class StoreStatistics {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "통계 ID", example = "1")
     private Long statisticsId;
 
-    @Column(name = "store_id")
+    @Column(name = "store_id", nullable = false)
+    @Schema(description = "가게 ID", example = "1001")
     private Long storeId;
+
+    @Column(name = "stat_date", nullable = false)
+    @Schema(description = "통계 집계 기준 날짜", example = "2025-04-17")
+    private LocalDate statDate;
 
     @Builder.Default
     @Column(nullable = false)
+    @Schema(description = "가게 조회 수", example = "150")
     private Integer views = 0;
 
     @Builder.Default
     @Column(nullable = false)
+    @Schema(description = "가게 저장 수", example = "45")
     private Integer saves = 0;
 
     @Builder.Default
     @Column(name = "store_review_count", nullable = false)
+    @Schema(description = "가게 자체 리뷰 수", example = "12")
     private Integer storeReviewCount = 0;
 
     @Builder.Default
     @Column(name = "community_review_count", nullable = false)
+    @Schema(description = "커뮤니티 연동 리뷰 수", example = "7")
     private Integer communityReviewCount = 0;
 
     @Builder.Default
     @Column(name = "dessert_mate_count", nullable = false)
+    @Schema(description = "디저트 메이트 매칭 수", example = "3")
     private Integer dessertMateCount = 0;
 
     @Builder.Default
     @Column(name = "coupon_use_count", nullable = false)
+    @Schema(description = "쿠폰 사용 횟수", example = "25")
     private Integer couponUseCount = 0;
 
-    @Column(name = "average_rating", precision = 2, scale = 1)
-    private BigDecimal averageRating;
-
-    private LocalDate createDate; // 가게가 등록된 날짜
+    @Builder.Default
+    @Column(name = "average_rating", precision = 2, scale = 1, nullable = false)
+    @Schema(description = "가게 평균 평점", example = "4.3")
+    private BigDecimal averageRating = BigDecimal.ZERO;
 
     @CreationTimestamp
-    private LocalDateTime createdAt; // 가게 통계가 집계된 시간
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Schema(description = "통계 레코드 생성 시각", example = "2025-04-17T00:00:00")
+    private LocalDateTime createdAt;
 
-    private LocalDateTime deletedAt; // 가게, 통계가 삭제(무효화)된 시간
+    @Column(name = "deleted_at")
+    @Schema(description = "소프트 삭제된 시각 (null이면 유효)", example = "2025-04-20T00:00:00", nullable = true)
+    private LocalDateTime deletedAt;
 
-    public void softDelete(){
+    public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/statistics/store/entity/StoreStatisticsSummary.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/entity/StoreStatisticsSummary.java
@@ -1,0 +1,54 @@
+package org.swyp.dessertbee.statistics.store.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 기간 단위(주간/월간/사용자 지정)로 집계된 요약 통계 저장
+ * (빠른 조회용)
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "store_statistics_summary", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"store_id", "period_type", "start_date", "end_date"})
+})
+public class StoreStatisticsSummary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false)
+    private String periodType; // WEEK, MONTH, CUSTOM
+
+    private Integer totalViews;
+    private Integer totalSaves;
+    private Integer totalStoreReviewCount;
+    private Integer totalCommunityReviewCount;
+    private Integer totalDessertMateCount;
+    private Integer totalCouponUseCount;
+
+    private BigDecimal averageRating;
+
+    private LocalDateTime createdAt;
+}
+

--- a/src/main/java/org/swyp/dessertbee/statistics/store/entity/StoreStatisticsSummary.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/entity/StoreStatisticsSummary.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.swyp.dessertbee.statistics.store.entity.enums.PeriodType;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -37,8 +38,9 @@ public class StoreStatisticsSummary {
     @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String periodType; // WEEK, MONTH, CUSTOM
+    private PeriodType periodType; // WEEK, MONTH, CUSTOM
 
     private Integer totalViews;
     private Integer totalSaves;

--- a/src/main/java/org/swyp/dessertbee/statistics/store/entity/enums/PeriodType.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/entity/enums/PeriodType.java
@@ -1,0 +1,5 @@
+package org.swyp.dessertbee.statistics.store.entity.enums;
+
+public enum PeriodType {
+    WEEK, MONTH, CUSTOM
+}

--- a/src/main/java/org/swyp/dessertbee/statistics/store/event/CouponUseEvent.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/event/CouponUseEvent.java
@@ -10,5 +10,5 @@ import java.util.UUID;
 public class CouponUseEvent {
     private final Long storeId;
     private final UUID userUuid;
-    private final String couponCode;
+    private final UUID couponUuid;
 }

--- a/src/main/java/org/swyp/dessertbee/statistics/store/repostiory/CouponUseLogRepository.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/repostiory/CouponUseLogRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.statistics.store.entity.CouponUseLog;
 
+import java.util.UUID;
+
 @Repository
 public interface CouponUseLogRepository extends JpaRepository<CouponUseLog, Long> {
+    boolean existsByCouponUuidAndUserUuid(UUID couponUuid, UUID userUuid);
 }

--- a/src/main/java/org/swyp/dessertbee/statistics/store/repostiory/StoreStatisticsRepository.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/repostiory/StoreStatisticsRepository.java
@@ -7,13 +7,28 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.statistics.store.entity.StoreStatistics;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface StoreStatisticsRepository extends JpaRepository<StoreStatistics, Long> {
 
+    /** 삭제되지 않은 전체 가게 id 조회 */
+    @Query("SELECT DISTINCT s.storeId FROM StoreStatistics s WHERE s.deletedAt IS NULL")
+    List<Long> findAllStoreIds();
+
+    /** 삭제되지 않은 특정 가게의 전체 통계 조회 */
     List<StoreStatistics> findAllByStoreIdAndDeletedAtIsNull(Long storeId);
+
+    /** 삭제되지 않은 특정 가게의 특정 기간 통계 조회 */
+    List<StoreStatistics> findByStoreIdAndDeletedAtIsNullAndStatDateBetween(
+            Long storeId, LocalDate start, LocalDate end);
+
+    /** 삭제되지 않은 특정 가게의 특정 기간 통계 조회 (오름차순 정렬) */
+    List<StoreStatistics> findByStoreIdAndDeletedAtIsNullAndStatDateBetweenOrderByStatDateAsc(
+            Long storeId, LocalDate start, LocalDate end
+    );
 
     /** 한줄리뷰 수 증가 */
     @Modifying(clearAutomatically = true)

--- a/src/main/java/org/swyp/dessertbee/statistics/store/repostiory/StoreStatisticsSummaryRepository.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/repostiory/StoreStatisticsSummaryRepository.java
@@ -1,0 +1,64 @@
+package org.swyp.dessertbee.statistics.store.repostiory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.statistics.store.entity.StoreStatisticsSummary;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface StoreStatisticsSummaryRepository extends JpaRepository<StoreStatisticsSummary, Long> {
+    List<StoreStatisticsSummary> findByStoreIdAndPeriodType(Long storeId, String periodType);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+    INSERT INTO store_statistics_summary (
+        store_id, period_type, start_date, end_date,
+        total_views, total_saves, total_store_review_count,
+        total_community_review_count, total_dessert_mate_count,
+        total_coupon_use_count, average_rating, created_at
+    ) VALUES (
+        :storeId, :periodType, :startDate, :endDate,
+        :views, :saves, :storeReviewCount,
+        :communityReviewCount, :mateCount,
+        :couponCount, :averageRating
+    )
+    ON DUPLICATE KEY UPDATE
+        total_views = VALUES(total_views),
+        total_saves = VALUES(total_saves),
+        total_store_review_count = VALUES(total_store_review_count),
+        total_community_review_count = VALUES(total_community_review_count),
+        total_dessert_mate_count = VALUES(total_dessert_mate_count),
+        total_coupon_use_count = VALUES(total_coupon_use_count),
+        average_rating = VALUES(average_rating),
+        created_at = NOW()
+    """, nativeQuery = true)
+    void upsertSummary(
+            @Param("storeId") Long storeId,
+            @Param("periodType") String periodType,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("views") int views,
+            @Param("saves") int saves,
+            @Param("storeReviewCount") int storeReviewCount,
+            @Param("communityReviewCount") int communityReviewCount,
+            @Param("mateCount") int mateCount,
+            @Param("couponCount") int couponCount,
+            @Param("averageRating") BigDecimal averageRating
+    );
+
+    /**
+     * 예전 데이터를 재집계하거나 초기화하기 위함
+     */
+    void deleteByStoreIdAndPeriodTypeAndStartDateAndEndDate(
+            Long storeId,
+            String periodType,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
@@ -122,14 +122,8 @@ public class StoreServiceImpl implements StoreService {
             storeStatisticsRepository.save(
                     StoreStatistics.builder()
                             .storeId(store.getStoreId())
-                            .views(0)
-                            .saves(0)
-                            .storeReviewCount(0)
-                            .communityReviewCount(0)
-                            .dessertMateCount(0)
-                            .couponUseCount(0)
+                            .statDate(LocalDate.now())
                             .averageRating(BigDecimal.ZERO)
-                            .createDate(store.getCreatedAt().toLocalDate())
                             .build()
             );
 


### PR DESCRIPTION
## :hash: 연관된 이슈

> #333 

## :memo: 작업 내용

> 쿠폰 사용 시 로그 저장
> 로그를 집계해서 기간별 통계 데이터 생성 로직 개발
> -> 주간(7일) / 월간(30일) (기본은 최근 30일, 캘린더에서 시작일자/종료일자 선택 가능. 조회기간 최대 90일로 제한)
> 주기적 집계를 위한 @scheduled 작업 스케줄링 (매일 자정마다 집계)
