### PR TITLE
[FEATURE] 특정 가게 저장 리스트 및 취향 태그 수정 API 추가

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
@@ -120,10 +120,11 @@ public class UserStoreController {
     }
 
     /** 저장된 가게 수정 */
-    @PatchMapping("/stores/{storeUuid}/lists")
     @Operation(summary = "저장된 가게 수정 (completed)", description = "가게의 저장된 리스트를 수정합니다. 선택된 리스트에 가게를 한꺼번에 저장하고 현재 사용자의 취향 태그를 반영합니다.")
     @ApiResponse(responseCode = "200", description = "저장된 가게 수정 성공")
+    @ApiErrorResponses({ErrorCode.USER_STORE_SERVICE_ERROR, ErrorCode.STORE_LIST_NOT_FOUND, ErrorCode.INVALID_STORE_UUID})
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
+    @PatchMapping("/stores/{storeUuid}/lists")
     public ResponseEntity<Void> updateSavedStoreLists(
             @PathVariable String storeUuid,
             @RequestBody UpdateSavedStoreListsRequest request) {

--- a/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
@@ -12,6 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
 import org.swyp.dessertbee.store.saved.dto.*;
+import org.swyp.dessertbee.store.saved.dto.request.UpdateSavedStoreListsRequest;
 import org.swyp.dessertbee.store.store.exception.StoreExceptions.*;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.store.saved.service.UserStoreService;
@@ -116,6 +117,23 @@ public class UserStoreController {
     @GetMapping("/lists/{listId}/stores")
     public ResponseEntity<UserStoreListDetailResponse> getStoresByList(@PathVariable Long listId) {
         return ResponseEntity.ok(userStoreService.getStoresByList(listId));
+    }
+
+    /** 저장된 가게 수정 */
+    @PutMapping("/stores/{storeUuid}")
+    @Operation(summary = "저장된 가게 수정 (completed)", description = "가게의 저장된 리스트를 수정합니다. 선택된 리스트와 userPreferences를 설정합니다.")
+    @ApiResponse(responseCode = "200", description = "저장된 가게 수정 성공")
+    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
+    public ResponseEntity<Void> updateSavedStoreLists(
+            @PathVariable String storeUuid,
+            @RequestBody UpdateSavedStoreListsRequest request) {
+        try {
+            UUID uuid = UUID.fromString(storeUuid);
+            userStoreService.updateSavedStoreLists(uuid, request.getSelectedLists());
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            throw new InvalidStoreUuidException();
+        }
     }
 
     /** 리스트에서 가게 삭제 */

--- a/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
@@ -120,7 +120,7 @@ public class UserStoreController {
     }
 
     /** 저장된 가게 수정 */
-    @PatchMapping("/stores/{storeUuid}")
+    @PatchMapping("/stores/{storeUuid}/lists")
     @Operation(summary = "저장된 가게 수정 (completed)", description = "가게의 저장된 리스트를 수정합니다. 선택된 리스트에 가게를 한꺼번에 저장하고 현재 사용자의 취향 태그를 반영합니다.")
     @ApiResponse(responseCode = "200", description = "저장된 가게 수정 성공")
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")

--- a/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
@@ -121,7 +121,7 @@ public class UserStoreController {
 
     /** 저장된 가게 수정 */
     @PatchMapping("/stores/{storeUuid}")
-    @Operation(summary = "저장된 가게 수정 (completed)", description = "가게의 저장된 리스트를 수정합니다. 선택된 리스트와 userPreferences를 설정합니다.")
+    @Operation(summary = "저장된 가게 수정 (completed)", description = "가게의 저장된 리스트를 수정합니다. 선택된 리스트에 가게를 한꺼번에 저장하고 현재 사용자의 취향 태그를 반영합니다.")
     @ApiResponse(responseCode = "200", description = "저장된 가게 수정 성공")
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     public ResponseEntity<Void> updateSavedStoreLists(

--- a/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
@@ -120,7 +120,7 @@ public class UserStoreController {
     }
 
     /** 저장된 가게 수정 */
-    @PutMapping("/stores/{storeUuid}")
+    @PatchMapping("/stores/{storeUuid}")
     @Operation(summary = "저장된 가게 수정 (completed)", description = "가게의 저장된 리스트를 수정합니다. 선택된 리스트와 userPreferences를 설정합니다.")
     @ApiResponse(responseCode = "200", description = "저장된 가게 수정 성공")
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")

--- a/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/controller/UserStoreController.java
@@ -85,7 +85,17 @@ public class UserStoreController {
     }
 
     /** 리스트에 가게 추가 */
-    @Operation(summary = "리스트에 가게 저장 (completed)", description = "해당 리스트에 가게를 저장합니다.")
+    @Operation(
+            summary = "리스트에 가게 저장 (completed)",
+            description = "해당 리스트에 가게를 저장합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "유저 취향 태그 ID 리스트",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = List.class, example = "[1, 2, 3]")
+                    )
+            )
+    )
     @ApiResponse( responseCode = "200", description = "리스트에 가게 저장 성공", content = @Content(schema = @Schema(implementation = SavedStoreResponse.class)))
     @ApiErrorResponses({ErrorCode.USER_STORE_SERVICE_ERROR, ErrorCode.STORE_LIST_NOT_FOUND, ErrorCode.STORE_SAVE_FAILED, ErrorCode.STORE_NOT_FOUND, ErrorCode.INVALID_STORE_UUID})
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
@@ -120,7 +130,16 @@ public class UserStoreController {
     }
 
     /** 저장된 가게 수정 */
-    @Operation(summary = "저장된 가게 수정 (completed)", description = "가게의 저장된 리스트를 수정합니다. 선택된 리스트에 가게를 한꺼번에 저장하고 현재 사용자의 취향 태그를 반영합니다.")
+    @Operation(
+            summary = "저장된 가게 수정 (completed)",
+            description = """
+        가게가 저장될 리스트 목록을 수정합니다.
+        
+        - 리스트를 하나도 선택하지 않은 경우(selectedLists가 비어있거나 null), 기존 저장된 리스트에서 가게가 모두 삭제됩니다.
+        - 리스트를 선택하면 해당 리스트에 가게가 저장되며, 미리 설정해둔 유저의 취향 태그(userPreferences)도 함께 저장됩니다.
+        - 취향 태그(userPreferences)는 선택 사항입니다. 취향 태그가 없다면 빈 리스트로 저장됩니다.
+        """
+    )
     @ApiResponse(responseCode = "200", description = "저장된 가게 수정 성공")
     @ApiErrorResponses({ErrorCode.USER_STORE_SERVICE_ERROR, ErrorCode.STORE_LIST_NOT_FOUND, ErrorCode.INVALID_STORE_UUID})
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")

--- a/src/main/java/org/swyp/dessertbee/store/saved/dto/request/UpdateSavedStoreListsRequest.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/dto/request/UpdateSavedStoreListsRequest.java
@@ -12,7 +12,14 @@ import java.util.List;
 @Builder
 public class UpdateSavedStoreListsRequest {
 
-    @Schema(description = "가게를 저장할 리스트 목록")
+    @Schema(
+            description = """
+            가게를 저장할 리스트들의 목록입니다.
+            - 리스트를 하나도 선택하지 않으면, 기존에 저장된 모든 리스트에서 가게가 삭제됩니다.
+            - 리스트를 선택하면 해당 리스트에 가게가 저장되며, 선택한 취향 태그(userPreferences)도 함께 저장됩니다.
+            """,
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private List<StoreListUpdateRequest> selectedLists;
 
     @Getter
@@ -22,10 +29,25 @@ public class UpdateSavedStoreListsRequest {
     @Builder
     public static class StoreListUpdateRequest {
 
-        @Schema(description = "리스트 ID", example = "1")
+        @Schema(
+                description = """
+                저장할 리스트의 ID입니다.
+                - 필수 값입니다.
+                """,
+                example = "1",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         private Long listId;
 
-        @Schema(description = "사용자가 선택한 취향 태그 ID 목록", example = "[1,2,3]")
+        @Schema(
+                description = """
+                사용자가 설정해둔 취향 태그 ID 목록입니다.
+                - 선택 값입니다.
+                - 설정해둔 취향 태그 ID가 없거나 빈 배열([])이면, 해당 리스트에는 취향 태그 없이 저장됩니다.
+                """,
+                example = "[1,2,3]",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
         private List<Long> userPreferences;
     }
 }

--- a/src/main/java/org/swyp/dessertbee/store/saved/dto/request/UpdateSavedStoreListsRequest.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/dto/request/UpdateSavedStoreListsRequest.java
@@ -25,7 +25,7 @@ public class UpdateSavedStoreListsRequest {
         @Schema(description = "리스트 ID", example = "1")
         private Long listId;
 
-        @Schema(description = "사용자가 선택한 취향 태그 ID 목록", example = "[101, 102, 103]")
+        @Schema(description = "사용자가 선택한 취향 태그 ID 목록", example = "[1,2,3]")
         private List<Long> userPreferences;
     }
 }

--- a/src/main/java/org/swyp/dessertbee/store/saved/dto/request/UpdateSavedStoreListsRequest.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/dto/request/UpdateSavedStoreListsRequest.java
@@ -1,0 +1,31 @@
+package org.swyp.dessertbee.store.saved.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateSavedStoreListsRequest {
+
+    @Schema(description = "가게를 저장할 리스트 목록")
+    private List<StoreListUpdateRequest> selectedLists;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StoreListUpdateRequest {
+
+        @Schema(description = "리스트 ID", example = "1")
+        private Long listId;
+
+        @Schema(description = "사용자가 선택한 취향 태그 ID 목록", example = "[101, 102, 103]")
+        private List<Long> userPreferences;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/store/saved/repository/SavedStoreRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/repository/SavedStoreRepository.java
@@ -113,4 +113,24 @@ public interface SavedStoreRepository extends JpaRepository<SavedStore, Long> {
         WHERE l.user.id = :userId
     """)
     List<SavedStore> findAllByUserIdWithStoreAndList(@Param("userId") Long userId);
+
+    /** 특정 가게를 유저가 저장한 SavedStore 모두 조회 */
+    @Query("""
+        SELECT ss
+        FROM SavedStore ss
+        JOIN ss.userStoreList usl
+        WHERE ss.store = :store
+          AND usl.user.id = :userId
+    """)
+    List<SavedStore> findByStoreAndUserId(@Param("store") Store store, @Param("userId") Long userId);
+
+    /** 특정 리스트-가게 조합으로 SavedStore 삭제 */
+    @Transactional
+    @Modifying
+    @Query("""
+        DELETE FROM SavedStore ss
+        WHERE ss.userStoreList = :userStoreList
+          AND ss.store = :store
+    """)
+    void deleteByUserStoreListAndStore(@Param("userStoreList") UserStoreList userStoreList, @Param("store") Store store);
 }

--- a/src/main/java/org/swyp/dessertbee/store/saved/service/UserStoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/service/UserStoreService.java
@@ -1,6 +1,7 @@
 package org.swyp.dessertbee.store.saved.service;
 
 import org.swyp.dessertbee.store.saved.dto.*;
+import org.swyp.dessertbee.store.saved.dto.request.UpdateSavedStoreListsRequest;
 
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +30,9 @@ public interface UserStoreService {
 
     /** 리스트별 저장된 가게 조회 */
     UserStoreListDetailResponse getStoresByList(Long listId);
+
+    /** 저장된 가게 수정 */
+    void updateSavedStoreLists(UUID storeUuid, List<UpdateSavedStoreListsRequest.StoreListUpdateRequest> selectedLists);
 
     /** 리스트에서 가게 삭제 */
     void removeStoreFromList(Long listId, UUID storeUuid);

--- a/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/controller/StoreController.java
@@ -88,7 +88,7 @@ public class StoreController {
         아래 3가지 방식 중 **하나만** 사용할 수 있습니다:
 
         1. 기본 요청 (전체 가게 조회)
-        2. preferenceTagIds로 필터링 (복수 개 가능, 예: preferenceTagIds=1&preferenceTagIds=2)
+        2. preferenceTagIds로 필터링 (복수 개 가능, 예: preferenceTagIds=1,2,3)
         3. 검색어(searchKeyword) 기반 조회 - WEB 전용 (예: 검색어를 URL 인코딩해서 전달)
         """
     )


### PR DESCRIPTION
## :hash: 연관된 이슈

> #356 

## :memo: 작업 내용

> 특정 가게(storeUuid) 기준으로 저장 리스트를 수정하는 API 추가
> 요청 DTO 생성
> 저장 성공 시 관련 로그 발행하여 통계 데이터 일관성 유지

### 스크린샷

<img width="665" alt="image" src="https://github.com/user-attachments/assets/e5861c61-ce46-4317-858a-cc8abf313fdc" />

> 플로우 차트입니다.
