### PR TITLE
[CHORE] 스케줄러 멀티스레드 분리 및 Store Top Tag 배치 수동 실행 기능 추가

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/controller/BatchTestController.java
+++ b/src/main/java/org/swyp/dessertbee/common/controller/BatchTestController.java
@@ -1,0 +1,30 @@
+package org.swyp.dessertbee.common.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swyp.dessertbee.store.preference.service.StoreTopTagBatchTriggerService;
+
+@Tag(name = "Batch Test", description = "배치 작업 수동 실행 API")
+@RestController
+@RequestMapping("/api/batch")
+@RequiredArgsConstructor
+public class BatchTestController {
+
+    private final StoreTopTagBatchTriggerService storeTopTagBatchTriggerService;
+
+    @Operation(
+            summary = "Store Top Tag 배치 수동 실행",
+            description = "store_top_tag 테이블을 초기화하고, 가게별 Top 3 태그를 재집계하는 배치 작업을 수동으로 실행합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "Store Top Tag 배치 수동 실행 완료")
+    @PostMapping("/store-top-tag")
+    public String runStoreTopTagBatch() {
+        storeTopTagBatchTriggerService.executeBatch();
+        return "Store Top Tag 배치 수동 실행 완료!";
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/common/scheduler/SearchScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/common/scheduler/SearchScheduler.java
@@ -16,7 +16,7 @@ public class SearchScheduler {
         searchService.syncPopularSearchesToDB();
     }
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 3 0 * * *", zone = "Asia/Seoul") // 매일 00:03 실행
     public void midnightSyncPopularSearchesToDB() {
         searchService.midnightSyncPopularSearchesToDB();
     }

--- a/src/main/java/org/swyp/dessertbee/common/scheduler/StoreTopTagScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/common/scheduler/StoreTopTagScheduler.java
@@ -4,23 +4,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.swyp.dessertbee.store.preference.service.StoreTopTagBatchService;
+import org.swyp.dessertbee.store.preference.service.StoreTopTagBatchTriggerService;
+
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class StoreTopTagScheduler {
 
-    private final StoreTopTagBatchService storeTopTagBatchService;
+    private final StoreTopTagBatchTriggerService storeTopTagBatchTriggerService;
 
-    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul") // 매일 새벽 3시
     public void runTopTagBatch() {
-        try {
-            log.info("[스케줄러] store_top_tag 배치 시작");
-            storeTopTagBatchService.refreshStoreTopTags();
-            log.info("[스케줄러] store_top_tag 배치 종료");
-        } catch (Exception e) {
-            log.error("[스케줄러] store_top_tag 배치 실패", e);
-        }
+        storeTopTagBatchTriggerService.executeBatch();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/config/SchedulerConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SchedulerConfig.java
@@ -1,0 +1,21 @@
+package org.swyp.dessertbee.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(3); //todo: t2.micro 인스턴스 환경에서의 poolSize 적정선은 2~3개?
+        scheduler.setThreadNamePrefix("scheduled-task-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/config/SchedulerConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SchedulerConfig.java
@@ -13,7 +13,7 @@ public class SchedulerConfig {
     @Bean
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(3); //todo: t2.micro 인스턴스 환경에서의 poolSize 적정선은 2~3개?
+        scheduler.setPoolSize(2); //todo: t2.micro 인스턴스 환경에서의 poolSize 적정선은 2~3개?
         scheduler.setThreadNamePrefix("scheduled-task-");
         scheduler.initialize();
         return scheduler;

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/stores/map/**").permitAll()
                         .requestMatchers("/api/images/**").permitAll()
                         .requestMatchers("/api/banners/**").permitAll()
+                        .requestMatchers("/api/batch/**").permitAll()
                         .requestMatchers(
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",

--- a/src/main/java/org/swyp/dessertbee/search/service/SearchServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/search/service/SearchServiceImpl.java
@@ -19,6 +19,7 @@ import org.swyp.dessertbee.search.repository.UserSearchHistoryRepository;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
 
@@ -308,7 +309,7 @@ public class SearchServiceImpl implements SearchService {
      * 매일 자정 MySQL로 데이터 이전 후 Redis 초기화
      */
     public void midnightSyncPopularSearchesToDB() {
-        log.info("자정 인기 검색어 백업 및 초기화 시작");
+        log.info("[스케줄러 시작] 인기 검색어 백업 at {}", LocalDateTime.now());
 
         // 락 설정
         if (!acquireLock(SYNC_LOCK_KEY, SYNC_LOCK_TIMEOUT)) {
@@ -349,10 +350,10 @@ public class SearchServiceImpl implements SearchService {
             // 동기화가 성공한 경우에만 Redis 초기화
             clearPopularSearchCache();
 
-            log.info("인기 검색어 백업 및 초기화 완료");
+            log.info("[스케줄러 종료] 인기 검색어 백업 at {}", LocalDateTime.now());
 
         } catch (PopularInitFailedException e) {
-            log.warn("인기 검색어 초기화 실패 - {}", e.getMessage());
+            log.warn("[스케줄러 실패] 인기 검색어 초기화 실패 - {}", e.getMessage());
             throw e;
         } catch (Exception e) {
             log.error("예상치 못한 오류 발생 - Redis 초기화 중단", e);

--- a/src/main/java/org/swyp/dessertbee/statistics/common/scheduler/StoreStatisticsScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/statistics/common/scheduler/StoreStatisticsScheduler.java
@@ -28,7 +28,7 @@ public class StoreStatisticsScheduler {
     private final StoreStatisticsRepository statisticsRepository;
     private final StoreStatisticsSummaryRepository summaryRepository;
 
-    @Scheduled(cron = "0 0 0 * * *") // 매일 자정
+    @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul") // 매일 00:10 실행
     @Transactional
     public void summarizeStatistics() {
         log.info("[통계 요약] 주간/월간 집계 시작");

--- a/src/main/java/org/swyp/dessertbee/store/preference/repository/StoreTopTagRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/preference/repository/StoreTopTagRepository.java
@@ -41,16 +41,16 @@ public interface StoreTopTagRepository extends JpaRepository<StoreTopTag, Long> 
     @Modifying
     @Transactional
     @Query(value = """
-        INSERT INTO store_top_tag (store_id, tag_id, tag_rank)
-        SELECT store_id, tag_id, tag_rank
-        FROM (
-            SELECT ss.store_id, sp.preference AS tag_id,
-                   ROW_NUMBER() OVER (PARTITION BY ss.store_id ORDER BY COUNT(*) DESC) AS tag_rank
-            FROM saved_store ss
-            JOIN saved_store_preferences sp ON ss.id = sp.saved_store_id
-            GROUP BY ss.store_id, sp.preference
-        ) ranked
-        WHERE tag_rank <= 11
-        """, nativeQuery = true)
+    INSERT INTO store_top_tag (store_id, tag_id, tag_rank, created_at)
+    SELECT store_id, tag_id, tag_rank, NOW()
+    FROM (
+        SELECT ss.store_id, sp.preference AS tag_id,
+                ROW_NUMBER() OVER (PARTITION BY ss.store_id ORDER BY COUNT(*) DESC) AS tag_rank
+        FROM saved_store ss
+        JOIN saved_store_preferences sp ON ss.id = sp.saved_store_id
+        GROUP BY ss.store_id, sp.preference
+    ) ranked
+    WHERE tag_rank <= 11
+    """, nativeQuery = true)
     void populateStoreTopTag();
 }

--- a/src/main/java/org/swyp/dessertbee/store/preference/service/StoreTopTagBatchService.java
+++ b/src/main/java/org/swyp/dessertbee/store/preference/service/StoreTopTagBatchService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.swyp.dessertbee.store.preference.repository.StoreTopTagRepository;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -18,9 +20,9 @@ public class StoreTopTagBatchService {
         log.info("[배치] store_top_tag 초기화 시작");
         storeTopTagRepository.truncateStoreTopTag();
 
-        log.info("[배치] store_top_tag 집계 및 저장 시작");
+        log.info("[스케줄러 시작] 통계 집계 at {}", LocalDateTime.now());
         storeTopTagRepository.populateStoreTopTag();
 
-        log.info("[배치] store_top_tag 배치 완료");
+        log.info("[스케줄러 종료] 통계 집계 완료 at {}", LocalDateTime.now());
     }
 }

--- a/src/main/java/org/swyp/dessertbee/store/preference/service/StoreTopTagBatchTriggerService.java
+++ b/src/main/java/org/swyp/dessertbee/store/preference/service/StoreTopTagBatchTriggerService.java
@@ -1,0 +1,25 @@
+package org.swyp.dessertbee.store.preference.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.swyp.dessertbee.store.preference.service.StoreTopTagBatchService;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreTopTagBatchTriggerService {
+
+    private final StoreTopTagBatchService storeTopTagBatchService;
+
+    public void executeBatch() {
+        try {
+            log.info("[수동/자동 트리거] store_top_tag 배치 시작");
+            storeTopTagBatchService.refreshStoreTopTags();
+            log.info("[수동/자동 트리거] store_top_tag 배치 종료");
+        } catch (Exception e) {
+            log.error("[수동/자동 트리거] store_top_tag 배치 실패", e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/coupon/scheduler/CouponScheduler.java
+++ b/src/main/java/org/swyp/dessertbee/user/coupon/scheduler/CouponScheduler.java
@@ -1,6 +1,7 @@
 package org.swyp.dessertbee.user.coupon.scheduler;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,18 +14,21 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class CouponScheduler {
 
     private final CouponRepository couponRepository;
 
     @Transactional
-    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 자정 실행
     public void expireCoupons() {
+        log.info("[스케줄러 시작] 쿠폰 만료 체크 at {}", LocalDateTime.now());
         List<Coupon> expiredCoupons = couponRepository.findAllByHasExpiryDateIsTrueAndStatusIs(CouponStatus.CREATED)
                 .stream()
                 .filter(coupon -> coupon.getExpiryDate() != null && coupon.getExpiryDate().isBefore(LocalDateTime.now()))
                 .toList();
 
         expiredCoupons.forEach(Coupon::expire);
+        log.info("[스케줄러 종료] 쿠폰 만료 체크 완료 at {}", LocalDateTime.now());
     }
 }


### PR DESCRIPTION
## :hash: 연관된 이슈

> #274 

## :memo: 작업 내용

> 자정에 동시 실행되는 스케줄러 간 블로킹 문제를 해결하기 위해 스케줄러를 멀티스레드로 분리했습니다.
> 매일 새벽 3시에 실행되던 Store Top Tag 배치 작업을 수동으로 실행할 수 있도록 수동 트리거 API를 추가했습니다.
