### PR TITLE
[FEATURE] 기존 web Apple OAuth에 App 로직 추가

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AppleCallbackTestController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AppleCallbackTestController.java
@@ -2,6 +2,7 @@ package org.swyp.dessertbee.auth.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,11 +15,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Apple 로그인 콜백을 긴급 처리하기 위한 임시 컨트롤러
+ * Apple 로그인 콜백을 처리하기 위한 임시 컨트롤러
  * 테스트 용도로만 사용
  */
 @Controller
 @RequestMapping("/ko/oauth/callback")
+@Profile("dev")
 @Slf4j
 public class AppleCallbackTestController {
 
@@ -55,7 +57,6 @@ public class AppleCallbackTestController {
 
     /**
      * Apple 로그인 콜백 처리 - JSON API 버전
-     * 이 엔드포인트는 프론트엔드에서 직접 호출할 수 있음
      */
     @PostMapping(value = "/apple/api")
     @ResponseBody

--- a/src/main/java/org/swyp/dessertbee/auth/controller/AppleCallbackTestController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AppleCallbackTestController.java
@@ -1,0 +1,86 @@
+package org.swyp.dessertbee.auth.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Apple 로그인 콜백을 긴급 처리하기 위한 임시 컨트롤러
+ * 테스트 용도로만 사용
+ */
+@Controller
+@RequestMapping("/ko/oauth/callback")
+@Slf4j
+public class AppleCallbackTestController {
+
+    /**
+     * Apple 로그인 콜백 처리 - Form POST 방식으로 받은 데이터를 로깅하고 HTML 응답 제공
+     */
+    @PostMapping("/apple")
+    public String handleAppleCallback(
+            @RequestParam(value = "code", required = false) String code,
+            @RequestParam(value = "id_token", required = false) String idToken,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "user", required = false) String user,
+            HttpServletRequest request
+    ) {
+        log.info("Apple 로그인 콜백 데이터 수신 (EmergencyCallbackController)");
+        log.info("code: {}", code);
+        log.info("id_token: {}", idToken);
+        log.info("state: {}", state);
+        log.info("user: {}", user);
+
+        // 모든 요청 파라미터 로깅
+        Enumeration<String> paramNames = request.getParameterNames();
+        while (paramNames.hasMoreElements()) {
+            String paramName = paramNames.nextElement();
+            log.info("Parameter: {} = {}", paramName, request.getParameter(paramName));
+        }
+
+        // 테스트 페이지로 리다이렉트하면서 파라미터 전달
+        return "redirect:/apple-oauth-test.html?code=" + code +
+                (idToken != null ? "&id_token=" + idToken : "") +
+                (state != null ? "&state=" + state : "") +
+                (user != null ? "&user=" + user : "");
+    }
+
+    /**
+     * Apple 로그인 콜백 처리 - JSON API 버전
+     * 이 엔드포인트는 프론트엔드에서 직접 호출할 수 있음
+     */
+    @PostMapping(value = "/apple/api")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> handleAppleCallbackApi(
+            @RequestParam(value = "code", required = false) String code,
+            @RequestParam(value = "id_token", required = false) String idToken,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "user", required = false) String user,
+            HttpServletRequest request
+    ) {
+        log.info("Apple 로그인 API 콜백 수신");
+        log.info("code: {}", code);
+        log.info("id_token: {}", idToken);
+        log.info("state: {}", state);
+        log.info("user: {}", user);
+
+        // 응답 데이터 생성
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("message", "Apple 로그인 콜백이 성공적으로 처리되었습니다.");
+        response.put("code", code);
+        response.put("id_token", idToken);
+        response.put("state", state);
+        response.put("user", user);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/auth/dto/response/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/response/LoginResponse.java
@@ -81,6 +81,15 @@ public class LoginResponse {
     private String deviceId;        // 디바이스 식별자
 
     @Schema(
+            description = "앱에서 로그인한 요청인지 여부",
+            example = "false",
+            defaultValue = "false",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Builder.Default
+    private Boolean fromApp = false; // 앱에서 로그인 여부
+
+    @Schema(
             description = "이미지 관련 오류 메시지 (이미지 업로드 실패 시에만 존재)",
             implementation = ErrorResponse.class,
             nullable = true,
@@ -119,6 +128,7 @@ public class LoginResponse {
                 .profileImageUrl(profileImageUrl)
                 .deviceId(deviceId)
                 .isPreferenceSet(isPreferenceSet)
+                .fromApp(false) // 기본값은 false (웹 로그인)
                 .build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -43,7 +43,7 @@ public class OAuthService {
             // enum을 사용하여 적절한 서비스 호출
             return switch (provider) {
                 case KAKAO -> kakaoOAuthService.processKakaoLogin(code, deviceId);
-                case APPLE -> appleOAuthService.processAppleLogin(code, null, null, null, deviceId);
+                case APPLE -> appleOAuthService.processAppleLogin(code, null, null, null, deviceId, false); // false = WEB
                 // 추후 다른 OAuth 제공자 추가
                 default -> throw new InvalidProviderException("아직 구현되지 않은 OAuth 제공자입니다: " + provider.getProviderName());
             };
@@ -67,13 +67,13 @@ public class OAuthService {
      * @return 로그인 응답 (JWT 토큰 포함)
      */
     @Transactional
-    public LoginResponse processAppleLogin(String code, String idToken, String state, AppleUserInfo userInfo, String deviceId) {
+    public LoginResponse processAppleLogin(String code, String idToken, String state, AppleUserInfo userInfo, String deviceId, boolean isApp) {
         try {
-            return appleOAuthService.processAppleLogin(code, idToken, state, userInfo, deviceId);
+            return appleOAuthService.processAppleLogin(code, idToken, state, userInfo, deviceId, isApp);
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Apple 로그인 처리 중 오류 발생", e);
+            log.error("Apple 로그인 처리 중 오류 발생 - 플랫폼: {}", isApp ? "APP" : "WEB", e);
             throw new OAuthAuthenticationException("Apple 로그인 처리 중 오류가 발생했습니다.");
         }
     }

--- a/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
+++ b/src/main/java/org/swyp/dessertbee/config/SecurityConfig.java
@@ -79,6 +79,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/mates/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/search/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        // apple OAuth login testing 용도
+                        .requestMatchers("/apple-oauth-test.html/**").permitAll()
+                        .requestMatchers("/ko/oauth/callback/**").permitAll()
 
                         // 나머지 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,6 +24,8 @@ spring:
             redirect-uri: "http://localhost:8000/kakao-oauth-test.html"
           apple:
             redirect-uri: https://61c8-2001-2d8-2117-cf18-bc1c-5c7c-e9b8-c225.ngrok-free.app/apple-oauth-test.html
+          apple-app:
+            redirect-uri: https://61c8-2001-2d8-2117-cf18-bc1c-5c7c-e9b8-c225.ngrok-free.app/apple-oauth-test.html
 
   graphql:
     cors:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,10 +22,10 @@ spring:
         registration:
           kakao:
             redirect-uri: "http://localhost:8000/kakao-oauth-test.html"
-          apple:
-            redirect-uri: https://61c8-2001-2d8-2117-cf18-bc1c-5c7c-e9b8-c225.ngrok-free.app/apple-oauth-test.html
+          apple: # ngrok 새로킬 때마다 변경되는 값임.
+            redirect-uri: https://e05c-210-107-70-217.ngrok-free.app/ko/oauth/callback/apple
           apple-app:
-            redirect-uri: https://61c8-2001-2d8-2117-cf18-bc1c-5c7c-e9b8-c225.ngrok-free.app/apple-oauth-test.html
+            redirect-uri: https://e05c-210-107-70-217.ngrok-free.app/apple-oauth-test.html
 
   graphql:
     cors:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,7 +15,9 @@ spring:
           kakao:
             redirect-uri: ${KAKAO_REDIRECT_URI_PROD}
           apple:
-            redirect-uri: ${APPLE_REDIRECT_URI_PROD}
+            redirect-uri: ${APPLE_WEB_REDIRECT_URI_PROD}
+          apple-app: # TODO : 추후 앱 전용 리다이렉트 주소 사용해야함.
+            redirect-uri: ${APPLE_APP_REDIRECT_URI_PROD}
 #  elasticsearch:
 #    uris: http://desserbee-es:9200
 #  graphql:

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -33,7 +33,9 @@ spring:
           kakao:
             redirect-uri: ${KAKAO_REDIRECT_URI_TEST}
           apple:
-            redirect-uri: ${APPLE_REDIRECT_URI_TEST}
+            redirect-uri: ${APPLE_WEB_REDIRECT_URI_TEST}
+          apple-app : # TODO : 추후 앱 전용 리다이렉트 주소 사용해야함.
+            redirect-uri: ${APPLE_APP_REDIRECT_URI_TEST}
 #  elasticsearch:
 #    uris: http://desserbee-es:9200
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,10 +45,17 @@ spring:
               - account_email
             client-authentication-method: client_secret_post
           apple:
-            client-id: ${APPLE_CLIENT_ID}            # Service ID (웹 client-id)
+            client-id: ${APPLE_WEB_CLIENT_ID}            # Service ID (웹 client-id)
             authorization-grant-type: authorization_code
             scope:
               - email
+          apple-app:
+            client-id: ${APPLE_APP_CLIENT_ID}            # App Bundle ID (앱 client-id)
+            client-name: Apple App
+            authorization-grant-type: authorization_code
+            scope:
+              - email
+            provider: apple
 
         provider:
           kakao:


### PR DESCRIPTION
## :hash: 연관된 이슈
#395 
## :memo: 작업 내용
- OAuthController:
  - X-Platform 헤더 추가 - 기본값 "WEB"
  - 허용값: "APP", "WEB"
- 앱과 웹의 환경변수 분리
- Apple OAuth 서비스:
  - processWebAppleLogin과 processAppAppleLogin 메서드 분리, 환경별 처리
- LoginResponse에 fromApp 필드 추가로 앱 로그인 여부 표시

## :speech_balloon: 리뷰 요구사항(선택)
- 웹과 다르게 앱 실제 테스트는... 해보지 않았습니다... 