### PR TITLE
[FIX] 내 디저트메이트 조회 버그 및 탈퇴한 유저 목록 조회 버그 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/community/mate/dto/response/MateAppReplyResponse.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/dto/response/MateAppReplyResponse.java
@@ -44,7 +44,7 @@ public class MateAppReplyResponse {
     private String content;
 
     @NotBlank
-    @Schema(description = "댓글 작성자 프로필 이미지", example = " mateImage=: https://desserbee-bucket.s3.ap-northeast-2.amazonaws.com/profile/75/7edd7706-0bfa-46cf-a6c2-ad67f8a9a440-IMG_8828.jpeg")
+    @Schema(description = "댓글 작성자 프로필 이미지", example = " profileImage=: https://desserbee-bucket.s3.ap-northeast-2.amazonaws.com/profile/75/7edd7706-0bfa-46cf-a6c2-ad67f8a9a440-IMG_8828.jpeg")
     private String profileImage;
 
     @NotBlank

--- a/src/main/java/org/swyp/dessertbee/community/mate/repository/MateMemberRepository.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/repository/MateMemberRepository.java
@@ -1,5 +1,7 @@
 package org.swyp.dessertbee.community.mate.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -19,7 +21,7 @@ public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
     @Query("SELECT u FROM UserEntity u " +
             "JOIN MateMember m ON u.id = m.userId " +
             "WHERE m.mateId = :mateId AND m.grade = 'CREATOR'")
-    UserEntity findByMateId(@Param("mateId") Long mateId);
+    Optional<UserEntity> findByMateId(@Param("mateId") Long mateId);
 
     @Modifying
     @Query("UPDATE MateMember m SET m.applyStatus = :applyStatus WHERE m.mateId = :mateId AND m.userId = :userId")
@@ -45,4 +47,6 @@ public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
 
     @Query("SELECT COUNT(m) FROM MateMember  m WHERE m.mateId = :mateId AND m.deletedAt IS NULL")
     Long countByMateId(Long mateId);
+
+    Page<MateMember> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/swyp/dessertbee/community/mate/service/SavedMateServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/service/SavedMateServiceImpl.java
@@ -141,7 +141,8 @@ public class SavedMateServiceImpl implements SavedMateService {
                 .map(mate -> {
                     String mateImage = imageService.getImageByTypeAndId(ImageType.MATE, mate.getMateId());
                     String mateCategory = mateCategoryRepository.findCategoryNameById(mate.getMateCategoryId());
-                    UserEntity creator = mateMemberRepository.findByMateId(mate.getMateId());
+                    UserEntity creator = mateMemberRepository.findByMateId(mate.getMateId())
+                            .orElseThrow(() -> new MateMemberNotFoundExcption("작성자 정보를 찾을 수 없습니다."));
                     String profileImage = imageService.getImageByTypeAndId(ImageType.PROFILE, mate.getUserId());
 
 


### PR DESCRIPTION
## :hash: 연관된 이슈

> 387

## :memo: 작업 내용

> 내가 참여한 디저트메이트 조회 시 내가 작성한 게시글만 나오던 버그 참여하고 있는 모든 게시글 다 나오도록 수정
> 탈퇴한 회원의 게시글 조회 가능하도록 수정


## :speech_balloon: 리뷰 요구사항(선택)

> 탈퇴한 회원의 닉네임을 나중에 다른 사람이 이어서 쓰게 되면 조회 시 문제가 되지 않을까요?
> 나중엔 user에 deletedAt이 null 이 아닐 땐 닉네임 대신 탈퇴한 회원입니다로 나오게 하는게 좋은지 다른분들의 의견이 궁금합니다.
