### PR TITLE
[REFACTOR] 관리자 신고 관리 기능 리팩토링

### DIFF
--- a/src/main/java/org/swyp/dessertbee/admin/report/controller/MateReportAdminController.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/controller/MateReportAdminController.java
@@ -69,6 +69,14 @@ public class MateReportAdminController {
         return ResponseEntity.ok().build();
     }
 
+    //신고된 게시글 작성자 작성제한 (3단계)
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/report/{mateUuid}/restrict-writing")
+    public ResponseEntity<Void> restrictMateAuthorWriting(@PathVariable UUID mateUuid) {
+        mateReportAdminService.restrictMateAuthorWriting(mateUuid);
+        return ResponseEntity.ok().build();
+    }
+
     //----------------- 댓글 ------------------
 
     // 신고된 게시글 댓글 조회 API
@@ -111,6 +119,14 @@ public class MateReportAdminController {
     @PostMapping("/replies/report/{mateReplyId}/suspend")
     public ResponseEntity<Void> suspendMateReplyAuthor(@PathVariable Long mateReplyId) {
         mateReportAdminService.suspendMateReplyAuthor(mateReplyId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 신고된 댓글 작성자 작성제한 (3단계)
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/replies/report/{mateReplyId}/restrict-writing")
+    public ResponseEntity<Void> restrictMateReplyAuthorWriting(@PathVariable Long mateReplyId) {
+        mateReportAdminService.restrictMateReplyAuthorWriting(mateReplyId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/admin/report/controller/MateReportAdminController.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/controller/MateReportAdminController.java
@@ -61,6 +61,16 @@ public class MateReportAdminController {
         return ResponseEntity.ok().build();
     }
 
+    //신고된 게시글 작성자 정지 (3단계)
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/report/{mateUuid}/suspend")
+    public ResponseEntity<Void> suspendMateAuthor(@PathVariable UUID mateUuid) {
+        mateReportAdminService.suspendMateAuthor(mateUuid);
+        return ResponseEntity.ok().build();
+    }
+
+    //----------------- 댓글 ------------------
+
     // 신고된 게시글 댓글 조회 API
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/replies/report")
@@ -96,5 +106,12 @@ public class MateReportAdminController {
         return ResponseEntity.ok().build();
     }
 
+    // 신고된 댓글 작성자 정지 (3단계)
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/replies/report/{mateReplyId}/suspend")
+    public ResponseEntity<Void> suspendMateReplyAuthor(@PathVariable Long mateReplyId) {
+        mateReportAdminService.suspendMateReplyAuthor(mateReplyId);
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/src/main/java/org/swyp/dessertbee/admin/report/controller/MateReportAdminController.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/controller/MateReportAdminController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.swyp.dessertbee.admin.report.dto.response.MateReplyReportCountResponse;
+import org.swyp.dessertbee.admin.report.dto.response.MateReportCountResponse;
 import org.swyp.dessertbee.admin.report.service.MateReportAdminService;
 import org.swyp.dessertbee.community.mate.dto.response.MateReportResponse;
 
@@ -29,14 +31,34 @@ public class MateReportAdminController {
         return ResponseEntity.ok(reports);
     }
 
-    // 게시글 삭제 API
+    //신고된 게시글의 신고 횟수 조회 API
     @PreAuthorize("hasRole('ADMIN')")
-    @DeleteMapping("/{mateUuid}/report")
+    @GetMapping("/report/{mateUuid}/count")
+    public ResponseEntity<MateReportCountResponse> getMateReportCount(@PathVariable UUID mateUuid) {
+        MateReportCountResponse response = mateReportAdminService.getMateReportCount(mateUuid);
+        return ResponseEntity.ok(response);
+    }
+
+
+    // 신고된 게시글 삭제 API (1단계)
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/report/{mateUuid}")
     public ResponseEntity<Map<String, String>> deleteMate(@PathVariable UUID mateUuid) {
         mateReportAdminService.deleteMateByUuid(mateUuid);
         Map<String, String> response = new HashMap<>();
         response.put("message", "게시글이 삭제되었습니다.");
         return ResponseEntity.ok(response);
+    }
+
+    // 신고된 Mate 게시글 사용자 경고 (2단계)
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/report/{mateUuid}/warn")
+    public ResponseEntity<Void> warnMateAuthor(
+            @PathVariable UUID mateUuid,
+            @RequestParam Long reportCategoryId
+    ) {
+        mateReportAdminService.warnMateAuthor(mateUuid, reportCategoryId);
+        return ResponseEntity.ok().build();
     }
 
     // 신고된 게시글 댓글 조회 API
@@ -47,14 +69,32 @@ public class MateReportAdminController {
         return ResponseEntity.ok(reportedReplies);
     }
 
-    // 신고된 Mate 댓글 삭제
+    //신고된 댓글의 신고 횟수 조회 API
     @PreAuthorize("hasRole('ADMIN')")
-    @DeleteMapping("/replies/{mateReplyId}/report")
+    @GetMapping("/replies/report/{mateReplyId}/count")
+    public ResponseEntity<MateReplyReportCountResponse> getMateReplyReportCount(@PathVariable Long mateReplyId) {
+        MateReplyReportCountResponse response = mateReportAdminService.getMateReplyReportCount(mateReplyId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 신고된 Mate 댓글 삭제 (1단계)
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/replies/report/{mateReplyId}")
     public ResponseEntity<String> deleteReportedMateReply(@PathVariable Long mateReplyId) {
         mateReportAdminService.deleteReportedMateReply(mateReplyId);
         return ResponseEntity.ok("신고된 댓글이 삭제되었습니다.");
     }
 
+    //신고된 Mate 댓글 작성자 경고 (2단계)
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/replies/report/{mateReplyId}/warn")
+    public ResponseEntity<Void> warnMateReplyAuthor(
+            @PathVariable Long mateReplyId,
+            @RequestParam Long reportCategoryId
+    ) {
+        mateReportAdminService.warnMateReplyAuthor(mateReplyId, reportCategoryId);
+        return ResponseEntity.ok().build();
+    }
 
 
 }

--- a/src/main/java/org/swyp/dessertbee/admin/report/controller/MateReportAdminController.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/controller/MateReportAdminController.java
@@ -7,6 +7,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.swyp.dessertbee.admin.report.dto.response.MateReplyReportCountResponse;
 import org.swyp.dessertbee.admin.report.dto.response.MateReportCountResponse;
+import org.swyp.dessertbee.admin.report.dto.response.ReportActionResponse;
 import org.swyp.dessertbee.admin.report.service.MateReportAdminService;
 import org.swyp.dessertbee.community.mate.dto.response.MateReportResponse;
 
@@ -50,34 +51,6 @@ public class MateReportAdminController {
         return ResponseEntity.ok(response);
     }
 
-    // 신고된 Mate 게시글 사용자 경고 (2단계)
-    @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping("/report/{mateUuid}/warn")
-    public ResponseEntity<Void> warnMateAuthor(
-            @PathVariable UUID mateUuid,
-            @RequestParam Long reportCategoryId
-    ) {
-        mateReportAdminService.warnMateAuthor(mateUuid, reportCategoryId);
-        return ResponseEntity.ok().build();
-    }
-
-    //신고된 게시글 작성자 정지 (3단계)
-    @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping("/report/{mateUuid}/suspend")
-    public ResponseEntity<Void> suspendMateAuthor(@PathVariable UUID mateUuid) {
-        mateReportAdminService.suspendMateAuthor(mateUuid);
-        return ResponseEntity.ok().build();
-    }
-
-    //신고된 게시글 작성자 작성제한 (3단계)
-    @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping("/report/{mateUuid}/restrict-writing")
-    public ResponseEntity<Void> restrictMateAuthorWriting(@PathVariable UUID mateUuid) {
-        mateReportAdminService.restrictMateAuthorWriting(mateUuid);
-        return ResponseEntity.ok().build();
-    }
-
-    //----------------- 댓글 ------------------
 
     // 신고된 게시글 댓글 조회 API
     @PreAuthorize("hasRole('ADMIN')")
@@ -102,32 +75,40 @@ public class MateReportAdminController {
         mateReportAdminService.deleteReportedMateReply(mateReplyId);
         return ResponseEntity.ok("신고된 댓글이 삭제되었습니다.");
     }
+    // -------------------- 신고 조치(2, 3단계) 통합 API --------------------
 
-    //신고된 Mate 댓글 작성자 경고 (2단계)
+    // 2단계 경고 (동일 유형 3회 이상)
     @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping("/replies/report/{mateReplyId}/warn")
-    public ResponseEntity<Void> warnMateReplyAuthor(
-            @PathVariable Long mateReplyId,
+    @PostMapping("/report/action/warn")
+    public ResponseEntity<ReportActionResponse> warnAuthor(
+            @RequestParam(required = false) UUID mateUuid,
+            @RequestParam(required = false) Long mateReplyId,
             @RequestParam Long reportCategoryId
     ) {
-        mateReportAdminService.warnMateReplyAuthor(mateReplyId, reportCategoryId);
-        return ResponseEntity.ok().build();
+        ReportActionResponse response = mateReportAdminService.warnAuthor(mateUuid, mateReplyId, reportCategoryId);
+        return ResponseEntity.ok(response);
     }
 
-    // 신고된 댓글 작성자 정지 (3단계)
+    // 3단계 계정 정지 (한 달)
     @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping("/replies/report/{mateReplyId}/suspend")
-    public ResponseEntity<Void> suspendMateReplyAuthor(@PathVariable Long mateReplyId) {
-        mateReportAdminService.suspendMateReplyAuthor(mateReplyId);
-        return ResponseEntity.ok().build();
+    @PostMapping("/report/action/suspend")
+    public ResponseEntity<ReportActionResponse> suspendAuthor(
+            @RequestParam(required = false) UUID mateUuid,
+            @RequestParam(required = false) Long mateReplyId
+    ) {
+        ReportActionResponse response = mateReportAdminService.suspendAuthor(mateUuid, mateReplyId);
+        return ResponseEntity.ok(response);
     }
 
-    // 신고된 댓글 작성자 작성제한 (3단계)
+    // 3단계 작성 제한 (7일)
     @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping("/replies/report/{mateReplyId}/restrict-writing")
-    public ResponseEntity<Void> restrictMateReplyAuthorWriting(@PathVariable Long mateReplyId) {
-        mateReportAdminService.restrictMateReplyAuthorWriting(mateReplyId);
-        return ResponseEntity.ok().build();
+    @PostMapping("/report/action/restrict-writing")
+    public ResponseEntity<ReportActionResponse> restrictAuthorWriting(
+            @RequestParam(required = false) UUID mateUuid,
+            @RequestParam(required = false) Long mateReplyId
+    ) {
+        ReportActionResponse response = mateReportAdminService.restrictAuthorWriting(mateUuid, mateReplyId);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/org/swyp/dessertbee/admin/report/dto/response/MateReplyReportCountResponse.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/dto/response/MateReplyReportCountResponse.java
@@ -1,0 +1,14 @@
+package org.swyp.dessertbee.admin.report.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class MateReplyReportCountResponse {
+    private Long mateReplyId;
+    private Long totalReportCount;
+    private Map<Long, Long> categoryReportCounts; // <카테고리ID, 신고수>
+}

--- a/src/main/java/org/swyp/dessertbee/admin/report/dto/response/MateReportCountResponse.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/dto/response/MateReportCountResponse.java
@@ -1,0 +1,15 @@
+package org.swyp.dessertbee.admin.report.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class MateReportCountResponse {
+    private Long mateId;
+    private Long totalReportCount;
+    private Map<Long, Long> categoryReportCounts; // <카테고리ID, 신고수>
+}
+

--- a/src/main/java/org/swyp/dessertbee/admin/report/dto/response/ReportActionResponse.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/dto/response/ReportActionResponse.java
@@ -1,0 +1,22 @@
+package org.swyp.dessertbee.admin.report.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class ReportActionResponse {
+
+    private UUID mateUuid;              // 신고된 게시글 UUID (null 가능)
+    private Long mateReplyId;           // 신고된 댓글 ID (null 가능)
+    private UUID userUuid;              // 조치 대상 사용자 UUID
+
+    private LocalDateTime actionAt;     // 조치 일시
+
+    // 아래 두 필드는 조치 유형에 따라 한쪽만 값이 들어감
+    private LocalDateTime restrictionEndAt; // 작성제한 만료일 (작성제한 시)
+    private LocalDateTime suspendedUntil;   // 정지 만료일 (정지 시)
+}

--- a/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminService.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminService.java
@@ -3,6 +3,7 @@ package org.swyp.dessertbee.admin.report.service;
 import org.springframework.transaction.annotation.Transactional;
 import org.swyp.dessertbee.admin.report.dto.response.MateReplyReportCountResponse;
 import org.swyp.dessertbee.admin.report.dto.response.MateReportCountResponse;
+import org.swyp.dessertbee.admin.report.dto.response.ReportActionResponse;
 import org.swyp.dessertbee.community.mate.dto.response.MateReportResponse;
 
 import java.util.List;
@@ -20,15 +21,6 @@ public interface MateReportAdminService {
     //Mate 게시글 삭제
     void deleteMateByUuid(UUID mateUuid);
 
-    //Mate 작성자 경고
-    void warnMateAuthor(UUID mateUuid,Long reportCategoryId);
-
-    //Mate 작성자 정지
-    void suspendMateAuthor(UUID mateUuid);
-
-    //Mate 작성자 작성제한
-    void restrictMateAuthorWriting(UUID mateUuid);
-
     //신고된 Mate 댓글 조회
     List<MateReportResponse> getReportedMateReplies();
 
@@ -38,12 +30,14 @@ public interface MateReportAdminService {
     //Mate 댓글 삭제
     void deleteReportedMateReply(Long mateReplyId);
 
-    //Mate 댓글 작성자 경고
-    void warnMateReplyAuthor(Long mateReplyId, Long reportCategoryId);
+    //사용자 경고
+    ReportActionResponse warnAuthor(UUID mateUuid, Long mateReplyId, Long reportCategoryId);
 
-    //Mate 댓글 작성자 정지
-    void suspendMateReplyAuthor(Long mateReplyId);
+    //사용자 정지
+    ReportActionResponse suspendAuthor(UUID mateUuid, Long mateReplyId);
 
-    //Mate 댓글 작성자 작성제한
-    void restrictMateReplyAuthorWriting(Long mateReplyId);
+    //사용자 작성 제한
+    ReportActionResponse restrictAuthorWriting(UUID mateUuid, Long mateReplyId);
+
+
 }

--- a/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminService.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminService.java
@@ -1,9 +1,12 @@
 package org.swyp.dessertbee.admin.report.service;
 
 import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.admin.report.dto.response.MateReplyReportCountResponse;
+import org.swyp.dessertbee.admin.report.dto.response.MateReportCountResponse;
 import org.swyp.dessertbee.community.mate.dto.response.MateReportResponse;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface MateReportAdminService {
@@ -11,12 +14,23 @@ public interface MateReportAdminService {
     // 신고된 Mate 게시글 목록 조회
     List<MateReportResponse> getReportedMates();
 
+    //Mate 신고 횟수 조회
+    MateReportCountResponse getMateReportCount(UUID mateUuid);
+
     //Mate 게시글 삭제
     void deleteMateByUuid(UUID mateUuid);
 
+    //Mate 작성자 경고
+    void warnMateAuthor(UUID mateUuid,Long reportCategoryId);
     //신고된 Mate 댓글 조회
     List<MateReportResponse> getReportedMateReplies();
 
+    //Mate 댓글 신고 횟수 조회
+    MateReplyReportCountResponse getMateReplyReportCount(Long mateReplyId);
+
     //Mate 댓글 삭제
     void deleteReportedMateReply(Long mateReplyId);
+
+    //Mate 댓글 작성자 경고
+    void warnMateReplyAuthor(Long mateReplyId, Long reportCategoryId);
 }

--- a/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminService.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminService.java
@@ -26,6 +26,9 @@ public interface MateReportAdminService {
     //Mate 작성자 정지
     void suspendMateAuthor(UUID mateUuid);
 
+    //Mate 작성자 작성제한
+    void restrictMateAuthorWriting(UUID mateUuid);
+
     //신고된 Mate 댓글 조회
     List<MateReportResponse> getReportedMateReplies();
 
@@ -40,4 +43,7 @@ public interface MateReportAdminService {
 
     //Mate 댓글 작성자 정지
     void suspendMateReplyAuthor(Long mateReplyId);
+
+    //Mate 댓글 작성자 작성제한
+    void restrictMateReplyAuthorWriting(Long mateReplyId);
 }

--- a/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminService.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminService.java
@@ -22,6 +22,10 @@ public interface MateReportAdminService {
 
     //Mate 작성자 경고
     void warnMateAuthor(UUID mateUuid,Long reportCategoryId);
+
+    //Mate 작성자 정지
+    void suspendMateAuthor(UUID mateUuid);
+
     //신고된 Mate 댓글 조회
     List<MateReportResponse> getReportedMateReplies();
 
@@ -33,4 +37,7 @@ public interface MateReportAdminService {
 
     //Mate 댓글 작성자 경고
     void warnMateReplyAuthor(Long mateReplyId, Long reportCategoryId);
+
+    //Mate 댓글 작성자 정지
+    void suspendMateReplyAuthor(Long mateReplyId);
 }

--- a/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminServiceImpl.java
@@ -1,8 +1,13 @@
 package org.swyp.dessertbee.admin.report.service;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.admin.report.dto.response.MateReplyReportCountResponse;
+import org.swyp.dessertbee.admin.report.dto.response.MateReportCountResponse;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.community.mate.dto.response.MateReportResponse;
 import org.swyp.dessertbee.community.mate.entity.Mate;
 import org.swyp.dessertbee.community.mate.entity.MateReply;
@@ -13,8 +18,13 @@ import org.swyp.dessertbee.community.mate.repository.MateReportRepository;
 import org.swyp.dessertbee.community.mate.repository.MateRepository;
 import org.swyp.dessertbee.community.mate.service.MateReplyService;
 import org.swyp.dessertbee.community.mate.service.MateService;
+import org.swyp.dessertbee.email.service.WarningMailService;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserRepository;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -25,6 +35,8 @@ public class MateReportAdminServiceImpl implements MateReportAdminService {
     private final MateRepository mateRepository;
     private final MateReportRepository mateReportRepository;
     private final MateReplyRepository mateReplyRepository;
+    private final UserRepository userRepository;
+    private final WarningMailService warningMailService;
 
     /**
      *   신고된 Mate 게시글 목록 조회
@@ -38,7 +50,35 @@ public class MateReportAdminServiceImpl implements MateReportAdminService {
 
 
     /**
-     * 신고된 Mate 게시글 삭제
+     * 신고된 Mate(게시글)의 신고 횟수(전체, 카테고리별) 조회
+     */
+    @Transactional(readOnly = true)
+    public MateReportCountResponse getMateReportCount(UUID mateUuid) {
+        Mate mate = mateRepository.findByMateUuidAndDeletedAtIsNull(mateUuid)
+                .orElseThrow(() -> new MateExceptions.MateNotFoundException("존재하지 않는 디저트메이트입니다."));
+        Long mateId = mate.getMateId();
+
+        // 전체 신고수
+        long totalCount = mateReportRepository.countByMateId(mateId);
+
+        // 카테고리별 신고수
+        List<Object[]> grouped = mateReportRepository.countByMateIdGroupByCategory(mateId);
+        Map<Long, Long> categoryCounts = new HashMap<>();
+        for (Object[] row : grouped) {
+            Long categoryId = (Long) row[0];
+            Long count = (Long) row[1];
+            categoryCounts.put(categoryId, count);
+        }
+
+        return MateReportCountResponse.builder()
+                .mateId(mateId)
+                .totalReportCount(totalCount)
+                .categoryReportCounts(categoryCounts)
+                .build();
+    }
+
+    /**
+     * 신고된 Mate 게시글 삭제 (1단계)
      */
     @Transactional
     public void deleteMateByUuid(UUID mateUuid) {
@@ -56,6 +96,29 @@ public class MateReportAdminServiceImpl implements MateReportAdminService {
         mateRepository.save(mate);
     }
 
+    /**
+     * 신고된 Mate 게시글 사용자 경고 (2단계)
+     */
+    @Transactional
+    public void warnMateAuthor(UUID mateUuid,Long reportCategoryId) {
+        Mate mate = mateRepository.findByMateUuidAndDeletedAtIsNull(mateUuid)
+                .orElseThrow(() -> new MateExceptions.MateNotFoundException("존재하지 않는 디저트메이트입니다."));
+
+        // 동일 신고 유형(카테고리) 3회 이상인지 확인
+        long count = mateReportRepository.countByMateIdAndReportCategoryId(mate.getMateId(), reportCategoryId);
+        if (count < 3) {
+            throw new MateExceptions.MateReportNotFoundException( "동일 유형 신고가 3회 미만입니다.");
+        }
+
+        //작성자 정보 조회
+        UserEntity user = userRepository.findById(mate.getUserId())
+                .orElseThrow(() -> new MateExceptions.MateReportNotFoundException("작성자 정보를 찾을 수 없습니다."));
+
+        // 경고 메일 발송
+        String reason = getReportCategoryName(reportCategoryId); // 신고 유형명 반환 메서드 구현 필요
+        warningMailService.sendWarningEmail(user.getEmail(), reason);
+    }
+
 
     /**
      *  신고된 Mate 댓글 조회
@@ -68,8 +131,33 @@ public class MateReportAdminServiceImpl implements MateReportAdminService {
                 .collect(Collectors.toList());
     }
 
+
     /**
-     * 신고된 Mate 댓글 삭제
+     * 신고된 Mate 댓글의 신고 횟수(전체, 카테고리별) 조회
+     */
+    @Transactional(readOnly = true)
+    public MateReplyReportCountResponse getMateReplyReportCount(Long mateReplyId) {
+        // 전체 신고수
+        long totalCount = mateReportRepository.countByMateReplyId(mateReplyId);
+
+        // 카테고리별 신고수
+        List<Object[]> grouped = mateReportRepository.countByMateReplyIdGroupByCategory(mateReplyId);
+        Map<Long, Long> categoryCounts = new HashMap<>();
+        for (Object[] row : grouped) {
+            Long categoryId = (Long) row[0];
+            Long count = (Long) row[1];
+            categoryCounts.put(categoryId, count);
+        }
+
+        return MateReplyReportCountResponse.builder()
+                .mateReplyId(mateReplyId)
+                .totalReportCount(totalCount)
+                .categoryReportCounts(categoryCounts)
+                .build();
+    }
+
+    /**
+     * 신고된 Mate 댓글 삭제 (1단계)
      */
     @Transactional
     public void deleteReportedMateReply(Long mateReplyId) {
@@ -83,6 +171,44 @@ public class MateReportAdminServiceImpl implements MateReportAdminService {
 
         mateReply.softDelete();
         mateReplyRepository.save(mateReply);
+    }
+
+    /**
+     * 신고된 Mate 댓글 작성자 경고 (2단계)
+     */
+    @Transactional
+    public void warnMateReplyAuthor(Long mateReplyId, Long reportCategoryId) {
+        // 동일 유형 신고 3회 이상인지 확인
+        long count = mateReportRepository.countByMateReplyIdAndReportCategoryId(mateReplyId, reportCategoryId);
+        if (count < 3) {
+            throw new MateExceptions.MateReportNotFoundException("동일 유형 신고가 3회 미만입니다.");
+        }
+
+        // 댓글 정보 조회
+        MateReply mateReply = mateReplyRepository.findByMateReplyIdAndDeletedAtIsNull(mateReplyId)
+                .orElseThrow(() -> new MateExceptions.MateReplyNotReportedException("존재하지 않는 댓글입니다."));
+
+        // 작성자 정보 조회
+        UserEntity user = userRepository.findById(mateReply.getUserId())
+                .orElseThrow(() -> new MateExceptions.MateReportNotFoundException("작성자 정보를 찾을 수 없습니다."));
+
+        // 경고 메일 발송
+        String reason = getReportCategoryName(reportCategoryId); // 신고 유형명 반환
+        warningMailService.sendWarningEmail(user.getEmail(), reason);
+    }
+
+    // 신고 유형명을 반환하는 메서드
+    private String getReportCategoryName(Long reportCategoryId) {
+        // 예시: 실제로는 DB 또는 Enum 등에서 조회
+        switch (reportCategoryId.intValue()) {
+            case 1: return "욕설 및 폭언";
+            case 2: return "음란물 또는 부적절한 내용";
+            case 3: return "광고 또는 스팸";
+            case 4: return "허위 정보";
+            case 5: return "게시물 도배";
+            case 6: return "기타";
+            default: return "기타";
+        }
     }
 }
 

--- a/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminServiceImpl.java
@@ -4,40 +4,85 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.swyp.dessertbee.community.mate.dto.response.MateReportResponse;
+import org.swyp.dessertbee.community.mate.entity.Mate;
+import org.swyp.dessertbee.community.mate.entity.MateReply;
+import org.swyp.dessertbee.community.mate.entity.MateReport;
+import org.swyp.dessertbee.community.mate.exception.MateExceptions;
+import org.swyp.dessertbee.community.mate.repository.MateReplyRepository;
+import org.swyp.dessertbee.community.mate.repository.MateReportRepository;
+import org.swyp.dessertbee.community.mate.repository.MateRepository;
 import org.swyp.dessertbee.community.mate.service.MateReplyService;
 import org.swyp.dessertbee.community.mate.service.MateService;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MateReportAdminServiceImpl implements MateReportAdminService {
 
-    private final MateService mateService;
-    private final MateReplyService mateReplyService;
+    private final MateRepository mateRepository;
+    private final MateReportRepository mateReportRepository;
+    private final MateReplyRepository mateReplyRepository;
 
-    // 신고된 Mate 게시글 목록 조회
+    /**
+     *   신고된 Mate 게시글 목록 조회
+     */
     public List<MateReportResponse> getReportedMates() {
-        return mateService.getReportedMates();
+        List<MateReport> reports = mateReportRepository.findAllByMateIdIsNotNull();
+        return reports.stream()
+                .map(MateReportResponse::new)
+                .collect(Collectors.toList());
     }
 
 
-    //Mate 게시글 삭제
+    /**
+     * 신고된 Mate 게시글 삭제
+     */
     @Transactional
     public void deleteMateByUuid(UUID mateUuid) {
-        mateService.deleteMateByUuid(mateUuid);
+        Mate mate = mateRepository.findByMateUuidAndDeletedAtIsNull(mateUuid)
+                .orElseThrow(() -> new MateExceptions.MateNotFoundException("존재하지 않는 디저트메이트입니다."));
+
+        // mateUuid가 있는 신고 데이터 확인
+        boolean isReported = mateReportRepository.existsByMateId(mate.getMateId());
+        if (!isReported) {
+            throw new MateExceptions.MateReportNotFoundException("신고되지 않은 디저트메이트입니다.");
+        }
+
+        // 게시글 삭제 (soft delete)
+        mate.softDelete();
+        mateRepository.save(mate);
     }
 
-    //신고된 Mate 댓글 조회
+
+    /**
+     *  신고된 Mate 댓글 조회
+     */
     public List<MateReportResponse> getReportedMateReplies() {
-        return mateReplyService.getReportedMateReplies();
+        List<MateReport> reports = mateReportRepository.findAllByMateReplyIdIsNotNull();
+
+        return reports.stream()
+                .map(MateReportResponse::new)
+                .collect(Collectors.toList());
     }
 
-    //Mate 댓글 삭제
+    /**
+     * 신고된 Mate 댓글 삭제
+     */
     @Transactional
     public void deleteReportedMateReply(Long mateReplyId) {
-        mateReplyService.deleteReportedMateReply(mateReplyId);
+        boolean isReported = mateReportRepository.existsByMateReplyId(mateReplyId);
+        if (!isReported) {
+            throw new MateExceptions.MateReplyNotReportedException("신고되지 않은 디저트메이트 댓글입니다.");
+        }
+
+        MateReply mateReply = mateReplyRepository.findByMateReplyIdAndDeletedAtIsNull(mateReplyId)
+                .orElseThrow(() ->  new MateExceptions.MateReplyNotReportedException("신고되지 않은 디저트메이트 댓글입니다."));
+
+        mateReply.softDelete();
+        mateReplyRepository.save(mateReply);
     }
 }
 

--- a/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/admin/report/service/MateReportAdminServiceImpl.java
@@ -119,7 +119,7 @@ public class MateReportAdminServiceImpl implements MateReportAdminService {
         warningMailService.sendWarningEmail(user.getEmail(), reason);
     }
 
-
+    //--------------------- Mate 댓글 ---------------------
     /**
      *  신고된 Mate 댓글 조회
      */

--- a/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminService.java
+++ b/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminService.java
@@ -1,8 +1,16 @@
 package org.swyp.dessertbee.admin.user.service;
 
+import org.swyp.dessertbee.email.service.WarningMailService;
+
 import java.util.UUID;
 
 public interface UserAdminService {
-
+    //계정 정지
     void suspendUserForOneMonthByUuid(UUID userUuid);
+
+    //작성 제한
+    void restrictUserWritingFor7DaysByUuid(UUID userUuid);
+
+    //사용자 경고
+    void warnUserByUuid(UUID userUuid, String reason, WarningMailService warningMailService, String email);
 }

--- a/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminService.java
+++ b/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminService.java
@@ -1,0 +1,8 @@
+package org.swyp.dessertbee.admin.user.service;
+
+import java.util.UUID;
+
+public interface UserAdminService {
+
+    void suspendUserForOneMonthByUuid(UUID userUuid);
+}

--- a/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.email.service.WarningMailService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.exception.UserExceptions;
 import org.swyp.dessertbee.user.repository.UserRepository;
@@ -30,5 +31,30 @@ public class UserAdminServiceImpl implements UserAdminService {
         }
         user.suspendForOneMonth();
         userRepository.save(user);
+    }
+
+    /**
+     * 작성 제한(7일)
+     */
+    @Transactional
+    public void restrictUserWritingFor7DaysByUuid(UUID userUuid) {
+        UserEntity user = userRepository.findByUserUuid(userUuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (user.isWriteRestricted()) {
+            throw new UserExceptions.InvalidUserStatusException("이미 작성제한 중인 계정입니다.");
+        }
+        user.restrictWritingFor7Days();
+        userRepository.save(user);
+    }
+
+    /**
+     * 경고 메일 발송
+     */
+    @Transactional
+    public void warnUserByUuid(UUID userUuid, String reason, WarningMailService warningMailService, String email) {
+        UserEntity user = userRepository.findByUserUuid(userUuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        // 경고 메일 발송
+        warningMailService.sendWarningEmail(email, reason);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminServiceImpl.java
@@ -1,0 +1,31 @@
+package org.swyp.dessertbee.admin.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.exception.UserExceptions;
+import org.swyp.dessertbee.user.repository.UserRepository;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserAdminServiceImpl implements UserAdminService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void suspendUserForOneMonthByUuid(UUID userUuid) {
+        UserEntity user = userRepository.findByUserUuid(userUuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.isSuspended()) {
+            throw new UserExceptions.InvalidUserStatusException("이미 정지된 계정입니다.");
+        }
+        user.suspendForOneMonth();
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/admin/user/service/UserAdminServiceImpl.java
@@ -17,6 +17,9 @@ public class UserAdminServiceImpl implements UserAdminService {
 
     private final UserRepository userRepository;
 
+    /**
+     * 계정 정지(한달)
+     */
     @Transactional
     public void suspendUserForOneMonthByUuid(UUID userUuid) {
         UserEntity user = userRepository.findByUserUuid(userUuid)

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -205,6 +205,11 @@ public class AuthServiceImpl implements AuthService {
             // 사용자 조회
             UserEntity user = userService.findUserByEmail(request.getEmail(), ErrorCode.INVALID_EMAIL);
 
+            // 정지 여부 확인
+            if (user.isSuspended()) {
+                throw new AccountLockedException("계정이 정지되었습니다. 정지 해제 일시: " + user.getSuspendedUntil());
+            }
+
             // 비밀번호 검증 및 실패 처리
             // 비밀번호 검증
             if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -156,6 +156,11 @@ public class KakaoOAuthService {
         UserEntity user = userRepository.findByEmail(oauth2Response.getEmail())
                 .orElseGet(() -> registerNewUser(oauth2Response));
 
+        // 정지 여부 확인
+        if (user.isSuspended()) {
+            throw new AccountLockedException("계정이 정지되었습니다. 정지 해제 일시: " + user.getSuspendedUntil());
+        }
+
         // 사용자 역할 조회
         List<String> roles = user.getUserRoles().stream()
                 .map(userRole -> userRole.getRole().getName().getRoleName())

--- a/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
@@ -188,6 +188,11 @@ public class TokenService {
             UserEntity user = userService.findByUserUuid(userUuid);
             String email = user.getEmail();
 
+            // 정지 여부 확인
+            if (user.isSuspended()) {
+                throw new AccountLockedException("계정이 정지되었습니다. 정지 해제 일시: " + user.getSuspendedUntil());
+            }
+
             // 디바이스 ID 확인
             if (deviceId == null || deviceId.isEmpty()) {
                 log.warn("리프레시 토큰 검증 실패 - 디바이스 ID 없음: {}", email);

--- a/src/main/java/org/swyp/dessertbee/common/aop/CheckWriteRestriction.java
+++ b/src/main/java/org/swyp/dessertbee/common/aop/CheckWriteRestriction.java
@@ -1,0 +1,12 @@
+package org.swyp.dessertbee.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckWriteRestriction {
+}
+

--- a/src/main/java/org/swyp/dessertbee/common/aop/WriteRestrictionAspect.java
+++ b/src/main/java/org/swyp/dessertbee/common/aop/WriteRestrictionAspect.java
@@ -1,0 +1,24 @@
+package org.swyp.dessertbee.common.aop;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.service.UserService;
+
+@Aspect
+@Component
+public class WriteRestrictionAspect {
+
+    @Autowired
+    private UserService userService; // 현재 사용자 정보를 얻기 위한 서비스
+
+    @Before("@annotation(CheckWriteRestriction)")
+    public void checkWriteRestriction() {
+        UserEntity user = userService.getCurrentUser();
+        if (user.isWriteRestricted()) {
+            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -168,6 +168,8 @@ public enum ErrorCode {
     MATE_REPLY_NOT_REPORTED(HttpStatus.NOT_FOUND, "M019" , "신고되지 않은 디저트메이트 댓글입니다." ),
     MATE_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "M020", "최대 수용 인원 초과입니다." ),
     INVALID_REPLY_DEPTH( HttpStatus.BAD_REQUEST, "M021", "대댓글에는 댓글을 달 수 없습니다."),
+    NOT_ENOUGH_REPORT_COUNT(HttpStatus.BAD_REQUEST, "M022", "동일 유형 신고가 3회 미만입니다."),
+    REPORT_TARGET_NOT_SPECIFIED(HttpStatus.BAD_REQUEST, "M023", "신고 대상이 지정되지 않았습니다."),
 
     //커뮤니티 리뷰
     COMMUNITY_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001" , "존재하지 않는 리뷰입니다." ),

--- a/src/main/java/org/swyp/dessertbee/community/mate/repository/MateReportRepository.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/repository/MateReportRepository.java
@@ -1,6 +1,8 @@
 package org.swyp.dessertbee.community.mate.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.community.mate.entity.MateReport;
 
@@ -20,5 +22,26 @@ public interface MateReportRepository extends JpaRepository<MateReport, Long> {
     List<MateReport> findAllByMateReplyIdIsNotNull();
 
     boolean existsByMateReplyId(Long mateReplyId);
+
+    // 특정 게시글의 전체 신고 횟수
+    long countByMateId(Long mateId);
+
+    // 특정 게시글의 카테고리별 신고 횟수
+    long countByMateIdAndReportCategoryId(Long mateId, Long reportCategoryId);
+
+    // 특정 게시글의 카테고리별 신고 횟수 일괄 집계 (카테고리별로 그룹핑)
+    @Query("SELECT mr.reportCategoryId, COUNT(mr) FROM MateReport mr WHERE mr.mateId = :mateId GROUP BY mr.reportCategoryId")
+    List<Object[]> countByMateIdGroupByCategory(@Param("mateId") Long mateId);
+
+    // 특정 댓글의 전체 신고수
+    long countByMateReplyId(Long mateReplyId);
+
+    // 댓글에 대한 동일 유형 신고수 카운트
+    long countByMateReplyIdAndReportCategoryId(Long mateReplyId, Long reportCategoryId);
+
+    // 특정 댓글의 카테고리별 신고수 집계
+    @Query("SELECT mr.reportCategoryId, COUNT(mr) FROM MateReport mr WHERE mr.mateReplyId = :mateReplyId GROUP BY mr.reportCategoryId")
+    List<Object[]> countByMateReplyIdGroupByCategory(@Param("mateReplyId") Long mateReplyId);
+
 }
 

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyService.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyService.java
@@ -13,36 +13,46 @@ import java.util.UUID;
 
 public interface MateReplyService {
 
-    /** 디저트메이트 댓글 생성 */
+    /**
+     * 디저트메이트 댓글 생성
+     */
     MateReplyResponse createReply(UUID mateUuid, MateReplyCreateRequest request);
 
     MateReplyResponse createAppReply(UUID mateUuid, MateAppReplyCreateRequest request);
-    /** 디저트메이트 댓글 조회(한개만) */
+
+    /**
+     * 디저트메이트 댓글 조회(한개만)
+     */
     MateReplyResponse getReplyDetail(UUID mateUuid, Long replyId);
 
-    /** 디저트메이트 댓글 조회(한개만)(앱) */
+    /**
+     * 디저트메이트 댓글 조회(한개만)(앱)
+     */
     MateAppReplyResponse getAppReplyDetail(UUID mateUuid, Long replyId);
-    /** 디저트메이트 댓글 전체 조회 */
+
+    /**
+     * 디저트메이트 댓글 전체 조회
+     */
     MateReplyPageResponse getReplies(UUID mateUuid, Pageable pageable);
 
-    /** 디저트메이트 댓글 전체 조회(앱)*/
+    /**
+     * 디저트메이트 댓글 전체 조회(앱)
+     */
     MateAppReplyPageResponse getAppReplies(UUID mateUuid, Pageable pageable);
 
-    /** 디저트메이트 댓글 수정 */
+    /**
+     * 디저트메이트 댓글 수정
+     */
     void updateReply(UUID mateUuid, Long replyId, MateReplyCreateRequest request);
 
-    /** 디저트메이트 댓글 삭제 */
+    /**
+     * 디저트메이트 댓글 삭제
+     */
     void deleteReply(UUID mateUuid, Long replyId);
 
-    /** 디저트메이트 댓글 신고 */
+    /**
+     * 디저트메이트 댓글 신고
+     */
     void reportMateReply(UUID mateUuid, Long replyId, MateReportRequest request);
 
-
-    //     -------------- 관리자용 메이트 댓글 신고 관리 기능 ------------
-
-    /**  신고된 Mate 댓글 조회*/
-    List<MateReportResponse> getReportedMateReplies();
-
-    /** 신고된 Mate 댓글 삭제*/
-    void deleteReportedMateReply(Long mateReplyId);
 }

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyServiceImpl.java
@@ -55,6 +55,12 @@ public class MateReplyServiceImpl implements MateReplyService {
     @Transactional
     public MateReplyResponse createReply(UUID mateUuid, MateReplyCreateRequest request) {
 
+        UserEntity user = userService.getCurrentUser();
+
+        // 작성 제한 체크
+        if (user.isWriteRestricted()) {
+            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
+        }
 
         //디저트 메이트 유효성 검사
         MateUserIds mateUserIds = validateMateAndUser(mateUuid, request.getUserUuid());
@@ -82,6 +88,13 @@ public class MateReplyServiceImpl implements MateReplyService {
     @Override
     @Transactional
     public MateReplyResponse createAppReply(UUID mateUuid, MateAppReplyCreateRequest request){
+
+        UserEntity user = userService.getCurrentUser();
+
+        // 작성 제한 체크
+        if (user.isWriteRestricted()) {
+            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
+        }
 
         //디저트 메이트 유효성 검사
         MateUserIds mateUserIds = validateMateAndUser(mateUuid, request.getUserUuid());

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyServiceImpl.java
@@ -369,35 +369,4 @@ public class MateReplyServiceImpl implements MateReplyService {
         return new MateUserIds(mate.getMateId(), null);
     }
 
-
-//     -------------- 관리자용 메이트 댓글 신고 관리 기능 ------------
-
-
-    /**
-     *  신고된 Mate 댓글 조회
-     */
-    public List<MateReportResponse> getReportedMateReplies() {
-        List<MateReport> reports = mateReportRepository.findAllByMateReplyIdIsNotNull();
-
-        return reports.stream()
-                .map(MateReportResponse::new)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * 신고된 Mate 댓글 삭제
-     */
-    @Transactional
-    public void deleteReportedMateReply(Long mateReplyId) {
-        boolean isReported = mateReportRepository.existsByMateReplyId(mateReplyId);
-        if (!isReported) {
-            throw new MateReplyNotReportedException("신고되지 않은 디저트메이트 댓글입니다.");
-        }
-
-        MateReply mateReply = mateReplyRepository.findByMateReplyIdAndDeletedAtIsNull(mateReplyId)
-                .orElseThrow(() ->  new MateReplyNotReportedException("신고되지 않은 디저트메이트 댓글입니다."));
-
-        mateReply.softDelete();
-        mateReplyRepository.save(mateReply);
-    }
 }

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateReplyServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.common.aop.CheckWriteRestriction;
 import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.entity.ReportCategory;
 import org.swyp.dessertbee.common.exception.BusinessException;
@@ -50,14 +51,9 @@ public class MateReplyServiceImpl implements MateReplyService {
      * */
     @Override
     @Transactional
+    @CheckWriteRestriction
     public MateReplyResponse createReply(UUID mateUuid, MateReplyCreateRequest request) {
 
-        UserEntity user = userService.getCurrentUser();
-
-        // 작성 제한 체크
-        if (user.isWriteRestricted()) {
-            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
-        }
 
         //디저트 메이트 유효성 검사
         MateUserIds mateUserIds = validateMateAndUser(mateUuid, request.getUserUuid());
@@ -84,14 +80,9 @@ public class MateReplyServiceImpl implements MateReplyService {
      * */
     @Override
     @Transactional
+    @CheckWriteRestriction
     public MateReplyResponse createAppReply(UUID mateUuid, MateAppReplyCreateRequest request){
 
-        UserEntity user = userService.getCurrentUser();
-
-        // 작성 제한 체크
-        if (user.isWriteRestricted()) {
-            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
-        }
 
         //디저트 메이트 유효성 검사
         MateUserIds mateUserIds = validateMateAndUser(mateUuid, request.getUserUuid());

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateService.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateService.java
@@ -14,35 +14,43 @@ import java.util.UUID;
 
 public interface MateService {
 
-    /** 메이트 등록 */
+    /**
+     * 메이트 등록
+     */
     MateDetailResponse createMate(MateCreateRequest request, MultipartFile mateImage);
 
-    /** 메이트 등록(앱)*/
+    /**
+     * 메이트 등록(앱)
+     */
     MateDetailResponse createAppMate(MateCreateRequest request, MultipartFile mateImage);
 
-    /** 메이트 상세 정보 */
+    /**
+     * 메이트 상세 정보
+     */
     MateDetailResponse getMateDetail(UUID mateUuid);
 
-    /** 메이트 삭제 */
+    /**
+     * 메이트 삭제
+     */
     void deleteMate(UUID mateUuid);
 
-    /** 메이트 수정 */
+    /**
+     * 메이트 수정
+     */
     void updateMate(UUID mateUuid, MateCreateRequest request, MultipartFile mateImage);
 
-    /** 디저트메이트 전체 조회 */
+    /**
+     * 디저트메이트 전체 조회
+     */
     MatesPageResponse getMates(Pageable pageable, String keyword, Long mateCategoryId, Boolean recruitYn);
 
-    /** 내가 참여한 디저트메이트 조회 */
+    /**
+     * 내가 참여한 디저트메이트 조회
+     */
     MatesPageResponse getMyMates(Pageable pageable);
 
-    /** 디저트메이트 신고*/
+    /**
+     * 디저트메이트 신고
+     */
     void reportMate(UUID mateUuid, MateReportRequest request);
-
-//    -------------- 관리자용 메이트 신고 관리 기능 ------------
-
-    /** 신고된 Mate 게시글 목록 조회 */
-    List<MateReportResponse> getReportedMates();
-
-    /** 신고된 Mate 삭제 */
-    void deleteMateByUuid(UUID mateUuid);
 }

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.common.aop.CheckWriteRestriction;
 import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.entity.ReportCategory;
 import org.swyp.dessertbee.common.exception.BusinessException;
@@ -54,14 +55,11 @@ public class MateServiceImpl implements MateService {
     /** 메이트 등록 */
     @Override
     @Transactional
+    @CheckWriteRestriction
     public MateDetailResponse createMate(MateCreateRequest request, MultipartFile mateImage){
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
         UserEntity user = userService.getCurrentUser();
 
-        // 작성 제한 체크
-        if (user.isWriteRestricted()) {
-            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
-        }
 
         if(request.getCapacity() > 5){
             throw new MateCapacityExceededException("최대 수용 인원 초과입니다.");
@@ -118,14 +116,10 @@ public class MateServiceImpl implements MateService {
     }
 
     @Override
+    @CheckWriteRestriction
     public MateDetailResponse createAppMate(MateCreateRequest request, MultipartFile mateImage) {
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
         UserEntity user = userService.getCurrentUser();
-
-        // 작성 제한 체크
-        if (user.isWriteRestricted()) {
-            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
-        }
 
 
         if(request.getCapacity() > 5){

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
@@ -378,36 +378,4 @@ public class MateServiceImpl implements MateService {
 
     }
 
-//    -------------- 관리자용 메이트 신고 관리 기능 ------------
-
-    /**
-     *   신고된 Mate 게시글 목록 조회
-     */
-    public List<MateReportResponse> getReportedMates() {
-        List<MateReport> reports = mateReportRepository.findAllByMateIdIsNotNull();
-        return reports.stream()
-                .map(MateReportResponse::new)
-                .collect(Collectors.toList());
-    }
-
-
-    /**
-     * 신고된 Mate 게시글 삭제
-     */
-    @Transactional
-    public void deleteMateByUuid(UUID mateUuid) {
-        Mate mate = mateRepository.findByMateUuidAndDeletedAtIsNull(mateUuid)
-                .orElseThrow(() -> new MateNotFoundException("존재하지 않는 디저트메이트입니다."));
-
-        // mateUuid가 있는 신고 데이터 확인
-        boolean isReported = mateReportRepository.existsByMateId(mate.getMateId());
-        if (!isReported) {
-            throw new MateReportNotFoundException("신고되지 않은 디저트메이트입니다.");
-        }
-
-        // 게시글 삭제 (soft delete)
-        mate.softDelete();
-        mateRepository.save(mate);
-    }
-
 }

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/MateServiceImpl.java
@@ -59,6 +59,11 @@ public class MateServiceImpl implements MateService {
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
         UserEntity user = userService.getCurrentUser();
 
+        // 작성 제한 체크
+        if (user.isWriteRestricted()) {
+            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
+        }
+
         if(request.getCapacity() > 5){
             throw new MateCapacityExceededException("최대 수용 인원 초과입니다.");
         }
@@ -117,6 +122,12 @@ public class MateServiceImpl implements MateService {
     public MateDetailResponse createAppMate(MateCreateRequest request, MultipartFile mateImage) {
         // getCurrentUser() 내부에서 SecurityContext를 통해 현재 사용자 정보를 가져옴
         UserEntity user = userService.getCurrentUser();
+
+        // 작성 제한 체크
+        if (user.isWriteRestricted()) {
+            throw new IllegalStateException("작성 제한 기간입니다. 제한 해제 일시: " + user.getWriteRestrictedUntil());
+        }
+
 
         if(request.getCapacity() > 5){
             throw new MateCapacityExceededException("최대 수용 인원 초과입니다.");

--- a/src/main/java/org/swyp/dessertbee/email/service/WarningMailService.java
+++ b/src/main/java/org/swyp/dessertbee/email/service/WarningMailService.java
@@ -1,0 +1,5 @@
+package org.swyp.dessertbee.email.service;
+
+public interface WarningMailService {
+    void sendWarningEmail(String toEmail, String reason);
+}

--- a/src/main/java/org/swyp/dessertbee/email/service/WarningMailServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/email/service/WarningMailServiceImpl.java
@@ -1,0 +1,61 @@
+package org.swyp.dessertbee.email.service;
+
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WarningMailServiceImpl implements WarningMailService {
+
+    private final JavaMailSender emailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+    private final String serviceName = "DesserBee";
+    private final String senderName = "DesserBee 고객센터";
+
+    /**
+     * 경고 메일 발송
+     * @param toEmail 수신자 이메일
+     * @param reason 경고 사유
+     */
+    public void sendWarningEmail(String toEmail, String reason) {
+        try {
+            MimeMessage message = emailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(new InternetAddress(fromEmail, senderName));
+            helper.setTo(toEmail);
+            helper.setSubject(serviceName + " 경고 안내");
+
+            // Thymeleaf 템플릿 변수 설정
+            Context context = new Context();
+            context.setVariable("serviceName", serviceName);
+            context.setVariable("reason", reason);
+
+            // warning-email.html 템플릿 사용
+            String htmlContent = templateEngine.process("warning-email", context);
+            helper.setText(htmlContent, true);
+
+            emailSender.send(message);
+            log.debug("Warning email sent to: {}", toEmail);
+
+        } catch (Exception e) {
+            log.error("경고 이메일 발송 실패 - 이메일: {}", toEmail, e);
+            // 필요에 따라 커스텀 예외 처리
+            throw new BusinessException(ErrorCode.EMAIL_SENDING_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -74,6 +74,9 @@ public class UserEntity {
     @Column(name = "suspended_until")
     private LocalDateTime suspendedUntil; // 정지 만료일
 
+    @Column(name = "write_restricted_until")
+    private LocalDateTime writeRestrictedUntil; //작성제한 만료일
+
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<UserRoleEntity> userRoles = new HashSet<>();
@@ -181,4 +184,15 @@ public class UserEntity {
     public boolean isSuspended() {
         return suspendedUntil != null && LocalDateTime.now().isBefore(suspendedUntil);
     }
+
+    // 작성 제한 처리
+    public void restrictWritingFor7Days() {
+        this.writeRestrictedUntil = LocalDateTime.now().plusDays(7);
+    }
+
+    //작성 제한 여부
+    public boolean isWriteRestricted() {
+        return writeRestrictedUntil != null && LocalDateTime.now().isBefore(writeRestrictedUntil);
+    }
+
 }

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -71,6 +71,9 @@ public class UserEntity {
     @Column(name = "gender", length = 6)
     private Gender gender;
 
+    @Column(name = "suspended_until")
+    private LocalDateTime suspendedUntil; // 정지 만료일
+
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<UserRoleEntity> userRoles = new HashSet<>();
@@ -163,5 +166,19 @@ public class UserEntity {
     public void removeRole(UserRoleEntity userRole) {
         this.userRoles.remove(userRole);
         userRole.clearUser();
+    }
+
+    // 정지 처리
+    public void suspendForOneMonth() {
+        this.suspendedUntil = LocalDateTime.now().plusMonths(1);
+    }
+
+    public void unsuspend() {
+        this.suspendedUntil = null;
+    }
+
+    // 정지 여부
+    public boolean isSuspended() {
+        return suspendedUntil != null && LocalDateTime.now().isBefore(suspendedUntil);
     }
 }

--- a/src/main/resources/templates/mail/warning-email.html
+++ b/src/main/resources/templates/mail/warning-email.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${serviceName} + ' 경고 조치 안내'">DessertBee 경고 조치 안내</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+<!-- 전체 컨테이너 -->
+<div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+    <!-- 헤더 영역 -->
+    <div style="background-color: #FFD700; padding: 20px; text-align: center; border-radius: 10px;">
+        <h1 style="color: #333333; margin: 0;" th:text="${serviceName}">DessertBee</h1>
+    </div>
+
+    <!-- 본문 영역 -->
+    <div style="background-color: #ffffff; padding: 20px; margin-top: 20px; border: 1px solid #dee2e6; border-radius: 10px;">
+        <h2 style="color: #d9534f;">경고 안내</h2>
+        <p>
+            안녕하세요. <span th:text="${serviceName}">DessertBee</span>입니다.
+        </p>
+        <p>
+            아래와 같은 사유로 경고 조치가 이루어졌음을 안내드립니다.
+        </p>
+
+        <!-- 경고 사유 영역 -->
+        <div style="background-color: #FFF8DC; padding: 15px; text-align: center; margin: 20px 0; border-radius: 5px; border: 1px solid #FFD700;">
+            <span style="font-size: 18px; font-weight: bold; color: #d9534f;"
+                  th:text="${reason}">여기에 경고 사유가 들어갑니다.</span>
+        </div>
+
+        <p style="color: #666666; font-size: 14px;">
+            서비스 이용에 참고해 주시기 바라며, 동일 사유가 반복될 경우 계정 정지 등의 추가 조치가 있을 수 있습니다.<br>
+            문의사항이 있으실 경우 고객센터로 연락해 주세요.
+        </p>
+    </div>
+
+    <!-- 푸터 영역 -->
+    <div style="margin-top: 20px; text-align: center; color: #999999; font-size: 12px;">
+        <p>본 메일은 발신전용입니다. 문의사항은 고객센터를 이용해주세요.</p>
+        <p>&copy; 2025 <span th:text="${serviceName}">DessertBee</span>. All rights reserved.</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## :hash: 연관된 이슈

> ex) 322

## :memo: 작업 내용
신고 처리 가이드 라인에 따른 구현
> 신고 처리 1단계 -  Mate 삭제, MateReply 삭제
> 신고 처리 2단계 - 작성자에게 경고 메일 발송
> 신고 처리 3단계(1) - 작성자 계정 정지 한달
> 신고 처리 3단계(2) - 작성 제한 7일
------
고민되는 점
신고된 Mate(댓글)에 대해서만 작성자에게 조치를 취해야할지.. 현재는 제한이 없는 상태.
1. 문제가 없는 Mate를 작성한 사용자에게 실수로 제한 할 수 있음
2. 수동 조치 프로세스이기 때문에 신고가 안되었더라도 중대한 문제라면 조치를 취해야하는 상황이 생길 수 있음
