### PR TITLE
[CHORE] 동일 날짜 리뷰 등록 방지 예외처리 추가

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -128,6 +128,7 @@ public enum ErrorCode {
     STORE_NOTICE_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S049", "가게 공지사항 서비스 처리 중 오류가 발생했습니다."),
     STORE_HOLIDAY_TERM_ERROR(HttpStatus.BAD_REQUEST, "S050", "휴무일의 종료일은 시작일 이후여야 합니다."),
     STORE_HOLIDAY_TYPE_ERROR(HttpStatus.BAD_REQUEST, "S051", "날짜 형식이 올바르지 않습니다. yyyy.MM.dd 또는 yyyy.MM.dd-yyyy.MM.dd 형식을 사용해주세요."),
+    STORE_REVIEW_ALREADY_EXISTS_TODAY(HttpStatus.BAD_REQUEST, "S052", "오늘 이미 작성한 리뷰가 존재합니다."),
 
 
     // 사장님 권한

--- a/src/main/java/org/swyp/dessertbee/store/review/exception/StoreReviewExceptions.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/exception/StoreReviewExceptions.java
@@ -98,4 +98,17 @@ public class StoreReviewExceptions {
             super(ErrorCode.STORE_REVIEW_NOT_FOUND, message);
         }
     }
+
+    /**
+     * 유효하지 않은 한줄리뷰 예외
+     */
+    public static class StoreReviewAlreadyExistsTodayException extends BusinessException {
+        public StoreReviewAlreadyExistsTodayException() {
+            super(ErrorCode.STORE_REVIEW_ALREADY_EXISTS_TODAY);
+        }
+
+        public StoreReviewAlreadyExistsTodayException(String message) {
+            super(ErrorCode.STORE_REVIEW_NOT_FOUND, message);
+        }
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
@@ -29,4 +29,16 @@ public interface StoreReviewRepository extends JpaRepository<StoreReview, Long> 
 
     @Query("SELECT COUNT(r) FROM StoreReview r WHERE r.storeId = :storeId AND r.deletedAt IS NULL")
     int countByStoreIdAndDeletedAtIsNull(@Param("storeId") Long storeId);
+
+    /**
+     * 특정 유저가 특정 가게에 "오늘" 날짜로 작성한 리뷰가 있는지 체크
+     */
+    @Query("""
+        SELECT COUNT(r) FROM StoreReview r
+        WHERE r.storeId = :storeId
+          AND r.userUuid = :userUuid
+          AND r.deletedAt IS NULL
+          AND FUNCTION('DATE', r.createdAt) = CURRENT_DATE
+    """)
+    int countTodayReviewsByUserAndStore(@Param("userUuid") UUID userUuid, @Param("storeId") Long storeId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewServiceImpl.java
@@ -51,6 +51,12 @@ public class StoreReviewServiceImpl implements StoreReviewService {
                 throw new InvalidStoreUuidException();
             }
 
+            // 오늘 같은 가게에 이미 작성했는지 체크
+            int todayReviewCount = storeReviewRepository.countTodayReviewsByUserAndStore(request.getUserUuid(), storeId);
+            if (todayReviewCount > 0) {
+                throw new StoreReviewAlreadyExistsTodayException();
+            }
+
             StoreReview review = StoreReview.builder()
                     .storeId(storeId)
                     .userUuid(request.getUserUuid())


### PR DESCRIPTION
## :hash: 연관된 이슈

> #362 

## :memo: 작업 내용

> 유저가 한 가게에 오늘 날짜로 작성한 리뷰가 이미 존재하면 예외를 던지도록 했습니다.