### PR TITLE
[FEATURE] Elasticsearch 기반 가게 검색 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
 
+    // Java API Client (Elasticsearch)
+    implementation 'co.elastic.clients:elasticsearch-java:8.13.2'
+
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,9 +48,25 @@ services:
       - redis-data:/data
     command: ["redis-server", "--appendonly", "yes"]
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.0
+    container_name: desserbee-es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    networks:
+      - app-network
+    restart: always
+
 networks:
   app-network:
     driver: bridge
 
 volumes:
   redis-data:
+  es-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     command: ["redis-server", "--appendonly", "yes"]
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.2
     container_name: desserbee-es
     environment:
       - discovery.type=single-node

--- a/src/main/java/org/swyp/dessertbee/common/exception/BusinessException.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/BusinessException.java
@@ -19,4 +19,9 @@ public class BusinessException extends RuntimeException {
         super(message);
         this.errorCode = errorCode;
     }
+
+    public BusinessException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause); // RuntimeException(message, cause)
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     // Common
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 에러가 발생했습니다."),
+    INVALID_PLATFORM_VALUE(HttpStatus.BAD_REQUEST, "C003", "잘못된 플랫폼 헤더 입력값입니다."),
 
     // Auth
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A001", "이미 등록된 이메일입니다."),
@@ -68,6 +69,7 @@ public enum ErrorCode {
     POPULAR_KEYWORD_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "K006", "인기 검색 기록 생성에 실패했습니다."),
     POPULAR_KEYWORD_SYNC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "K007", "인기 검색 기록 동기화에 실패했습니다."),
     POPULAR_KEYWORD_INIT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "K008", "인기 검색 기록 초기화에 실패했습니다."),
+    ELASTICSEARCH_COMMUNICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "K009", "Elasticsearch 통신 중 오류가 발생했습니다."),
 
     // Log
     MATE_LOG_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "L001", "디저트 메이트 로그 저장에 실패했습니다."),

--- a/src/main/java/org/swyp/dessertbee/common/scheduler/SearchScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/common/scheduler/SearchScheduler.java
@@ -3,7 +3,7 @@ package org.swyp.dessertbee.common.scheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.swyp.dessertbee.common.service.SearchService;
+import org.swyp.dessertbee.search.service.SearchService;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/swyp/dessertbee/config/ElasticsearchConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/ElasticsearchConfig.java
@@ -1,0 +1,27 @@
+package org.swyp.dessertbee.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchConfig {
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        RestClient restClient = RestClient.builder(
+                new HttpHost("localhost", 9200, "http")
+        ).build();
+
+        ElasticsearchTransport transport = new RestClientTransport(
+                restClient, new JacksonJsonpMapper()
+        );
+
+        return new ElasticsearchClient(transport);
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/search/controller/SearchController.java
+++ b/src/main/java/org/swyp/dessertbee/search/controller/SearchController.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.common.controller;
+package org.swyp.dessertbee.search.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -11,11 +11,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
-import org.swyp.dessertbee.common.dto.PopularSearchesList;
-import org.swyp.dessertbee.common.dto.UserSearchHistoryDto;
-import org.swyp.dessertbee.common.exception.SearchExceptions.*;
+import org.swyp.dessertbee.search.dto.PopularSearchesList;
+import org.swyp.dessertbee.search.dto.UserSearchHistoryDto;
+import org.swyp.dessertbee.search.exception.SearchExceptions.*;
 import org.swyp.dessertbee.common.exception.ErrorCode;
-import org.swyp.dessertbee.common.service.SearchService;
+import org.swyp.dessertbee.search.service.SearchService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.service.UserService;
 

--- a/src/main/java/org/swyp/dessertbee/search/controller/StoreSearchController.java
+++ b/src/main/java/org/swyp/dessertbee/search/controller/StoreSearchController.java
@@ -1,0 +1,40 @@
+package org.swyp.dessertbee.search.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swyp.dessertbee.search.service.StoreSearchService;
+
+@Tag(name = "StoreSearch", description = "가게 검색 관련 API")
+@RestController
+@RequestMapping("/api/stores/search")
+@RequiredArgsConstructor
+public class StoreSearchController {
+
+    private final StoreSearchService storeSearchService;
+
+    /**
+     * (관리자 전용) 모든 가게 데이터를 Elasticsearch에 색인
+     */
+    @Operation(
+            summary = "(관리자) 가게 데이터 Elasticsearch 마이그레이션",
+            description = """
+                DB에 존재하는 모든 가게 데이터를 Elasticsearch에 일괄 색인합니다.
+                운영 중에는 자주 호출하지 않으며, 보통 초기 세팅 시 사용됩니다.
+                관리자(ROLE_ADMIN) 권한 필요
+                """
+    )
+    @ApiResponse(responseCode = "200", description = "Elasticsearch 색인 마이그레이션 완료")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
+    @PostMapping("/migrate")
+    public ResponseEntity<String> migrateAllStoresToElasticsearch() {
+        storeSearchService.migrateStoresToElasticsearch();
+        return ResponseEntity.ok("Elasticsearch 색인 마이그레이션 완료");
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/search/controller/StoreSearchController.java
+++ b/src/main/java/org/swyp/dessertbee/search/controller/StoreSearchController.java
@@ -31,6 +31,7 @@ public class StoreSearchController {
                 """
     )
     @ApiResponse(responseCode = "200", description = "Elasticsearch 색인 마이그레이션 완료")
+    @ApiResponse(responseCode = "500", description = "Elasticsearch 색인 중 오류 발생 (IOException 또는 연결 실패)")
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
     @PostMapping("/migrate")
     public ResponseEntity<String> migrateAllStoresToElasticsearch() {

--- a/src/main/java/org/swyp/dessertbee/search/doc/StoreDocument.java
+++ b/src/main/java/org/swyp/dessertbee/search/doc/StoreDocument.java
@@ -1,0 +1,38 @@
+package org.swyp.dessertbee.search.doc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreDocument {
+
+    @JsonProperty("storeId")
+    private Long storeId;
+
+    @JsonProperty("storeUuid")
+    private UUID storeUuid;
+
+    @JsonProperty("storeName")
+    private String storeName;
+
+    @JsonProperty("address")
+    private String address;
+
+    @JsonProperty("tagNames")
+    private List<String> tagNames;
+
+    @JsonProperty("menuNames")
+    private List<String> menuNames;
+
+    @JsonProperty("deleted")
+    private boolean deleted;
+}

--- a/src/main/java/org/swyp/dessertbee/search/dto/PopularSearchResponse.java
+++ b/src/main/java/org/swyp/dessertbee/search/dto/PopularSearchResponse.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.common.dto;
+package org.swyp.dessertbee.search.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/org/swyp/dessertbee/search/dto/PopularSearchesList.java
+++ b/src/main/java/org/swyp/dessertbee/search/dto/PopularSearchesList.java
@@ -1,8 +1,7 @@
-package org.swyp.dessertbee.common.dto;
+package org.swyp.dessertbee.search.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/org/swyp/dessertbee/search/dto/StoreSearchResponse.java
+++ b/src/main/java/org/swyp/dessertbee/search/dto/StoreSearchResponse.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.store.store.dto.response;
+package org.swyp.dessertbee.search.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/swyp/dessertbee/search/dto/StoreSearchWrapperResponse.java
+++ b/src/main/java/org/swyp/dessertbee/search/dto/StoreSearchWrapperResponse.java
@@ -1,0 +1,26 @@
+package org.swyp.dessertbee.search.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.swyp.dessertbee.store.store.dto.response.StoreSummaryResponse;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "검색 결과 응답")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StoreSearchWrapperResponse {
+
+    @Schema(description = "가게 검색 결과 목록 (검색 결과가 여러 개일 경우에만 사용)")
+    private List<StoreSearchResponse> stores;
+
+    @Schema(description = "검색 결과가 하나일 경우 자동으로 포함되는 간략 정보")
+    private StoreSummaryResponse summary;
+}

--- a/src/main/java/org/swyp/dessertbee/search/dto/UserSearchHistoryDto.java
+++ b/src/main/java/org/swyp/dessertbee/search/dto/UserSearchHistoryDto.java
@@ -1,11 +1,11 @@
-package org.swyp.dessertbee.common.dto;
+package org.swyp.dessertbee.search.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.swyp.dessertbee.common.entity.UserSearchHistory;
+import org.swyp.dessertbee.search.entity.UserSearchHistory;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/org/swyp/dessertbee/search/entity/PopularSearchKeyword.java
+++ b/src/main/java/org/swyp/dessertbee/search/entity/PopularSearchKeyword.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.common.entity;
+package org.swyp.dessertbee.search.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/org/swyp/dessertbee/search/entity/UserSearchHistory.java
+++ b/src/main/java/org/swyp/dessertbee/search/entity/UserSearchHistory.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.common.entity;
+package org.swyp.dessertbee.search.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/org/swyp/dessertbee/search/exception/SearchExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/search/exception/SearchExceptions.java
@@ -1,4 +1,7 @@
-package org.swyp.dessertbee.common.exception;
+package org.swyp.dessertbee.search.exception;
+
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 
 /**
  * 가게 한줄리뷰 관련 예외 클래스들을 모아둔 클래스
@@ -106,6 +109,19 @@ public class SearchExceptions {
 
         public PopularInitFailedException(String message) {
             super(ErrorCode.POPULAR_KEYWORD_INIT_FAILED, message);
+        }
+    }
+
+    /**
+     * 인기 검색어 초기화 예외
+     */
+    public static class InvalidPlatformException extends BusinessException {
+        public InvalidPlatformException() {
+            super(ErrorCode.INVALID_PLATFORM_VALUE);
+        }
+
+        public InvalidPlatformException(String message) {
+            super(ErrorCode.INVALID_PLATFORM_VALUE, message);
         }
     }
 }

--- a/src/main/java/org/swyp/dessertbee/search/exception/SearchExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/search/exception/SearchExceptions.java
@@ -124,4 +124,21 @@ public class SearchExceptions {
             super(ErrorCode.INVALID_PLATFORM_VALUE, message);
         }
     }
+
+    /**
+     * Elasticsearch 통신 오류 예외
+     */
+    public static class ElasticsearchCommunicationException extends BusinessException {
+        public ElasticsearchCommunicationException() {
+            super(ErrorCode.ELASTICSEARCH_COMMUNICATION_FAILED);
+        }
+
+        public ElasticsearchCommunicationException(String message) {
+            super(ErrorCode.ELASTICSEARCH_COMMUNICATION_FAILED, message);
+        }
+
+        public ElasticsearchCommunicationException(String message, Throwable cause) {
+            super(ErrorCode.ELASTICSEARCH_COMMUNICATION_FAILED, message, cause);
+        }
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/search/repository/PopularSearchKeywordRepository.java
+++ b/src/main/java/org/swyp/dessertbee/search/repository/PopularSearchKeywordRepository.java
@@ -1,8 +1,8 @@
-package org.swyp.dessertbee.common.repository;
+package org.swyp.dessertbee.search.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import org.swyp.dessertbee.common.entity.PopularSearchKeyword;
+import org.swyp.dessertbee.search.entity.PopularSearchKeyword;
 
 import java.util.Optional;
 

--- a/src/main/java/org/swyp/dessertbee/search/repository/UserSearchHistoryRepository.java
+++ b/src/main/java/org/swyp/dessertbee/search/repository/UserSearchHistoryRepository.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.common.repository;
+package org.swyp.dessertbee.search.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-import org.swyp.dessertbee.common.entity.UserSearchHistory;
+import org.swyp.dessertbee.search.entity.UserSearchHistory;
 
 import java.util.List;
 

--- a/src/main/java/org/swyp/dessertbee/search/service/SearchService.java
+++ b/src/main/java/org/swyp/dessertbee/search/service/SearchService.java
@@ -1,7 +1,7 @@
-package org.swyp.dessertbee.common.service;
+package org.swyp.dessertbee.search.service;
 
-import org.swyp.dessertbee.common.dto.PopularSearchesList;
-import org.swyp.dessertbee.common.dto.UserSearchHistoryDto;
+import org.swyp.dessertbee.search.dto.PopularSearchesList;
+import org.swyp.dessertbee.search.dto.UserSearchHistoryDto;
 
 import java.util.List;
 

--- a/src/main/java/org/swyp/dessertbee/search/service/SearchServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/search/service/SearchServiceImpl.java
@@ -1,4 +1,4 @@
-package org.swyp.dessertbee.common.service;
+package org.swyp.dessertbee.search.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,14 +8,14 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.swyp.dessertbee.common.dto.PopularSearchResponse;
-import org.swyp.dessertbee.common.dto.PopularSearchesList;
-import org.swyp.dessertbee.common.dto.UserSearchHistoryDto;
-import org.swyp.dessertbee.common.exception.SearchExceptions.*;
-import org.swyp.dessertbee.common.entity.PopularSearchKeyword;
-import org.swyp.dessertbee.common.entity.UserSearchHistory;
-import org.swyp.dessertbee.common.repository.PopularSearchKeywordRepository;
-import org.swyp.dessertbee.common.repository.UserSearchHistoryRepository;
+import org.swyp.dessertbee.search.dto.PopularSearchResponse;
+import org.swyp.dessertbee.search.dto.PopularSearchesList;
+import org.swyp.dessertbee.search.dto.UserSearchHistoryDto;
+import org.swyp.dessertbee.search.exception.SearchExceptions.*;
+import org.swyp.dessertbee.search.entity.PopularSearchKeyword;
+import org.swyp.dessertbee.search.entity.UserSearchHistory;
+import org.swyp.dessertbee.search.repository.PopularSearchKeywordRepository;
+import org.swyp.dessertbee.search.repository.UserSearchHistoryRepository;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/src/main/java/org/swyp/dessertbee/search/service/StoreSearchService.java
+++ b/src/main/java/org/swyp/dessertbee/search/service/StoreSearchService.java
@@ -1,0 +1,11 @@
+package org.swyp.dessertbee.search.service;
+
+public interface StoreSearchService {
+    /** (관리자 전용) 모든 가게 데이터를 Elasticsearch에 색인 */
+    void migrateStoresToElasticsearch();
+
+    /**
+     * 가게 저장/수정 후 Elasticsearch 반영
+     */
+    void indexStore(Long storeId);
+}

--- a/src/main/java/org/swyp/dessertbee/search/service/StoreSearchServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/search/service/StoreSearchServiceImpl.java
@@ -1,143 +1,48 @@
 package org.swyp.dessertbee.search.service;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch.indices.ExistsRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.swyp.dessertbee.search.doc.StoreDocument;
-import org.swyp.dessertbee.store.menu.repository.MenuRepository;
+import org.swyp.dessertbee.search.util.ElasticsearchIndexer;
+import org.swyp.dessertbee.search.util.StoreDocumentFactory;
 import org.swyp.dessertbee.store.store.entity.Store;
 import org.swyp.dessertbee.store.store.repository.StoreRepository;
-import org.swyp.dessertbee.store.store.repository.StoreTagRelationRepository;
 import org.swyp.dessertbee.store.store.exception.StoreExceptions.*;
-import org.swyp.dessertbee.search.exception.SearchExceptions.*;
 
 import java.io.IOException;
 import java.util.List;
 
-@Slf4j
-@Service
 @RequiredArgsConstructor
 @Transactional
+@Service
+@Slf4j
 public class StoreSearchServiceImpl implements StoreSearchService {
 
     private final StoreRepository storeRepository;
-    private final StoreTagRelationRepository storeTagRelationRepository;
-    private final MenuRepository menuRepository;
-    private final ElasticsearchClient client;
+    private final StoreDocumentFactory storeDocumentFactory;
+    private final ElasticsearchIndexer elasticsearchIndexer;
 
-    /**
-     * [1] 인덱스가 없으면 생성
-     */
-    public void createStoreIndexIfNotExists() {
-        try {
-            boolean exists = client.indices()
-                    .exists(ExistsRequest.of(e -> e.index("stores")))
-                    .value();
+    private static final String INDEX_NAME = "stores";
 
-            if (!exists) {
-                client.indices().create(c -> c
-                        .index("stores")
-                        .mappings(m -> m
-                                .properties("storeId", p -> p.long_(l -> l))
-                                .properties("storeUuid", p -> p.keyword(k -> k))
-                                .properties("storeName", p -> p.text(t -> t))
-                                .properties("address", p -> p.text(t -> t))
-                                .properties("tagNames", p -> p.keyword(k -> k))
-                                .properties("menuNames", p -> p.keyword(k -> k))
-                                .properties("deleted", p -> p.boolean_(b -> b))
-                        )
-                );
-                log.info("[Elasticsearch] 'stores' 인덱스 생성 완료");
-            } else {
-                log.info("[Elasticsearch] 'stores' 인덱스는 이미 존재합니다");
-            }
-
-        } catch (IOException e) {
-            log.error("[Elasticsearch] 인덱스 존재 여부 확인/생성 실패", e);
-            throw new ElasticsearchCommunicationException(
-                    "Elasticsearch 인덱스 생성 중 IOException 발생", e
-            );
-        }
-    }
-
-    /**
-     * [2] 초기 마이그레이션 (MySQL → Elasticsearch)
-     */
     @Override
-    @Transactional(readOnly = true)
     public void migrateStoresToElasticsearch() {
-        createStoreIndexIfNotExists(); // 인덱스가 없으면 생성
+        elasticsearchIndexer.createIndexIfNotExists(INDEX_NAME);
 
         List<Store> stores = storeRepository.findAll();
-
         for (Store store : stores) {
-            List<String> tagNames = storeTagRelationRepository.findTagNamesByStoreId(store.getStoreId());
-            List<String> menuNames = menuRepository.findMenuNamesByStoreId(store.getStoreId());
-
-            StoreDocument doc = StoreDocument.builder()
-                    .storeId(store.getStoreId())
-                    .storeUuid(store.getStoreUuid())
-                    .storeName(store.getName())
-                    .address(store.getAddress())
-                    .tagNames(tagNames)
-                    .menuNames(menuNames)
-                    .deleted(store.getDeletedAt() != null)
-                    .build();
-
-            try {
-                client.index(i -> i
-                        .index("stores")
-                        .id(store.getStoreId().toString())
-                        .document(doc)
-                );
-            } catch (IOException e) {
-                log.error("[Elasticsearch] 색인 실패 - storeId: {}", store.getStoreId(), e);
-                throw new ElasticsearchCommunicationException(
-                        "[Elasticsearch] 색인 실패 - storeId: " + store.getStoreId(), e
-                );
-            }
+            StoreDocument doc = storeDocumentFactory.fromStore(store);
+            elasticsearchIndexer.indexStoreDocument(INDEX_NAME, store.getStoreId().toString(), doc);
         }
-
-        log.info("[Elasticsearch] 모든 가게 색인 완료");
     }
 
-    /**
-     * 가게 저장/수정 후 Elasticsearch 반영
-     */
     @Override
-    @Transactional(readOnly = true)
     public void indexStore(Long storeId) {
         Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreNotFoundException());
+                .orElseThrow(StoreNotFoundException::new);
 
-        List<String> tagNames = storeTagRelationRepository.findTagNamesByStoreId(storeId);
-        List<String> menuNames = menuRepository.findMenuNamesByStoreId(storeId);
-
-        StoreDocument doc = StoreDocument.builder()
-                .storeId(store.getStoreId())
-                .storeUuid(store.getStoreUuid())
-                .storeName(store.getName())
-                .address(store.getAddress())
-                .tagNames(tagNames)
-                .menuNames(menuNames)
-                .deleted(store.getDeletedAt() != null)
-                .build();
-
-        try {
-            client.index(i -> i
-                    .index("stores")
-                    .id(store.getStoreId().toString())
-                    .document(doc)
-            );
-            log.info("[Elasticsearch] 가게 색인 완료 - storeId={}", storeId);
-        } catch (IOException e) {
-            log.error("[Elasticsearch] 가게 색인 실패 - storeId={}", storeId, e);
-            throw new ElasticsearchCommunicationException(
-                    "[Elasticsearch] 가게 색인 실패 - storeId: " + storeId, e
-            );
-        }
+        StoreDocument doc = storeDocumentFactory.fromStore(store);
+        elasticsearchIndexer.indexStoreDocument(INDEX_NAME, storeId.toString(), doc);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/search/service/StoreSearchServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/search/service/StoreSearchServiceImpl.java
@@ -1,0 +1,143 @@
+package org.swyp.dessertbee.search.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.ExistsRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.search.doc.StoreDocument;
+import org.swyp.dessertbee.store.menu.repository.MenuRepository;
+import org.swyp.dessertbee.store.store.entity.Store;
+import org.swyp.dessertbee.store.store.repository.StoreRepository;
+import org.swyp.dessertbee.store.store.repository.StoreTagRelationRepository;
+import org.swyp.dessertbee.store.store.exception.StoreExceptions.*;
+import org.swyp.dessertbee.search.exception.SearchExceptions.*;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StoreSearchServiceImpl implements StoreSearchService {
+
+    private final StoreRepository storeRepository;
+    private final StoreTagRelationRepository storeTagRelationRepository;
+    private final MenuRepository menuRepository;
+    private final ElasticsearchClient client;
+
+    /**
+     * [1] 인덱스가 없으면 생성
+     */
+    public void createStoreIndexIfNotExists() {
+        try {
+            boolean exists = client.indices()
+                    .exists(ExistsRequest.of(e -> e.index("stores")))
+                    .value();
+
+            if (!exists) {
+                client.indices().create(c -> c
+                        .index("stores")
+                        .mappings(m -> m
+                                .properties("storeId", p -> p.long_(l -> l))
+                                .properties("storeUuid", p -> p.keyword(k -> k))
+                                .properties("storeName", p -> p.text(t -> t))
+                                .properties("address", p -> p.text(t -> t))
+                                .properties("tagNames", p -> p.keyword(k -> k))
+                                .properties("menuNames", p -> p.keyword(k -> k))
+                                .properties("deleted", p -> p.boolean_(b -> b))
+                        )
+                );
+                log.info("[Elasticsearch] 'stores' 인덱스 생성 완료");
+            } else {
+                log.info("[Elasticsearch] 'stores' 인덱스는 이미 존재합니다");
+            }
+
+        } catch (IOException e) {
+            log.error("[Elasticsearch] 인덱스 존재 여부 확인/생성 실패", e);
+            throw new ElasticsearchCommunicationException(
+                    "Elasticsearch 인덱스 생성 중 IOException 발생", e
+            );
+        }
+    }
+
+    /**
+     * [2] 초기 마이그레이션 (MySQL → Elasticsearch)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public void migrateStoresToElasticsearch() {
+        createStoreIndexIfNotExists(); // 인덱스가 없으면 생성
+
+        List<Store> stores = storeRepository.findAll();
+
+        for (Store store : stores) {
+            List<String> tagNames = storeTagRelationRepository.findTagNamesByStoreId(store.getStoreId());
+            List<String> menuNames = menuRepository.findMenuNamesByStoreId(store.getStoreId());
+
+            StoreDocument doc = StoreDocument.builder()
+                    .storeId(store.getStoreId())
+                    .storeUuid(store.getStoreUuid())
+                    .storeName(store.getName())
+                    .address(store.getAddress())
+                    .tagNames(tagNames)
+                    .menuNames(menuNames)
+                    .deleted(store.getDeletedAt() != null)
+                    .build();
+
+            try {
+                client.index(i -> i
+                        .index("stores")
+                        .id(store.getStoreId().toString())
+                        .document(doc)
+                );
+            } catch (IOException e) {
+                log.error("[Elasticsearch] 색인 실패 - storeId: {}", store.getStoreId(), e);
+                throw new ElasticsearchCommunicationException(
+                        "[Elasticsearch] 색인 실패 - storeId: " + store.getStoreId(), e
+                );
+            }
+        }
+
+        log.info("[Elasticsearch] 모든 가게 색인 완료");
+    }
+
+    /**
+     * 가게 저장/수정 후 Elasticsearch 반영
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public void indexStore(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreNotFoundException());
+
+        List<String> tagNames = storeTagRelationRepository.findTagNamesByStoreId(storeId);
+        List<String> menuNames = menuRepository.findMenuNamesByStoreId(storeId);
+
+        StoreDocument doc = StoreDocument.builder()
+                .storeId(store.getStoreId())
+                .storeUuid(store.getStoreUuid())
+                .storeName(store.getName())
+                .address(store.getAddress())
+                .tagNames(tagNames)
+                .menuNames(menuNames)
+                .deleted(store.getDeletedAt() != null)
+                .build();
+
+        try {
+            client.index(i -> i
+                    .index("stores")
+                    .id(store.getStoreId().toString())
+                    .document(doc)
+            );
+            log.info("[Elasticsearch] 가게 색인 완료 - storeId={}", storeId);
+        } catch (IOException e) {
+            log.error("[Elasticsearch] 가게 색인 실패 - storeId={}", storeId, e);
+            throw new ElasticsearchCommunicationException(
+                    "[Elasticsearch] 가게 색인 실패 - storeId: " + storeId, e
+            );
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/search/util/ElasticsearchIndexer.java
+++ b/src/main/java/org/swyp/dessertbee/search/util/ElasticsearchIndexer.java
@@ -1,0 +1,51 @@
+package org.swyp.dessertbee.search.util;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.ExistsRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.swyp.dessertbee.search.doc.StoreDocument;
+import org.swyp.dessertbee.search.exception.SearchExceptions.*;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class ElasticsearchIndexer {
+
+    private final ElasticsearchClient client;
+
+    public void createIndexIfNotExists(String indexName) {
+        try {
+            boolean exists = client.indices()
+                    .exists(ExistsRequest.of(e -> e.index(indexName)))
+                    .value();
+
+            if (!exists) {
+                client.indices().create(c -> c
+                        .index(indexName)
+                        .mappings(m -> m
+                                .properties("storeId", p -> p.long_(l -> l))
+                                .properties("storeUuid", p -> p.keyword(k -> k))
+                                .properties("storeName", p -> p.text(t -> t))
+                                .properties("address", p -> p.text(t -> t))
+                                .properties("tagNames", p -> p.keyword(k -> k))
+                                .properties("menuNames", p -> p.keyword(k -> k))
+                                .properties("deleted", p -> p.boolean_(b -> b))
+                        )
+                );
+            }
+
+        } catch (IOException e) {
+            throw new ElasticsearchCommunicationException("Elasticsearch 인덱스 생성 실패", e);
+        }
+    }
+
+    public void indexStoreDocument(String indexName, String id, StoreDocument doc) {
+        try {
+            client.index(i -> i.index(indexName).id(id).document(doc));
+        } catch (IOException e) {
+            throw new ElasticsearchCommunicationException("Elasticsearch 색인 실패 - id=" + id, e);
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/search/util/StoreDocumentFactory.java
+++ b/src/main/java/org/swyp/dessertbee/search/util/StoreDocumentFactory.java
@@ -1,0 +1,33 @@
+package org.swyp.dessertbee.search.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.swyp.dessertbee.search.doc.StoreDocument;
+import org.swyp.dessertbee.store.menu.repository.MenuRepository;
+import org.swyp.dessertbee.store.store.entity.Store;
+import org.swyp.dessertbee.store.store.repository.StoreTagRelationRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StoreDocumentFactory {
+
+    private final StoreTagRelationRepository storeTagRelationRepository;
+    private final MenuRepository menuRepository;
+
+    public StoreDocument fromStore(Store store) {
+        List<String> tagNames = storeTagRelationRepository.findTagNamesByStoreId(store.getStoreId());
+        List<String> menuNames = menuRepository.findMenuNamesByStoreId(store.getStoreId());
+
+        return StoreDocument.builder()
+                .storeId(store.getStoreId())
+                .storeUuid(store.getStoreUuid())
+                .storeName(store.getName())
+                .address(store.getAddress())
+                .tagNames(tagNames)
+                .menuNames(menuNames)
+                .deleted(store.getDeletedAt() != null)
+                .build();
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/statistics/store/entity/StoreStatistics.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/store/entity/StoreStatistics.java
@@ -32,9 +32,10 @@ public class StoreStatistics {
     @Schema(description = "가게 ID", example = "1001")
     private Long storeId;
 
+    @Builder.Default
     @Column(name = "stat_date", nullable = false)
     @Schema(description = "통계 집계 기준 날짜", example = "2025-04-17")
-    private LocalDate statDate;
+    private LocalDate statDate = LocalDate.now();
 
     @Builder.Default
     @Column(nullable = false)

--- a/src/main/java/org/swyp/dessertbee/store/menu/controller/MenuController.java
+++ b/src/main/java/org/swyp/dessertbee/store/menu/controller/MenuController.java
@@ -13,7 +13,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
-import org.swyp.dessertbee.common.dto.UserSearchHistoryDto;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.store.menu.dto.request.MenuCreateRequest;
 import org.swyp.dessertbee.store.menu.dto.response.MenuResponse;

--- a/src/main/java/org/swyp/dessertbee/store/menu/repository/MenuRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/menu/repository/MenuRepository.java
@@ -16,6 +16,11 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
     // 특정 가게의 전체 메뉴 조회
     List<Menu> findByStoreIdAndDeletedAtIsNull(Long storeId);
     Optional<Menu> findByMenuIdAndStoreIdAndDeletedAtIsNull(Long menuId, Long storeId);
+
     @Query("SELECT m.menuId FROM Menu m WHERE m.menuUuid = :menuUuid")
     Long findMenuIdByMenuUuid(@Param("menuUuid") UUID menuUuid);
+
+    @Query("SELECT m.name FROM Menu m WHERE m.storeId = :storeId AND m.deletedAt IS NULL")
+    List<String> findMenuNamesByStoreId(@Param("storeId") Long storeId);
+
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -170,7 +170,8 @@ public class StoreController {
             ErrorCode.SEARCH_KEYWORD_NOT_FOUND,
             ErrorCode.SEARCH_SERVICE_ERROR,
             ErrorCode.RECENT_KEYWORD_CREATION_FAILED,
-            ErrorCode.POPULAR_KEYWORD_CREATION_FAILED
+            ErrorCode.POPULAR_KEYWORD_CREATION_FAILED,
+            ErrorCode.ELASTICSEARCH_COMMUNICATION_FAILED
     })
     @GetMapping("/search")
     public List<StoreSearchResponse> searchStores(

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSearchResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSearchResponse.java
@@ -1,5 +1,6 @@
 package org.swyp.dessertbee.store.store.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,9 +13,19 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StoreSearchResponse {
+
+    @Schema(description = "가게 고유 ID", example = "1")
     private Long storeId;
+
+    @Schema(description = "가게 UUID", example = "58fbeb5e-ff24-41e6-8460-301b1a424e53")
     private UUID storeUuid;
+
+    @Schema(description = "가게 이름", example = "디저트비 합정점")
     private String name;
+
+    @Schema(description = "가게 주소", example = "서울 마포구 양화로 23길 8")
     private String address;
+
+    @Schema(description = "가게 썸네일 이미지 URL", example = "https://dessertbee.s3.ap-northeast-2.amazonaws.com/store/3/example.png")
     private String thumbnail;
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSearchResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSearchResponse.java
@@ -1,0 +1,20 @@
+package org.swyp.dessertbee.store.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreSearchResponse {
+    private Long storeId;
+    private UUID storeUuid;
+    private String name;
+    private String address;
+    private String thumbnail;
+}

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -1,6 +1,7 @@
 package org.swyp.dessertbee.store.store.service;
 
 import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.store.store.dto.response.StoreSearchResponse;
 import org.swyp.dessertbee.store.store.dto.request.StoreCreateRequest;
 import org.swyp.dessertbee.store.store.dto.request.StoreUpdateRequest;
 import org.swyp.dessertbee.store.store.dto.response.*;
@@ -31,6 +32,9 @@ public interface StoreService {
 
     /** 반경 내 사용자 취향 태그에 해당하는 가게 조회 */
     List<StoreMapResponse> getStoresByMyPreferences(Double lat, Double lng, Double radius);
+
+    /** 검색결과와 일치하는 전체 가게 조회 */
+    List<StoreSearchResponse> searchStores(String keyword);
 
     /** 가게 간략 정보 조회 */
     StoreSummaryResponse getStoreSummary(UUID storeUuid);

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreService.java
@@ -1,7 +1,7 @@
 package org.swyp.dessertbee.store.store.service;
 
 import org.springframework.web.multipart.MultipartFile;
-import org.swyp.dessertbee.store.store.dto.response.StoreSearchResponse;
+import org.swyp.dessertbee.search.dto.StoreSearchResponse;
 import org.swyp.dessertbee.store.store.dto.request.StoreCreateRequest;
 import org.swyp.dessertbee.store.store.dto.request.StoreUpdateRequest;
 import org.swyp.dessertbee.store.store.dto.response.*;

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
@@ -14,7 +14,7 @@ import org.swyp.dessertbee.preference.exception.PreferenceExceptions.*;
 import org.swyp.dessertbee.search.exception.SearchExceptions.*;
 import org.swyp.dessertbee.search.doc.StoreDocument;
 import org.swyp.dessertbee.search.service.StoreSearchService;
-import org.swyp.dessertbee.store.store.dto.response.StoreSearchResponse;
+import org.swyp.dessertbee.search.dto.StoreSearchResponse;
 import org.swyp.dessertbee.statistics.store.entity.StoreStatistics;
 import org.swyp.dessertbee.statistics.store.event.StoreViewEvent;
 import org.swyp.dessertbee.statistics.store.repostiory.StoreStatisticsRepository;

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
@@ -1,5 +1,8 @@
 package org.swyp.dessertbee.store.store.service;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.nimbusds.jose.util.Pair;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +11,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.preference.exception.PreferenceExceptions.*;
+import org.swyp.dessertbee.search.exception.SearchExceptions.*;
+import org.swyp.dessertbee.search.doc.StoreDocument;
+import org.swyp.dessertbee.search.service.StoreSearchService;
+import org.swyp.dessertbee.store.store.dto.response.StoreSearchResponse;
 import org.swyp.dessertbee.statistics.store.entity.StoreStatistics;
 import org.swyp.dessertbee.statistics.store.event.StoreViewEvent;
 import org.swyp.dessertbee.statistics.store.repostiory.StoreStatisticsRepository;
@@ -48,6 +55,7 @@ import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.user.service.UserService;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -87,6 +95,9 @@ public class StoreServiceImpl implements StoreService {
     private final StoreNoticeService storeNoticeService;
     private final ApplicationEventPublisher eventPublisher;
     private final StoreTopTagRepository storeTopTagRepository;
+    private final StoreSearchService storeSearchService;
+    private final ElasticsearchClient client;
+
 
     /** 가게 등록 (이벤트, 쿠폰, 메뉴 + 이미지 포함) */
     @Override
@@ -143,6 +154,8 @@ public class StoreServiceImpl implements StoreService {
             // 휴무일 저장
             List<StoreHoliday> holidays = saveHolidays(request.getHolidays(), store.getStoreId());
             storeHolidayRepository.saveAll(holidays);
+
+            storeSearchService.indexStore(store.getStoreId());
         } catch (StoreCreationFailedException e) {
             log.warn("가게 등록 실패 - 업주Uuid: {}, 사유: {}", request.getUserUuid(), e.getMessage());
             throw e;
@@ -512,6 +525,51 @@ public class StoreServiceImpl implements StoreService {
         } catch (Exception e) {
             log.error("반경 내 사용자 취향 맞춤 가게 조회 처리 중 오류 발생", e);
             throw new StoreServiceException("반경 내 사용자 취향 맞춤 가게 조회 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * 검색결과와 정확히 일치하는 전체 가게 조회 (match_phrase 사용)
+     */
+    public List<StoreSearchResponse> searchStores(String keyword) {
+        try {
+            SearchResponse<StoreDocument> response = client.search(s -> s
+                            .index("stores")
+                            .query(q -> q
+                                    .bool(b -> b
+                                            .should(sh -> sh.matchPhrase(m -> m.field("storeName").query(keyword)))
+                                            .should(sh -> sh.matchPhrase(m -> m.field("address").query(keyword)))
+                                            .should(sh -> sh.matchPhrase(m -> m.field("menuNames").query(keyword)))
+                                            .should(sh -> sh.matchPhrase(m -> m.field("tagNames").query(keyword)))
+                                            .minimumShouldMatch("1")
+                                            .filter(f -> f.term(t -> t.field("deleted").value(false)))
+                                    )
+                            ),
+                    StoreDocument.class
+            );
+
+            return response.hits().hits().stream()
+                    .map(Hit::source)
+                    .filter(Objects::nonNull)
+                    .map(doc -> {
+                        List<String> storeImages = imageService.getImagesByTypeAndId(ImageType.STORE, doc.getStoreId());
+                        String thumbnail = storeImages.isEmpty() ? null : storeImages.get(0);
+
+                        return StoreSearchResponse.builder()
+                                .storeId(doc.getStoreId())
+                                .storeUuid(doc.getStoreUuid())
+                                .name(doc.getStoreName())
+                                .address(doc.getAddress())
+                                .thumbnail(thumbnail)
+                                .build();
+                    })
+                    .toList();
+
+        } catch (IOException e) {
+            log.error("Elasticsearch 검색 중 네트워크 오류 발생", e);
+            throw new ElasticsearchCommunicationException(
+                    "Elasticsearch 검색 중 IOException 발생", e
+            );
         }
     }
 
@@ -962,14 +1020,13 @@ public class StoreServiceImpl implements StoreService {
                 saveStoreTags(store, request.getTagIds());
             }
 
-            // 메뉴 처리
-            //processMenus(store, request.getMenus(), menuImageFiles, true);
-
             // 영업 시간 저장
             saveOrUpdateOperatingHours(store, request.getOperatingHours());
 
             // 휴무일 저장
             saveHolidays(request.getHolidays(), storeId);
+
+            storeSearchService.indexStore(storeId);
 
             return getStoreInfo(storeUuid);
         } catch (StoreUpdateException e) {
@@ -1002,6 +1059,7 @@ public class StoreServiceImpl implements StoreService {
 
             store.softDelete();
             storeRepository.save(store);
+            storeSearchService.indexStore(storeId);
         } catch (StoreDeleteException e){
             log.warn("가게 삭제 실패 - 사유: {}", e.getMessage());
             throw e;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -29,6 +29,8 @@ spring:
     redis:
       host: localhost
       port: ${SPRING_DATA_REDIS_PORT}
+  elasticsearch:
+    uris: http://localhost:9200
 app:
   client:
     redirect-url: "http://localhost:3000"
@@ -42,5 +44,12 @@ logging:
         orm:
           jdbc:
             bind: trace
+      springframework:
+        data:
+          elasticsearch:
+            client: debug
+      co:
+        elastic:
+          clients: debug
     com:
       dessertbee: debug

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,6 +14,8 @@ spring:
         registration:
           kakao:
             redirect-uri: ${KAKAO_REDIRECT_URI_PROD}
+  elasticsearch:
+    uris: http://desserbee-es:9200
 #  graphql:
 #    cors:
 #      allowed-origins: "https://desserbee.com,https://www.desserbee.com,http://desserbee.com,http://www.desserbee.com,https://api.desserbee.com,https://frontend-desserbee-web-git-vercel-test-eepyzs-projects.vercel.app/"

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -32,6 +32,8 @@ spring:
         registration:
           kakao:
             redirect-uri: ${KAKAO_REDIRECT_URI_TEST}
+  elasticsearch:
+    uris: http://desserbee-es:9200
 
 logging:
   level:


### PR DESCRIPTION
## :hash: 연관된 이슈

> #337 

## :memo: 작업 내용

> ElasticsearchClient를 활용한 검색 API searchStores() 구현
> 검색 대상 필드: storeName, address, menuNames, tagNames
> 정확한 키워드 검색을 위해 match_phrase 쿼리 적용
> 불필요한 결과 제거를 위해 minimum_should_match = 1 명시
> deleted = false 조건 필터링 적용
> 검색 결과에 가게 썸네일 이미지(storeImageFiles 중 첫 번째 이미지) 포함 처리

### 스크린샷

<img width="594" alt="image" src="https://github.com/user-attachments/assets/e31992b9-460e-4019-b41d-c1609e91cf4f" />

> 추후 자동완성, 하이라이팅, 검색어 인기 통계 등 고급 기능 확장을 고려 중
> 검색 대상 필드에 대한 정규화 및 analyzer 설정은 별도 인덱스 매핑 시 반영 예정
