### PR TITLE
[FIX] 가게 수정 API 버그 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/service/ImageService.java
+++ b/src/main/java/org/swyp/dessertbee/common/service/ImageService.java
@@ -11,6 +11,7 @@ import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.common.repository.ImageRepository;
 import org.springframework.mock.web.MockMultipartFile;
+import org.swyp.dessertbee.store.store.dto.response.StoreImageResponse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -114,6 +115,29 @@ public class ImageService {
             return images.stream()
                     .map(Image::getUrl)
                     .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("이미지 조회 중 오류 발생 - refType: {}, refId: {}", refType, refId, e);
+            throw new BusinessException(ErrorCode.IMAGE_FETCH_ERROR);
+        }
+    }
+
+    /**
+     * 특정 refType과 refId에 해당하는 이미지 조회 (ID + URL 반환)
+     */
+    public List<StoreImageResponse> getStoreImagesWithIdByTypeAndId(ImageType refType, Long refId) {
+        if (refType == null || refId == null) {
+            log.error("이미지 조회 실패 - 유효하지 않은 참조 정보: refType: {}, refId: {}", refType, refId);
+            throw new BusinessException(ErrorCode.IMAGE_REFERENCE_INVALID);
+        }
+
+        try {
+            List<Image> images = imageRepository.findByRefTypeAndRefId(refType, refId);
+            log.info("조회된 이미지 개수: {}, refType: {}, refId: {}", images.size(), refType, refId);
+
+            return images.stream()
+                    .map(image -> new StoreImageResponse(image.getId(), image.getUrl()))
+                    .collect(Collectors.toList());
+
         } catch (Exception e) {
             log.error("이미지 조회 중 오류 발생 - refType: {}, refId: {}", refType, refId, e);
             throw new BusinessException(ErrorCode.IMAGE_FETCH_ERROR);

--- a/src/main/java/org/swyp/dessertbee/store/schedule/service/StoreScheduleServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/schedule/service/StoreScheduleServiceImpl.java
@@ -148,6 +148,10 @@ public class StoreScheduleServiceImpl implements StoreScheduleService {
      */
     @Override
     public List<StoreHoliday> saveHolidays(List<BaseStoreRequest.HolidayRequest> requests, Long storeId) {
+        // 기존 휴무일 모두 삭제
+        storeHolidayRepository.deleteByStoreId(storeId);
+
+        // 새로 저장할 휴무일이 없으면 빈 리스트 반환
         if (requests == null || requests.isEmpty()) {
             return Collections.emptyList();
         }
@@ -185,6 +189,6 @@ public class StoreScheduleServiceImpl implements StoreScheduleService {
             }
         }
 
-        return holidays;
+        return storeHolidayRepository.saveAll(holidays);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/request/BaseStoreRequest.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/request/BaseStoreRequest.java
@@ -154,8 +154,8 @@ public abstract class BaseStoreRequest {
     public static class HolidayRequest {
 
         @Schema(
-                description = "휴무일 입력 (예: '2025.02.10-14' 또는 '2025.02.10')",
-                example = "2025.02.10-14"
+                description = "휴무일 입력 (예: '2025.02.10-2025.02.14 또는 2025.02.14')",
+                example = "2025.02.10-2025.02.14"
         )
         private String date; // 입력값을 파싱해서 LocalDate로 변환
 

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreDetailResponse.java
@@ -97,10 +97,10 @@ public class StoreDetailResponse {
     private List<MenuResponse> menus;
 
     @Schema(description = "가게 대표 이미지 URL 리스트", nullable = true)
-    private List<String> storeImages;
+    private List<StoreImageResponse> storeImages;
 
     @Schema(description = "업주가 직접 고른 추가 이미지 URL 리스트", nullable = true)
-    private List<String> ownerPickImages;
+    private List<StoreImageResponse> ownerPickImages;
 
     @Schema(description = "가게 대표 링크", example = "https://instagram.com/dessertbee", nullable = true)
     private String primaryStoreLink;
@@ -169,8 +169,8 @@ public class StoreDetailResponse {
                                                  List<HolidayResponse> holidays,
                                                  List<StoreNoticeResponse> notices,
                                                  List<MenuResponse> menus,
-                                                 List<String> storeImages,
-                                                 List<String> ownerPickImages,
+                                                 List<StoreImageResponse> storeImages,
+                                                 List<StoreImageResponse> ownerPickImages,
                                                  List<TopPreferenceTagResponse> topPreferences,
                                                  List<StoreReviewResponse> storeReviews,
                                                  List<StoreTagResponse> tags,

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreImageResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreImageResponse.java
@@ -1,0 +1,19 @@
+package org.swyp.dessertbee.store.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StoreImageResponse {
+
+    @Schema(description = "이미지 ID", example = "123")
+    private Long id;
+
+    @Schema(description = "이미지 URL", example = "image.jpg")
+    private String url;
+}
+

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreInfoResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreInfoResponse.java
@@ -81,10 +81,10 @@ public class StoreInfoResponse {
     private List<MenuResponse> menus;
 
     @Schema(description = "가게 대표 이미지 URL 리스트", nullable = true)
-    private List<String> storeImages;
+    private List<StoreImageResponse> storeImages;
 
     @Schema(description = "업주가 직접 고른 추가 이미지 URL 리스트", nullable = true)
-    private List<String> ownerPickImages;
+    private List<StoreImageResponse> ownerPickImages;
 
     @Schema(description = "가게 대표 링크", example = "https://instagram.com/dessertbee", nullable = true)
     private String primaryStoreLink;
@@ -130,8 +130,8 @@ public class StoreInfoResponse {
                                                List<HolidayResponse> holidays,
                                                StoreNoticeResponse notice,
                                                List<MenuResponse> menus,
-                                               List<String> storeImages,
-                                               List<String> ownerPickImages,
+                                               List<StoreImageResponse> storeImages,
+                                               List<StoreImageResponse> ownerPickImages,
                                                List<StoreTagResponse> tags,
                                                List<String> storeLinks,
                                                String primaryStoreLink) {

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSummaryResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/response/StoreSummaryResponse.java
@@ -38,10 +38,10 @@ public class StoreSummaryResponse {
     private BigDecimal averageRating;
 
     @Schema(description = "매장 대표 이미지 URL 리스트", nullable = true)
-    private List<String> storeImages;
+    private List<StoreImageResponse> storeImages;
 
     @Schema(description = "업주가 직접 고른 추가 이미지 URL 리스트", nullable = true)
-    private List<String> ownerPickImages;
+    private List<StoreImageResponse> ownerPickImages;
 
     @NotNull
     @Schema(description = "태그 리스트", example = "[\"케이크\", \"구움과자\"]")
@@ -88,8 +88,8 @@ public class StoreSummaryResponse {
                                                   String primaryStoreLink,
                                                   List<OperatingHourResponse> operatingHours,
                                                   List<HolidayResponse> holidays,
-                                                  List<String> storeImages,
-                                                  List<String> ownerPickImages,
+                                                  List<StoreImageResponse> storeImages,
+                                                  List<StoreImageResponse> ownerPickImages,
                                                   List<TopPreferenceTagResponse> topPreferences) {
         return StoreSummaryResponse.builder()
                 .storeId(store.getStoreId())

--- a/src/main/java/org/swyp/dessertbee/store/store/handler/StoreImageHandler.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/handler/StoreImageHandler.java
@@ -1,6 +1,7 @@
 package org.swyp.dessertbee.store.store.handler;
 
 import org.springframework.web.multipart.MultipartFile;
+import org.swyp.dessertbee.store.store.dto.response.StoreImageResponse;
 import org.swyp.dessertbee.store.store.entity.Store;
 
 import java.util.List;
@@ -13,9 +14,9 @@ public interface StoreImageHandler {
     /**
      * 가게 대표 이미지 조회 메서드
      */
-    List<String> getStoreImages(Long storeId);
+    List<StoreImageResponse> getStoreImages(Long storeId);
     /**
      * 사장님 픽 이미지 조회 메서드
      */
-    List<String> getOwnerPickImages(Long storeId);
+    List<StoreImageResponse> getOwnerPickImages(Long storeId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/handler/StoreImageHandlerImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/handler/StoreImageHandlerImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.service.ImageService;
+import org.swyp.dessertbee.store.store.dto.response.StoreImageResponse;
 import org.swyp.dessertbee.store.store.entity.Store;
 
 import java.util.List;
@@ -57,15 +58,15 @@ public class StoreImageHandlerImpl implements StoreImageHandler {
      * 가게 대표 이미지 조회 메서드
      */
     @Override
-    public List<String> getStoreImages(Long storeId) {
-        return imageService.getImagesByTypeAndId(ImageType.STORE, storeId);
+    public List<StoreImageResponse> getStoreImages(Long storeId) {
+        return imageService.getStoreImagesWithIdByTypeAndId(ImageType.STORE, storeId);
     }
 
     /**
      * 사장님 픽 이미지 조회 메서드
      */
     @Override
-    public List<String> getOwnerPickImages(Long storeId) {
-        return imageService.getImagesByTypeAndId(ImageType.OWNERPICK, storeId);
+    public List<StoreImageResponse> getOwnerPickImages(Long storeId) {
+        return imageService.getStoreImagesWithIdByTypeAndId(ImageType.OWNERPICK, storeId);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreManageServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreManageServiceImpl.java
@@ -134,8 +134,7 @@ public class StoreManageServiceImpl implements StoreManageService{
             storeScheduleService.saveOrUpdateOperatingHours(store, request.getOperatingHours());
 
             // 휴무일 저장
-            List<StoreHoliday> holidays = storeScheduleService.saveHolidays(request.getHolidays(), store.getStoreId());
-            storeHolidayRepository.saveAll(holidays);
+            storeScheduleService.saveHolidays(request.getHolidays(), store.getStoreId());
 
             //storeSearchService.indexStore(store.getStoreId());
         } catch (StoreExceptions.StoreCreationFailedException e) {

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreManageServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreManageServiceImpl.java
@@ -31,6 +31,7 @@ import org.swyp.dessertbee.store.store.dto.request.StoreCreateRequest;
 import org.swyp.dessertbee.store.store.dto.request.StoreUpdateRequest;
 import org.swyp.dessertbee.store.schedule.dto.HolidayResponse;
 import org.swyp.dessertbee.store.schedule.dto.OperatingHourResponse;
+import org.swyp.dessertbee.store.store.dto.response.StoreImageResponse;
 import org.swyp.dessertbee.store.store.dto.response.StoreInfoResponse;
 import org.swyp.dessertbee.store.store.handler.StoreImageHandler;
 import org.swyp.dessertbee.store.store.handler.StoreMenuHandler;
@@ -221,8 +222,8 @@ public class StoreManageServiceImpl implements StoreManageService{
                     .orElseThrow(() -> new StoreExceptions.StoreNotFoundException());
 
             // 가게 이미지 조회
-            List<String> storeImages = imageService.getImagesByTypeAndId(ImageType.STORE, storeId);
-            List<String> ownerPickImages = imageService.getImagesByTypeAndId(ImageType.OWNERPICK, storeId);
+            List<StoreImageResponse> storeImages = storeImageHandler.getStoreImages(storeId);
+            List<StoreImageResponse> ownerPickImages = storeImageHandler.getOwnerPickImages(storeId);
 
             // 태그 조회
             List<StoreTagResponse> tags = storeTagRelationRepository.findTagsByStoreId(storeId)

--- a/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/service/StoreServiceImpl.java
@@ -188,8 +188,8 @@ public class StoreServiceImpl implements StoreService {
 
             return stores.stream()
                     .map(store -> {
-                        List<String> storeImages = storeImageHandler.getStoreImages(store.getStoreId());
-                        String thumbnail = storeImages.isEmpty() ? null : storeImages.get(0);
+                        List<StoreImageResponse> storeImages = storeImageHandler.getStoreImages(store.getStoreId());
+                        String thumbnail = storeImages.isEmpty() ? null : storeImages.get(0).getUrl();
 
                         return StoreSearchResponse.builder()
                                 .storeId(store.getStoreId())
@@ -273,8 +273,8 @@ public class StoreServiceImpl implements StoreService {
             Store store = storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)
                     .orElseThrow(() -> new StoreNotFoundException());
 
-            List<String> storeImages = storeImageHandler.getStoreImages(storeId);
-            List<String> ownerPickImages = storeImageHandler.getOwnerPickImages(storeId);
+            List<StoreImageResponse> storeImages = storeImageHandler.getStoreImages(storeId);
+            List<StoreImageResponse> ownerPickImages = storeImageHandler.getOwnerPickImages(storeId);
             List<String> tags = storeTagService.getTagNames(storeId);
 
             // 가게 링크 및 대표 링크 조회
@@ -328,8 +328,8 @@ public class StoreServiceImpl implements StoreService {
             Long savedListId = savedInfo.getRight();
 
             // 가게 이미지 조회
-            List<String> storeImages = storeImageHandler.getStoreImages(storeId);
-            List<String> ownerPickImages = storeImageHandler.getOwnerPickImages(storeId);
+            List<StoreImageResponse> storeImages = storeImageHandler.getStoreImages(storeId);
+            List<StoreImageResponse> ownerPickImages = storeImageHandler.getOwnerPickImages(storeId);
 
             // 태그 조회
             List<StoreTagResponse> tags = storeTagService.getTagResponses(storeId);


### PR DESCRIPTION
## :hash: 연관된 이슈

> #384 

## :memo: 작업 내용

> 이후 삭제를 위해 storeImage, ownerPickImage 응답값을 이미지 고유 id필드를 포함한 StoreImageResponse형식으로 보냄
> 가게 수정 시 기존 휴무일 삭제 후 새롭게 휴무일 저장하는 로직 추가