### PR TITLE
[FIX] 유저 닉네임 중복 검사

### DIFF
--- a/src/main/java/org/swyp/dessertbee/config/TestAccountInitializer.java
+++ b/src/main/java/org/swyp/dessertbee/config/TestAccountInitializer.java
@@ -80,9 +80,7 @@ public class TestAccountInitializer implements ApplicationRunner {
             UserEntity user = UserEntity.builder()
                     .email(email)
                     .password(passwordEncoder.encode(USER_PASSWORD))
-                    .name("테스트사용자")
                     .nickname("테스트유저")
-                    .phoneNumber("010-1234-5678")
                     .userUuid(UUID.randomUUID())
                     .build();
 

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -37,7 +37,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
      * @param nickname 사용자 닉네임
      * @return boolean
      */
-    @Query("SELECT COUNT(u) > 0 FROM UserEntity u WHERE u.nickname = :nickname AND u.deletedAt IS NULL")
+    @Query("SELECT COUNT(u) > 0 FROM UserEntity u WHERE u.nickname = :nickname")
     boolean existsByNickname(String nickname);
 
     /**


### PR DESCRIPTION
## :hash: 연관된 이슈
#346 #335 
## :memo: 작업 내용
기존 에러 시나리오:
'바게트빵'으로 가입 -> 탈퇴 -> 다시 회원가입 -> 다시 닉네임 '바게트빵'으로 닉네임 중복확인 -> 중복확인 검증 통과 -> 회원가입 시도 -> A010 에러 코드 
즉, soft deleted를 수행하기에 탈퇴한 유저의 닉네임 정보가 사라지지 않음 닉네임 컬럼 유니크 제약 조건 위배

- 유저의 닉네임 중복 검사 시 조건 수정
  - 탈퇴한 유저의 닉네임 또한 중복 검사에 추가
- 테스트 계정 삽입 시 삽입되는 정보 수정
  -  일반 유저 테스트 계정 전화번호 정보 제거
  -  일반 유저 테스트 계정 실명 정보 제거
  
 