### PR TITLE
[FIX] UserDetailsService 빈 중복 경고 

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/CustomUserDetailsService.java
@@ -17,7 +17,6 @@ import java.util.List;
  * Spring Security의 사용자 조회를 담당하는 서비스
  * JWT 필터에서 인증할 때 DB 조회가 필요한 경우 사용
  */
-@Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 


### PR DESCRIPTION
## :memo: 작업 내용
AuthenticationManager → AuthenticationProvider →
내부적으로 UserDetailsService#loadUserByUsername(username) 호출
동일 타입의 빈이 2개 이상 등록되어 있던 상태
- @Service로 하나 등록 (customUserDetailsService)
- @Bean으로 하나 등록 (userDetailsService)
경고 발생 
-> `Found 2 UserDetailsService beans, with names [customUserDetailsService, userDetailsService].`

userDetailsService 빈 하나만 등록하고 내부적으로 CustomUserDetailsService 인스턴스를 사용하도록 변경