### PR TITLE
[FEAT] Apple Social Login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ src/main/resources/.env*
 src/test/resources/application-test.yml
 **/.DS_Store
 .DS_Store
+
+# Apple OAuth p8 Key
+*.p8
+apple/*.p8
+src/main/resources/apple/*.p8
+src/main/resources/*.p8

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'com.auth0:java-jwt:4.4.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,13 @@ services:
   app:
     image: ${DOCKERHUB_USERNAME}/desserbee:latest
     container_name: desserbee-app
+    volumes:
+      - /home/ec2-user/secrets/AuthKey_apple_login.p8:/app/resources/AuthKey_apple_login.p8
     environment:
+      - APPLE_KEY_PATH=/app/resources/AuthKey_apple_login.p8
+      - APPLE_KEY_ID=${APPLE_KEY_ID}
+      - APPLE_TEAM_ID=${APPLE_TEAM_ID}
+      - APPLE_CLIENT_ID=${APPLE_CLIENT_ID}
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-prod}
       - SPRING_DATA_REDIS_HOST=redis
       - SPRING_DATA_REDIS_PORT=6379

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -75,4 +75,25 @@ public class OAuthController {
 
         return ResponseEntity.ok(loginResponse);
     }
+
+    /**
+     * Apple 전용 OAuth 인가 코드 로그인 처리 (POST 요청)
+     */
+    @Operation(
+            summary = "Apple OAuth 회원가입, 로그인 (전용)",
+            description = "Apple OAuth 회원가입 및 로그인. Apple form_post 방식 대응."
+    )
+    @ApiResponse(responseCode = "200", description = "Apple 로그인 및 회원가입 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class)))
+    @ApiErrorResponses({ErrorCode.INVALID_INPUT_VALUE, ErrorCode.AUTHENTICATION_FAILED})
+    @PostMapping("/apple/callback")
+    public ResponseEntity<LoginResponse> appleOauthCallback(
+            @RequestParam("code") String code,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Device-ID", required = false) String deviceId
+    ) {
+        log.info("Apple OAuth 인가 코드 수신 - code: {}", code);
+        LoginResponse loginResponse = oAuthService.processOAuthLogin(code, "apple", deviceId);
+
+        return ResponseEntity.ok(loginResponse);
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/request/AppleLoginRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/request/AppleLoginRequest.java
@@ -1,6 +1,9 @@
 package org.swyp.dessertbee.auth.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,28 +16,37 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Apple 로그인 요청 DTO")
 public class AppleLoginRequest {
 
     /**
      * Apple에서 제공하는 일회용 인증 코드
      */
+    @NotBlank
+    @Schema(description = "Apple 인가 코드", example = "abcdef123456")
     private String code;
 
     /**
      * Apple에서 제공하는 ID 토큰 (JWT)
      */
+    @NotBlank
     @JsonProperty("id_token")
+    @Schema(description = "Apple ID 토큰 (JWT)", example = "eyJhbGciOi...")
     private String idToken;
 
     /**
      * CSRF 방지를 위한 상태값
      */
+    @NotBlank
+    @Schema(description = "CSRF 방지를 위한 상태값", example = "xyz789")
     private String state;
 
     /**
      * 사용자 정보 (최초 로그인 시에만 포함)
      */
+    @Valid
     @JsonProperty("user")
+    @Schema(description = "Apple 최초 로그인 시 제공되는 사용자 정보")
     private AppleUserInfo userInfo;
 
     /**
@@ -43,15 +55,19 @@ public class AppleLoginRequest {
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "Apple 사용자 정보")
     public static class AppleUserInfo {
         /**
          * 사용자 이메일
          */
+        @Schema(description = "사용자 이메일", example = "user@example.com")
         private String email;
 
         /**
          * 사용자 이름 정보
          */
+        @Valid
+        @Schema(description = "Apple 사용자 이름 정보")
         private Name name;
 
         /**
@@ -60,17 +76,20 @@ public class AppleLoginRequest {
         @Data
         @NoArgsConstructor
         @AllArgsConstructor
+        @Schema(description = "Apple 사용자 이름 구조")
         public static class Name {
             /**
              * 이름
              */
             @JsonProperty("firstName")
+            @Schema(description = "이름", example = "John")
             private String firstName;
 
             /**
              * 성
              */
             @JsonProperty("lastName")
+            @Schema(description = "성", example = "Appleseed")
             private String lastName;
         }
     }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/request/AppleLoginRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/request/AppleLoginRequest.java
@@ -1,0 +1,77 @@
+package org.swyp.dessertbee.auth.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Apple 로그인 요청 데이터 전송 객체
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppleLoginRequest {
+
+    /**
+     * Apple에서 제공하는 일회용 인증 코드
+     */
+    private String code;
+
+    /**
+     * Apple에서 제공하는 ID 토큰 (JWT)
+     */
+    @JsonProperty("id_token")
+    private String idToken;
+
+    /**
+     * CSRF 방지를 위한 상태값
+     */
+    private String state;
+
+    /**
+     * 사용자 정보 (최초 로그인 시에만 포함)
+     */
+    @JsonProperty("user")
+    private AppleUserInfo userInfo;
+
+    /**
+     * Apple 사용자 정보
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AppleUserInfo {
+        /**
+         * 사용자 이메일
+         */
+        private String email;
+
+        /**
+         * 사용자 이름 정보
+         */
+        private Name name;
+
+        /**
+         * Apple 사용자 이름 구조
+         */
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Name {
+            /**
+             * 이름
+             */
+            @JsonProperty("firstName")
+            private String firstName;
+
+            /**
+             * 성
+             */
+            @JsonProperty("lastName")
+            private String lastName;
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/enums/AuthProvider.java
+++ b/src/main/java/org/swyp/dessertbee/auth/enums/AuthProvider.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuthProvider {
     LOCAL("local"),
-    KAKAO("kakao");
+    KAKAO("kakao"),
+    APPLE("apple"); // 애플 소셜 로그인 제공자 추가
 
     private final String providerName;
 
@@ -21,7 +22,7 @@ public enum AuthProvider {
      */
     public static AuthProvider fromString(String providerName) {
         for (AuthProvider provider : AuthProvider.values()) {
-            if (provider.getProviderName().equals(providerName)) {
+            if (provider.getProviderName().equalsIgnoreCase(providerName)) {
                 return provider;
             }
         }

--- a/src/main/java/org/swyp/dessertbee/auth/oauth2/AppleResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/oauth2/AppleResponse.java
@@ -1,0 +1,81 @@
+package org.swyp.dessertbee.auth.oauth2;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+import java.util.Map;
+
+/**
+ * 애플 OAuth 응답을 처리하는 구현체
+ * 애플 ID 토큰에서 추출한 정보를 표준화된 형태로 변환
+ */
+@Slf4j
+public class AppleResponse implements OAuth2Response {
+    private final Map<String, Object> attributes;
+
+    /**
+     * 애플 ID 토큰 페이로드로부터 AppleResponse 객체 생성
+     *
+     * @param attributes 애플 ID 토큰 페이로드 (claims)
+     */
+    public AppleResponse(Map<String, Object> attributes) {
+        this.attributes = attributes;
+
+        // sub와 email 필드 검증
+        if (attributes.get("sub") == null) {
+            log.error("OAuth2 애플 응답에 sub(사용자 ID)가 없습니다.");
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error("invalid_response", "Missing subject identifier", null)
+            );
+        }
+
+        // 애플은 email_verified 속성이 true인 경우에만 email을 신뢰할 수 있음
+        if (attributes.get("email") == null) {
+            log.error("OAuth2 애플 응답에 email이 없습니다.");
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error("invalid_response", "Missing email data", null)
+            );
+        }
+    }
+
+    @Override
+    public String getProvider() {
+        // 제공자 이름 반환
+        return "apple";
+    }
+
+    @Override
+    public String getProviderId() {
+        // 애플에서는 'sub' claim이 사용자 고유 ID
+        return attributes.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        // 사용자 이메일 반환
+        return attributes.get("email").toString();
+    }
+
+    @Override
+    public String getNickname() {
+        // 이름 정보가 있는 경우 사용 (첫 로그인 시에만 제공됨)
+        String firstName = (String) attributes.getOrDefault("firstName", "");
+        String lastName = (String) attributes.getOrDefault("lastName", "");
+        String fullName = (lastName + firstName).trim();
+
+        // 이름 정보가 없는 경우 이메일에서 생성
+        if (fullName.isEmpty()) {
+            // 이메일 주소에서 @ 앞부분을 닉네임으로 사용
+            String email = getEmail();
+            return email != null ? email.split("@")[0] : "Apple User";
+        }
+        return fullName;
+    }
+
+    @Override
+    public String getImageUrl() {
+        // 애플은 프로필 이미지를 제공하지 않음
+        return null;
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
+++ b/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
@@ -68,4 +68,12 @@ public interface AuthRepository extends JpaRepository<AuthEntity, Integer> {
      */
     @Query("SELECT COUNT(a) > 0 FROM AuthEntity a WHERE a.user.userUuid = :userUuid AND a.active = :active")
     boolean existsByUserUuidAndActive(@Param("userUuid") UUID userUuid, @Param("active") boolean active);
+
+    /**
+     * 인증 제공자와 제공자 ID로 인증 정보 찾기 (소셜 로그인 사용자 식별용)
+     * @param provider 인증 제공자 (예: apple, kakao 등)
+     * @param providerId 제공자가 발급한 고유 ID
+     * @return 해당 조건에 맞는 인증 정보
+     */
+    Optional<AuthEntity> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
@@ -82,7 +82,7 @@ public class AppleOAuthService {
     @Transactional
     public LoginResponse processAppleLogin(String code, String idToken, String state, AppleUserInfo userInfo, String deviceId) {
         try {
-            log.info("애플 로그인 처리 시작 - 인가 코드: {}, ID 토큰 존재 여부: {}", code, idToken != null);
+            log.info("애플 로그인 처리 시작 ID 토큰 존재 여부: {}", idToken != null);
 
             // Apple의 인증 서버에서 토큰을 얻기 위한 client secret 생성
             String clientSecret = createClientSecret();

--- a/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.swyp.dessertbee.auth.dto.request.AppleLoginRequest.AppleUserInfo;
 import org.swyp.dessertbee.auth.dto.response.LoginResponse;
 import org.swyp.dessertbee.auth.exception.AuthExceptions.DuplicateNicknameException;
 import org.swyp.dessertbee.auth.exception.OAuthExceptions.OAuthAuthenticationException;
@@ -68,27 +69,50 @@ public class AppleOAuthService {
     @Value("${spring.security.oauth2.client.provider.apple.token-uri}")
     private String tokenUri;
 
+    /**
+     * Apple 로그인 처리 - 코드, ID 토큰, 상태값, 사용자 정보, 디바이스 ID를 함께 처리
+     *
+     * @param code Apple에서 제공한 인가 코드
+     * @param idToken Apple에서 제공한 ID 토큰
+     * @param state CSRF 방지를 위한 상태값
+     * @param userInfo 최초 로그인 시 Apple에서 제공하는 사용자 정보 (선택적)
+     * @param deviceId 디바이스 식별자
+     * @return 로그인 응답 객체
+     */
     @Transactional
-    public LoginResponse processAppleLogin(String code, String deviceId) {
+    public LoginResponse processAppleLogin(String code, String idToken, String state, AppleUserInfo userInfo, String deviceId) {
         try {
-            log.info("애플 로그인 처리 시작 - 인가 코드: {}", code);
+            log.info("애플 로그인 처리 시작 - 인가 코드: {}, ID 토큰 존재 여부: {}", code, idToken != null);
 
+            // Apple의 인증 서버에서 토큰을 얻기 위한 client secret 생성
             String clientSecret = createClientSecret();
 
-            String idToken = getAppleIdToken(code, clientSecret);
+            // 프론트에서 ID 토큰을 직접 전달받은 경우, 별도로 요청하지 않음
+            String appleIdToken = (idToken != null && !idToken.isEmpty())
+                    ? idToken
+                    : getAppleIdToken(code, clientSecret);
+
             log.info("애플 ID 토큰 획득 성공");
 
-            OAuth2Response userInfo = getAppleUserInfo(idToken);
-            log.info("애플 사용자 정보 획득 성공 - 이메일: {}", userInfo.getEmail());
+            // ID 토큰에서 사용자 정보 추출 (추가 사용자 정보가 있으면 보강)
+            OAuth2Response oAuth2Response = getAppleUserInfo(appleIdToken, userInfo);
+            log.info("애플 사용자 정보 획득 성공 - 이메일: {}", oAuth2Response.getEmail());
 
-            return processUserLogin(userInfo, deviceId);
+            // 사용자 로그인 또는 회원가입 처리
+            return processUserLogin(oAuth2Response, deviceId);
 
         } catch (Exception e) {
             log.error("애플 로그인 처리 중 오류 발생", e);
-            throw new OAuthServiceException("애플 로그인 처리 중 오류가 발생했습니다.");
+            throw new OAuthServiceException("애플 로그인 처리 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
 
+    /**
+     * Apple Client Secret 생성
+     * Apple의 인증 서버에 요청하기 위한 JWT 형식의 client secret을 생성
+     *
+     * @return 생성된 client secret
+     */
     private String createClientSecret() {
         try {
             ECPrivateKey privateKey = getPrivateKey();
@@ -107,10 +131,15 @@ public class AppleOAuthService {
 
             return jwt;
         } catch (Exception e) {
-            throw new OAuthServiceException("Apple client secret 생성 실패");
+            throw new OAuthServiceException("Apple client secret 생성 실패: " + e.getMessage());
         }
     }
 
+    /**
+     * Apple 비공개 키 로드
+     *
+     * @return ECPrivateKey 형식의 비공개 키
+     */
     private ECPrivateKey getPrivateKey() {
         try {
             ClassPathResource resource = new ClassPathResource(privateKeyPath.replaceFirst("classpath:", ""));
@@ -128,10 +157,17 @@ public class AppleOAuthService {
             KeyFactory keyFactory = KeyFactory.getInstance("EC");
             return (ECPrivateKey) keyFactory.generatePrivate(keySpec);
         } catch (Exception e) {
-            throw new OAuthServiceException("Apple 개인 키 로딩 실패");
+            throw new OAuthServiceException("Apple 개인 키 로딩 실패: " + e.getMessage());
         }
     }
 
+    /**
+     * Apple 토큰 엔드포인트에 요청하여 ID 토큰 획득
+     *
+     * @param code Apple에서 제공한 인가 코드
+     * @param clientSecret 생성된 client secret
+     * @return 획득한 ID 토큰
+     */
     private String getAppleIdToken(String code, String clientSecret) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -159,18 +195,44 @@ public class AppleOAuthService {
         return (String) responseBody.get("id_token");
     }
 
-    private OAuth2Response getAppleUserInfo(String idToken) {
+    /**
+     * Apple ID 토큰에서 사용자 정보 추출 및 추가 사용자 정보로 보강
+     *
+     * @param idToken Apple에서 제공한 ID 토큰
+     * @param userInfo 최초 로그인 시 추가로 제공되는 사용자 정보 (선택적)
+     * @return 표준화된 OAuth2Response 객체
+     */
+    private OAuth2Response getAppleUserInfo(String idToken, AppleUserInfo userInfo) {
         try {
             String[] parts = idToken.split("\\.");
             String payload = new String(Base64.getUrlDecoder().decode(parts[1]));
             Map<String, Object> claims = objectMapper.readValue(payload, Map.class);
 
+            // 추가 사용자 정보가 있는 경우 claims에 추가
+            if (userInfo != null) {
+                if (userInfo.getEmail() != null) {
+                    claims.putIfAbsent("email", userInfo.getEmail());
+                }
+
+                if (userInfo.getName() != null) {
+                    claims.putIfAbsent("firstName", userInfo.getName().getFirstName());
+                    claims.putIfAbsent("lastName", userInfo.getName().getLastName());
+                }
+            }
+
             return new AppleResponse(claims);
         } catch (Exception e) {
-            throw new OAuthAuthenticationException("애플 ID 토큰 디코딩 실패");
+            throw new OAuthAuthenticationException("애플 ID 토큰 디코딩 실패: " + e.getMessage());
         }
     }
 
+    /**
+     * 사용자 로그인 또는 회원가입 처리
+     *
+     * @param oauth2Response 표준화된 OAuth2Response 객체
+     * @param deviceId 디바이스 식별자
+     * @return 로그인 응답 객체
+     */
     private LoginResponse processUserLogin(OAuth2Response oauth2Response, String deviceId) {
         UserEntity user = userRepository.findByEmail(oauth2Response.getEmail())
                 .orElseGet(() -> registerNewUser(oauth2Response));
@@ -198,6 +260,12 @@ public class AppleOAuthService {
         return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, usedDeviceId, isPreferenceSet);
     }
 
+    /**
+     * 새 사용자 등록
+     *
+     * @param oauth2Response 표준화된 OAuth2Response 객체
+     * @return 생성된 사용자 엔티티
+     */
     private UserEntity registerNewUser(OAuth2Response oauth2Response) {
         log.info("새 사용자 등록 - 이메일: {}", oauth2Response.getEmail());
 
@@ -216,6 +284,12 @@ public class AppleOAuthService {
         return userRepository.save(user);
     }
 
+    /**
+     * 중복되지 않는 고유한 닉네임 생성
+     *
+     * @param baseNickname 기본 닉네임
+     * @return 고유한 닉네임
+     */
     private String generateUniqueNickname(String baseNickname) {
         if (!userRepository.existsByNickname(baseNickname)) {
             return baseNickname;
@@ -230,6 +304,11 @@ public class AppleOAuthService {
         throw new DuplicateNicknameException("고유한 닉네임을 생성할 수 없습니다.");
     }
 
+    /**
+     * 랜덤 숫자 생성 (닉네임 중복 방지용)
+     *
+     * @return 4자리 랜덤 숫자 문자열
+     */
     private String generateRandomNumber() {
         return String.format("%04d", new Random().nextInt(10000));
     }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
@@ -63,7 +63,7 @@ public class AppleOAuthService {
     @Value("${APPLE_KEY_ID}")
     private String keyId;
 
-    @Value("${APPLE_KEY_PATH}") // e.g. classpath:AuthKey_ABC123XYZ.p8
+    @Value("${APPLE_KEY_PATH}")
     private String privateKeyPath;
 
     @Value("${spring.security.oauth2.client.provider.apple.token-uri}")

--- a/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
@@ -1,0 +1,236 @@
+package org.swyp.dessertbee.auth.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.swyp.dessertbee.auth.dto.response.LoginResponse;
+import org.swyp.dessertbee.auth.exception.AuthExceptions.DuplicateNicknameException;
+import org.swyp.dessertbee.auth.exception.OAuthExceptions.OAuthAuthenticationException;
+import org.swyp.dessertbee.auth.exception.AuthExceptions.OAuthServiceException;
+import org.swyp.dessertbee.auth.jwt.JWTUtil;
+import org.swyp.dessertbee.auth.oauth2.AppleResponse;
+import org.swyp.dessertbee.auth.oauth2.OAuth2Response;
+import org.swyp.dessertbee.common.entity.ImageType;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.common.service.ImageService;
+import org.swyp.dessertbee.preference.service.PreferenceService;
+import org.swyp.dessertbee.role.entity.RoleEntity;
+import org.swyp.dessertbee.role.entity.RoleType;
+import org.swyp.dessertbee.role.repository.RoleRepository;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserRepository;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.security.interfaces.ECPrivateKey;
+import java.security.KeyFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AppleOAuthService {
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final TokenService tokenService;
+    private final JWTUtil jwtUtil;
+    private final ImageService imageService;
+    private final PreferenceService preferenceService;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${spring.security.oauth2.client.registration.apple.client-id}")
+    private String clientId;
+
+    @Value("${APPLE_TEAM_ID}")
+    private String teamId;
+
+    @Value("${APPLE_KEY_ID}")
+    private String keyId;
+
+    @Value("${APPLE_KEY_PATH}") // e.g. classpath:AuthKey_ABC123XYZ.p8
+    private String privateKeyPath;
+
+    @Value("${spring.security.oauth2.client.provider.apple.token-uri}")
+    private String tokenUri;
+
+    @Transactional
+    public LoginResponse processAppleLogin(String code, String deviceId) {
+        try {
+            log.info("애플 로그인 처리 시작 - 인가 코드: {}", code);
+
+            String clientSecret = createClientSecret();
+
+            String idToken = getAppleIdToken(code, clientSecret);
+            log.info("애플 ID 토큰 획득 성공");
+
+            OAuth2Response userInfo = getAppleUserInfo(idToken);
+            log.info("애플 사용자 정보 획득 성공 - 이메일: {}", userInfo.getEmail());
+
+            return processUserLogin(userInfo, deviceId);
+
+        } catch (Exception e) {
+            log.error("애플 로그인 처리 중 오류 발생", e);
+            throw new OAuthServiceException("애플 로그인 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    private String createClientSecret() {
+        try {
+            ECPrivateKey privateKey = getPrivateKey();
+
+            Algorithm algorithm = Algorithm.ECDSA256(null, privateKey);
+
+            long now = System.currentTimeMillis();
+            String jwt = JWT.create()
+                    .withIssuer(teamId)
+                    .withIssuedAt(new Date(now))
+                    .withExpiresAt(new Date(now + 86400 * 1000L)) // 24시간 유효
+                    .withAudience("https://appleid.apple.com")
+                    .withSubject(clientId)
+                    .withKeyId(keyId)
+                    .sign(algorithm);
+
+            return jwt;
+        } catch (Exception e) {
+            throw new OAuthServiceException("Apple client secret 생성 실패");
+        }
+    }
+
+    private ECPrivateKey getPrivateKey() {
+        try {
+            ClassPathResource resource = new ClassPathResource(privateKeyPath.replaceFirst("classpath:", ""));
+            StringBuilder privateKeyBuilder = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.contains("PRIVATE KEY")) continue;
+                    privateKeyBuilder.append(line);
+                }
+            }
+
+            byte[] keyBytes = Base64.getDecoder().decode(privateKeyBuilder.toString());
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return (ECPrivateKey) keyFactory.generatePrivate(keySpec);
+        } catch (Exception e) {
+            throw new OAuthServiceException("Apple 개인 키 로딩 실패");
+        }
+    }
+
+    private String getAppleIdToken(String code, String clientSecret) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("code", code);
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                tokenUri,
+                HttpMethod.POST,
+                requestEntity,
+                Map.class
+        );
+
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody == null || !responseBody.containsKey("id_token")) {
+            throw new OAuthAuthenticationException("애플 ID 토큰을 획득하는데 실패했습니다.");
+        }
+
+        return (String) responseBody.get("id_token");
+    }
+
+    private OAuth2Response getAppleUserInfo(String idToken) {
+        try {
+            String[] parts = idToken.split("\\.");
+            String payload = new String(Base64.getUrlDecoder().decode(parts[1]));
+            Map<String, Object> claims = objectMapper.readValue(payload, Map.class);
+
+            return new AppleResponse(claims);
+        } catch (Exception e) {
+            throw new OAuthAuthenticationException("애플 ID 토큰 디코딩 실패");
+        }
+    }
+
+    private LoginResponse processUserLogin(OAuth2Response oauth2Response, String deviceId) {
+        UserEntity user = userRepository.findByEmail(oauth2Response.getEmail())
+                .orElseGet(() -> registerNewUser(oauth2Response));
+
+        List<String> roles = user.getUserRoles().stream()
+                .map(userRole -> userRole.getRole().getName().getRoleName())
+                .collect(Collectors.toList());
+
+        boolean keepLoggedIn = false;
+        String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles);
+        String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), keepLoggedIn);
+        long expiresIn = jwtUtil.getACCESS_TOKEN_EXPIRE();
+
+        String usedDeviceId = tokenService.saveRefreshToken(
+                user.getUserUuid(), refreshToken,
+                oauth2Response.getProvider(), oauth2Response.getProviderId(), deviceId
+        );
+
+        List<String> profileImages = imageService.getImagesByTypeAndId(
+                ImageType.PROFILE, user.getId());
+        String profileImageUrl = profileImages.isEmpty() ? null : profileImages.get(0);
+
+        boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
+
+        return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, usedDeviceId, isPreferenceSet);
+    }
+
+    private UserEntity registerNewUser(OAuth2Response oauth2Response) {
+        log.info("새 사용자 등록 - 이메일: {}", oauth2Response.getEmail());
+
+        String uniqueNickname = generateUniqueNickname(oauth2Response.getNickname());
+
+        UserEntity user = UserEntity.builder()
+                .email(oauth2Response.getEmail())
+                .nickname(uniqueNickname)
+                .build();
+
+        RoleEntity role = roleRepository.findByName(RoleType.ROLE_USER)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE,
+                        "기본 사용자 역할을 찾을 수 없습니다."));
+        user.addRole(role);
+
+        return userRepository.save(user);
+    }
+
+    private String generateUniqueNickname(String baseNickname) {
+        if (!userRepository.existsByNickname(baseNickname)) {
+            return baseNickname;
+        }
+
+        for (int i = 1; i <= 100; i++) {
+            String candidate = baseNickname + " " + generateRandomNumber();
+            if (!userRepository.existsByNickname(candidate)) {
+                return candidate;
+            }
+        }
+        throw new DuplicateNicknameException("고유한 닉네임을 생성할 수 없습니다.");
+    }
+
+    private String generateRandomNumber() {
+        return String.format("%04d", new Random().nextInt(10000));
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.auth.dto.request.AppleLoginRequest.AppleUserInfo;
 import org.swyp.dessertbee.auth.dto.response.LoginResponse;
 import org.swyp.dessertbee.auth.enums.AuthProvider;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
+
 /**
  * OAuth 인증 처리를 담당하는 공통 서비스
  */
@@ -25,6 +27,7 @@ public class OAuthService {
      *
      * @param code 인가 코드
      * @param providerName OAuth 제공자 (kakao, naver, google 등)
+     * @param deviceId 디바이스 식별자
      * @return 로그인 응답 (JWT 토큰 포함)
      */
     @Transactional
@@ -40,7 +43,7 @@ public class OAuthService {
             // enum을 사용하여 적절한 서비스 호출
             return switch (provider) {
                 case KAKAO -> kakaoOAuthService.processKakaoLogin(code, deviceId);
-                case APPLE -> appleOAuthService.processAppleLogin(code, deviceId);
+                case APPLE -> appleOAuthService.processAppleLogin(code, null, null, null, deviceId);
                 // 추후 다른 OAuth 제공자 추가
                 default -> throw new InvalidProviderException("아직 구현되지 않은 OAuth 제공자입니다: " + provider.getProviderName());
             };
@@ -49,6 +52,29 @@ public class OAuthService {
         } catch (Exception e) {
             log.error("OAuth 로그인 처리 중 오류 발생 - 제공자: {}", providerName, e);
             throw new OAuthAuthenticationException("OAuth 로그인 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * Apple 로그인 처리를 위한 확장 메소드
+     * Apple은 추가 파라미터(idToken, state, userInfo)가 필요하므로 별도 메소드 제공
+     *
+     * @param code 인가 코드
+     * @param idToken Apple ID 토큰
+     * @param state CSRF 방지용 상태값
+     * @param userInfo 사용자 정보 (최초 로그인 시에만)
+     * @param deviceId 디바이스 식별자
+     * @return 로그인 응답 (JWT 토큰 포함)
+     */
+    @Transactional
+    public LoginResponse processAppleLogin(String code, String idToken, String state, AppleUserInfo userInfo, String deviceId) {
+        try {
+            return appleOAuthService.processAppleLogin(code, idToken, state, userInfo, deviceId);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple 로그인 처리 중 오류 발생", e);
+            throw new OAuthAuthenticationException("Apple 로그인 처리 중 오류가 발생했습니다.");
         }
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -17,7 +17,7 @@ import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
 public class OAuthService {
 
     private final KakaoOAuthService kakaoOAuthService;
-    // 추후 다른 OAuth 서비스 추가 (네이버, 구글 등)
+    private final AppleOAuthService appleOAuthService;
 
     /**
      * 인가 코드로 OAuth 로그인 처리
@@ -40,6 +40,7 @@ public class OAuthService {
             // enum을 사용하여 적절한 서비스 호출
             return switch (provider) {
                 case KAKAO -> kakaoOAuthService.processKakaoLogin(code, deviceId);
+                case APPLE -> appleOAuthService.processAppleLogin(code, deviceId);
                 // 추후 다른 OAuth 제공자 추가
                 default -> throw new InvalidProviderException("아직 구현되지 않은 OAuth 제공자입니다: " + provider.getProviderName());
             };

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,6 +22,9 @@ spring:
         registration:
           kakao:
             redirect-uri: "http://localhost:8000/kakao-oauth-test.html"
+          apple:
+            redirect-uri: https://61c8-2001-2d8-2117-cf18-bc1c-5c7c-e9b8-c225.ngrok-free.app/apple-oauth-test.html
+
   graphql:
     cors:
       allowed-origins: "http://localhost:3000"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,12 +44,22 @@ spring:
               - profile_image
               - account_email
             client-authentication-method: client_secret_post
+          apple:
+            client-id: ${APPLE_CLIENT_ID}            # Service ID (웹 client-id)
+            authorization-grant-type: authorization_code
+            scope:
+              - email
+
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize?response_mode=form_post
+            token-uri: https://appleid.apple.com/auth/token
+
   mail:
     host: smtp.gmail.com
     port: 587
@@ -89,5 +99,3 @@ aws:
     region: ap-northeast-2
     access-key: ${S3_ACCESS_KEY}
     secret-key: ${S3_SECRET_KEY}
-
-

--- a/src/main/resources/static/apple-oauth-test.html
+++ b/src/main/resources/static/apple-oauth-test.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DessertBee - Apple 로그인 테스트</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background-color: #f8f9fa;
+        }
+        .container {
+            background-color: white;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            max-width: 600px;
+            width: 100%;
+        }
+        h1 {
+            color: #333;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        #appleLogin {
+            background-color: black;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            padding: 12px 20px;
+            font-size: 16px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            margin-bottom: 30px;
+            font-weight: bold;
+            transition: background-color 0.2s;
+        }
+        #appleLogin:hover {
+            background-color: #333;
+        }
+        #appleLogin svg {
+            margin-right: 10px;
+        }
+        .environment-selector {
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .environment-selector label {
+            margin-right: 10px;
+            font-weight: bold;
+        }
+        #response {
+            margin-top: 20px;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            width: 100%;
+            min-height: 200px;
+            background-color: #f9f9f9;
+            overflow-wrap: break-word;
+            white-space: pre-wrap;
+            font-family: monospace;
+            font-size: 14px;
+        }
+        .response-container {
+            margin-top: 20px;
+        }
+        h3 {
+            color: #555;
+            margin-bottom: 10px;
+        }
+        .copy-button {
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            padding: 8px 15px;
+            font-size: 14px;
+            cursor: pointer;
+            margin-top: 10px;
+            transition: background-color 0.2s;
+        }
+        .copy-button:hover {
+            background-color: #45a049;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>DessertBee - Apple 로그인 테스트</h1>
+
+    <div class="environment-selector">
+        <label for="environment">테스트 환경 선택:</label>
+        <select id="environment">
+            <option value="local">로컬 테스트 (ngrok)</option>
+            <option value="test">테스트 서버</option>
+            <option value="prod">프로덕션 서버</option>
+        </select>
+    </div>
+
+    <button id="appleLogin">
+        <svg height="24" width="24" viewBox="0 0 24 24">
+            <path d="M16.74 13.13c0 2.92 2.4 3.87 2.4 3.87-.02.07-.57 2-1.89 3.96-1.14 1.67-2.32 3.34-4.17 3.34-1.82 0-2.4-1.08-4.5-1.08-2.1 0-2.76 1.04-4.5 1.04-1.75 0-3.08-1.81-4.25-3.5-2.3-3.35-4.06-9.44-1.7-13.58 1.17-2.06 3.27-3.37 5.54-3.37 1.73 0 3.35 1.16 4.4 1.16 1.05 0 3.03-1.44 5.1-1.23 2.8.21 4.8 2.32 5.36 4.54-5.76 2.45-4.8 8.84.73 10.85h-.02z" fill="white" />
+        </svg>
+        Apple로 로그인
+    </button>
+
+    <div class="response-container">
+        <h3>응답 결과:</h3>
+        <pre id="response">로그인 버튼을 클릭하여 Apple 로그인을 시도하세요.</pre>
+        <button id="copyResponse" class="copy-button">응답 복사</button>
+    </div>
+</div>
+
+<script>
+    // 설정값
+    const CLIENT_ID = 'com.desser.desserbee'; // Service ID (웹 client-id)
+    const REDIRECT_URI_LOCAL = 'https://f33f-218-146-57-68.ngrok-free.app/ko/oauth/callback/apple'; // ngrok URL로 수정
+    const REDIRECT_URI_TEST = 'https://test.desserbee.com/ko/oauth/callback/apple';
+    const REDIRECT_URI_PROD = 'https://desserbee.com/ko/oauth/callback/apple';
+
+    // 환경 선택에 따른 리다이렉트 URI 반환
+    function getRedirectUri() {
+        const environment = document.getElementById('environment').value;
+        if (environment === 'prod') return REDIRECT_URI_PROD;
+        if (environment === 'test') return REDIRECT_URI_TEST;
+        return REDIRECT_URI_LOCAL; // 기본값은 로컬 테스트 (ngrok)
+    }
+
+    // 임의의 상태값 생성 (CSRF 방지)
+    function generateRandomString(length) {
+        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        let result = '';
+        for (let i = 0; i < length; i++) {
+            result += characters.charAt(Math.floor(Math.random() * characters.length));
+        }
+        return result;
+    }
+
+    // Apple 로그인 버튼 이벤트 리스너
+    document.getElementById('appleLogin').addEventListener('click', () => {
+        // 상태값 생성 및 저장
+        const state = generateRandomString(16);
+        localStorage.setItem('appleLoginState', state);
+
+        // 리다이렉트 URI 결정
+        const redirectUri = getRedirectUri();
+
+        // 요청할 범위
+        const scope = 'name email';
+
+        // Apple 로그인 URL 생성
+        const authUrl = `https://appleid.apple.com/auth/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code id_token&state=${state}&scope=${scope}&response_mode=form_post`;
+
+        // 로그인 URL 표시
+        const responseElement = document.getElementById('response');
+        responseElement.textContent = `선택한 환경: ${document.getElementById('environment').value}\n\n`;
+        responseElement.textContent += `리다이렉트 URI: ${redirectUri}\n\n`;
+        responseElement.textContent += `Apple 로그인 URL:\n${authUrl}\n\n리다이렉트되는 중...`;
+
+        // 새 창에서 Apple 로그인 페이지 열기
+        window.location.href = authUrl;
+    });
+
+    // 복사 버튼 이벤트 리스너
+    document.getElementById('copyResponse').addEventListener('click', () => {
+        const responseElement = document.getElementById('response');
+
+        // 텍스트 선택 및 복사
+        const range = document.createRange();
+        range.selectNode(responseElement);
+        window.getSelection().removeAllRanges();
+        window.getSelection().addRange(range);
+        document.execCommand('copy');
+        window.getSelection().removeAllRanges();
+
+        // 알림
+        alert('응답이 클립보드에 복사되었습니다.');
+    });
+
+    // URL 파라미터 파싱 함수
+    function getUrlParams() {
+        const params = {};
+        const queryString = window.location.search.substring(1);
+        const pairs = queryString.split('&');
+
+        for (const pair of pairs) {
+            const [key, value] = pair.split('=');
+            if (key && value) {
+                params[decodeURIComponent(key)] = decodeURIComponent(value);
+            }
+        }
+
+        // form_post 방식으로 온 데이터도 처리
+        if (document.forms[0] && document.forms[0].elements) {
+            const form = document.forms[0];
+            for (let i = 0; i < form.elements.length; i++) {
+                const element = form.elements[i];
+                if (element.name) {
+                    params[element.name] = element.value;
+                }
+            }
+        }
+
+        return params;
+    }
+
+    // 페이지 로드 시 응답 확인
+    window.addEventListener('load', () => {
+        // URL 파라미터 확인
+        const params = getUrlParams();
+
+        // Apple 로그인 응답 처리
+        if (params.code) {
+            const responseElement = document.getElementById('response');
+
+            // 저장된 상태값 가져오기
+            const savedState = localStorage.getItem('appleLoginState');
+
+            // 상태값 검증
+            if (params.state && params.state !== savedState) {
+                responseElement.textContent = '오류: 상태값이 일치하지 않습니다 (CSRF 공격 가능성)';
+                return;
+            }
+
+            // 로그인 응답 객체 생성
+            const loginResponse = {
+                code: params.code,
+                id_token: params.id_token,
+                state: params.state,
+                user: params.user // 최초 로그인 시에만 전달됨
+            };
+
+            // 응답 표시
+            responseElement.textContent = '로그인 응답:\n' + JSON.stringify(loginResponse, null, 2);
+
+            // 백엔드 요청 준비
+            const apiUrl = '/api/auth/oauth2/apple/callback';
+            responseElement.textContent += `\n\n백엔드 요청 URL: ${apiUrl}`;
+            responseElement.textContent += '\n\n요청 본문:\n' + JSON.stringify({
+                code: params.code,
+                id_token: params.id_token,
+                state: params.state,
+                user: params.user ? JSON.parse(params.user) : null
+            }, null, 2);
+
+            // 백엔드로 데이터 전송
+            fetch(apiUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    code: params.code,
+                    id_token: params.id_token,
+                    state: params.state,
+                    user: params.user ? JSON.parse(params.user) : null
+                })
+            })
+                .then(response => response.json())
+                .then(data => {
+                    // 백엔드 응답 처리
+                    responseElement.textContent += '\n\n백엔드 응답:\n' + JSON.stringify(data, null, 2);
+                })
+                .catch(error => {
+                    responseElement.textContent += '\n\n오류:\n' + error.message;
+                });
+        }
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## :hash: 연관된 이슈
#283 
## :memo: 작업 내용
- 애플소셜 로그인 구현
- **TokenService 수정**:
   - 소셜 로그인 시 provider/providerId 조합으로 기존 인증 정보를 먼저 조회
   - 기존 정보가 없는 경우에만 사용자/디바이스 기반으로 조회
   - 디바이스 ID 변경 시 기존 인증 정보를 업데이트하는 로직 개선
-  **AuthRepository 추가**:
   - `findByProviderAndProviderId` 메서드 추가
   - provider와 providerId 조합으로 인증 정보를 조회할 수 있도록 지원

- 전체 플로우 정리
1. 사용자가 "[Apple로 로그인]" 버튼을 클릭
2. 애플 로그인 팝업/페이지가 열리고 사용자는 애플 계정으로 인증
3. 애플은 등록된 redirect_uri로 사용자를 리다이렉트
  - 다음 정보가 프론트엔드로 전달 (code, id_token, state, user)
5. 프론트엔드는 이 정보들을 백엔드 API(/api/auth/oauth2/apple/callback)로 전송
6. 컨트롤러는 프론트엔드에서 받은 code, id_token, state, 사용자 정보와 디바이스 ID를 서비스로 전달
7. processAppleLogin 메소드가 호출되며 애플 로그인 처리가 시작
8. 애플 서버와 통신하기 위한 client secret을 생성
9. 개발자 계정의 private key를 사용하여 JWT 형식으로 생성
10. ID 토큰 처리는 프론트엔드에서 id_token을 이미 전달받았다면 그것을 사용하고 없다면 code와 client_secret을 사용하여 애플 토큰 엔드포인트에서 ID 토큰을 획득
11. ID 토큰(JWT)을 디코딩하여 사용자 정보(sub, email 등)를 추출
12. 서버는 이메일을 기준으로 기존 사용자인지 확인 (로그인 or 회원가입 처리)
13. JWT access token과 refresh token을 생성, 디바이스 ID를 사용하여 refresh token을 저장후 이 모든 정보를 포함한 LoginResponse를 생성하여 반환