### PR TITLE
[FEATURE] 유저 한줄리뷰 리스트 조회 API 구현

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/review/controller/StoreReviewController.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/controller/StoreReviewController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
 import org.swyp.dessertbee.common.exception.ErrorCode;
-import org.swyp.dessertbee.store.menu.dto.response.MenuResponse;
 import org.swyp.dessertbee.store.review.dto.request.StoreReviewCreateRequest;
 import org.swyp.dessertbee.store.review.dto.request.StoreReviewUpdateRequest;
 import org.swyp.dessertbee.store.review.dto.response.StoreReviewResponse;

--- a/src/main/java/org/swyp/dessertbee/store/review/dto/response/UserReviewListResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/dto/response/UserReviewListResponse.java
@@ -1,5 +1,10 @@
 package org.swyp.dessertbee.store.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,27 +15,62 @@ import java.util.UUID;
 
 @Data
 @Builder
+@Schema(description = "유저가 작성한 리뷰 리스트 응답")
 public class UserReviewListResponse {
 
+    @Schema(description = "유저가 작성한 전체 리뷰 개수", example = "12", requiredMode = Schema.RequiredMode.REQUIRED)
     private int reviewCount;
+
+    @Schema(description = "유저가 작성한 리뷰 리스트", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<UserReviewItem> reviews;
 
     @Data
     @Builder
+    @Schema(description = "한 개의 유저 리뷰 아이템")
     public static class UserReviewItem {
+
+        @Schema(description = "리뷰 UUID", example = "4e8e1e28-c94e-40d7-8e93-6789abc45678", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "리뷰 UUID는 필수입니다.")
         private UUID reviewUuid;
+
+        @Schema(description = "리뷰 이미지 URL (첫 번째 이미지, 없을 경우 null)", example = "reviewImage.jpg", nullable = true)
         private String reviewImage;
-        private BigDecimal rate;
+
+        @Schema(description = "평점", example = "4.0", minimum = "0.0", maximum = "5.0", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "평점은 필수입니다.")
+        @DecimalMin(value = "0.0", message = "평점은 0.0 이상이어야 합니다.")
+        @DecimalMax(value = "5.0", message = "평점은 5.0 이하여야 합니다.")
+        private BigDecimal rating;
+
+        @Schema(description = "한 줄 리뷰 내용 (최대 50자)", example = "정말 맛있었어요!", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "리뷰 내용은 필수입니다.")
         private String content;
+
+        @Schema(description = "리뷰 등록일시", example = "2025-04-03T14:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "리뷰 작성 시간은 필수입니다.")
         private LocalDateTime createdAt;
+
+        @Schema(description = "리뷰를 작성한 가게 정보", requiredMode = Schema.RequiredMode.REQUIRED)
         private StoreInfo store;
 
         @Data
         @Builder
+        @Schema(description = "간단한 가게 정보")
         public static class StoreInfo {
+
+            @Schema(description = "가게 UUID", example = "9fa801ef-88f1-43ef-bda1-d1150c6fc12f", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull(message = "가게 UUID는 필수입니다.")
             private UUID storeUuid;
+
+            @Schema(description = "가게 대표 이미지 URL (썸네일)", example = "storeImage.jpg", nullable = true)
             private String thumbnail;
+
+            @Schema(description = "가게 이름", example = "디저트비 합정점", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "가게 이름은 필수입니다.")
             private String name;
+
+            @Schema(description = "가게 주소", example = "서울 강남구 테헤란로 123", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "가게 주소는 필수입니다.")
             private String address;
         }
     }

--- a/src/main/java/org/swyp/dessertbee/store/review/dto/response/UserReviewListResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/dto/response/UserReviewListResponse.java
@@ -1,0 +1,37 @@
+package org.swyp.dessertbee.store.review.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+public class UserReviewListResponse {
+
+    private int reviewCount;
+    private List<UserReviewItem> reviews;
+
+    @Data
+    @Builder
+    public static class UserReviewItem {
+        private UUID reviewUuid;
+        private String reviewImage;
+        private BigDecimal rate;
+        private String content;
+        private LocalDateTime createdAt;
+        private StoreInfo store;
+
+        @Data
+        @Builder
+        public static class StoreInfo {
+            private UUID storeUuid;
+            private String thumbnail;
+            private String name;
+            private String address;
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/repository/StoreReviewRepository.java
@@ -41,4 +41,11 @@ public interface StoreReviewRepository extends JpaRepository<StoreReview, Long> 
           AND FUNCTION('DATE', r.createdAt) = CURRENT_DATE
     """)
     int countTodayReviewsByUserAndStore(@Param("userUuid") UUID userUuid, @Param("storeId") Long storeId);
+
+    @Query("""
+        SELECT sr FROM StoreReview sr
+        WHERE sr.userUuid = :userUuid AND sr.deletedAt IS NULL
+        ORDER BY sr.createdAt DESC
+    """)
+    List<StoreReview> findByUserUuidOrderByCreatedAtDesc(@Param("userUuid") UUID userUuid);
 }

--- a/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewService.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewService.java
@@ -4,6 +4,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.store.review.dto.request.StoreReviewCreateRequest;
 import org.swyp.dessertbee.store.review.dto.request.StoreReviewUpdateRequest;
 import org.swyp.dessertbee.store.review.dto.response.StoreReviewResponse;
+import org.swyp.dessertbee.store.review.dto.response.UserReviewListResponse;
 
 import java.util.List;
 import java.util.UUID;
@@ -24,4 +25,7 @@ public interface StoreReviewService {
 
     /** 리뷰 삭제 */
     void deleteReview(UUID storeUuid, UUID reviewUuid);
+
+    /** 유저가 작성한 한줄 리뷰 리스트 (최신 등록순) 조회 */
+    UserReviewListResponse getUserReviewList();
 }

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
 import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.store.review.dto.response.UserReviewListResponse;
+import org.swyp.dessertbee.store.review.service.StoreReviewService;
 import org.swyp.dessertbee.user.dto.request.NicknameAvailabilityRequestDto;
 import org.swyp.dessertbee.user.dto.response.NicknameAvailabilityResponseDto;
 import org.swyp.dessertbee.user.dto.response.UserDetailResponseDto;
@@ -32,6 +34,7 @@ import org.swyp.dessertbee.user.service.UserService;
 public class UserController {
 
     private final UserService userService;
+    private final StoreReviewService storeReviewService;
 
     /**
      * 현재 인증된 사용자의 상세 정보를 조회
@@ -170,6 +173,22 @@ public class UserController {
             @RequestPart("image") MultipartFile image) {
         log.info("프로필 이미지 업데이트 요청 - 파일명: {}", image.getOriginalFilename());
         UserDetailResponseDto response = userService.updateProfileImage(image);
+        return ResponseEntity.ok(response);
+    }
+
+    /** 유저가 작성한 한줄 리뷰 리스트 (최신 등록순) 조회 */
+    @Operation(
+            summary = "내가 작성한 한줄 리뷰 리스트 조회 (completed)",
+            description = "인증된 사용자가 작성한 한줄 리뷰 목록을 최신순으로 반환합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "리뷰 리스트 조회 성공",
+            content = @Content(schema = @Schema(implementation = UserReviewListResponse.class)))
+    @ApiErrorResponses({ErrorCode.STORE_REVIEW_SERVICE_ERROR, ErrorCode.STORE_NOT_FOUND})
+    @GetMapping("/me/reviews/short")
+    public ResponseEntity<UserReviewListResponse> getMyShortReviews() {
+        UserReviewListResponse response = storeReviewService.getUserReviewList();
         return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## :hash: 연관된 이슈

> #371 

## :memo: 작업 내용

> 유저가 작성한 한줄리뷰 목록을 최신 등록순으로 조회하는 API 구현

## :speech_balloon: 리뷰 요구사항(선택)

> 커뮤니티 리뷰와 구분을 위해 `/reviews/short` 엔드포인트로 구분했습니다.
> `/me` 기반이므로 인증 기반 유저 식별 필요 (추후 `@AuthenticationPrincipal` 적용 가능)
