### PR TITLE
[FIX&MERGE] redirect 경로 추가

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,6 +14,8 @@ spring:
         registration:
           kakao:
             redirect-uri: ${KAKAO_REDIRECT_URI_PROD}
+          apple:
+            redirect-uri: ${APPLE_REDIRECT_URI_PROD}
 #  elasticsearch:
 #    uris: http://desserbee-es:9200
 #  graphql:

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -32,6 +32,8 @@ spring:
         registration:
           kakao:
             redirect-uri: ${KAKAO_REDIRECT_URI_TEST}
+          apple:
+            redirect-uri: ${APPLE_REDIRECT_URI_TEST}
 #  elasticsearch:
 #    uris: http://desserbee-es:9200
 


### PR DESCRIPTION
## :hash: 연관된 이슈
#381 
> ex) #이슈번호, #이슈번호, ...

## :memo: 작업 내용
```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager]: Factory method 'getAuthorizedClientManager' threw exception with message: Error creating bean with name 'clientRegistrationRepository' defined in class path resource [org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2ClientRegistrationRepositoryConfiguration.class]: Failed to instantiate [org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository]: Factory method 'clientRegistrationRepository' threw exception with message: redirectUri cannot be empty
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:199) ~[spring-beans-6.2.2.jar!/:6.2.2]
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiateWithFactoryMethod(SimpleInstantiationStrategy.java:88) ~[spring-beans-6.2.2.jar!/:6.2.2]
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:168) ~[spring-beans-6.2.2.jar!/:6.2.2]
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:653) ~[spring-beans-6.2.2.jar!/:6.2.2]
	... 111 common frames omitted
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'clientRegistrationRepository' defined in class path resource [org/springframework/boot/autoconfigure/security/oauth2/client/servlet/OAuth2ClientRegistrationRepositoryConfiguration.class]: Failed to instantiate [org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository]: Factory method 'clientRegistrationRepository' threw exception with message: redirectUri cannot be empty
```
해당 오류 해결