### PR TITLE
[FIX] 토큰 갱신 오류 - 엔진엑스 deviceId 세팅

### DIFF
--- a/nginx/conf/default.conf.template
+++ b/nginx/conf/default.conf.template
@@ -1,8 +1,7 @@
-# 변수 매핑 - 요청 시 동적으로 처리할 헤더를 안정적으로 지정
-# 덮어쓰기가 되는지 테스트하기 위한 용도의 주석
-map $cookie_deviceId $device_id {
-    default $cookie_deviceId;
-    ""      "";
+# 변수 매핑 - 헤더 또는 쿠키에서 디바이스 ID 가져오기 (헤더 우선)
+map $http_x_device_id $device_id {
+    default $http_x_device_id;  # 헤더 값이 있으면 사용
+    ""      $cookie_deviceId;   # 헤더 값이 없으면 쿠키 값 사용
 }
 
 map $http_authorization $auth_header {


### PR DESCRIPTION
## :hash: 연관된 이슈
#349 

## :memo: 작업 내용
엔진엑스에 deviceId 쿠키뿐만 아니라 
X-Device-ID 헤더에서 온 디바이스 아이디 또한 세팅할 수 있게 변경하였습니다.

## :speech_balloon: 리뷰 요구사항(선택)
이미 엔진엑스 설정을 릴리즈 서버에서 변경된 상태입니다. 
템플릿만 업데이트하여 후에도 적용되게 하였습니다.