### PR TITLE
[FEATURE] 유저 차단 엔티티 구현 

### DIFF
--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -56,6 +56,11 @@ public enum ErrorCode {
     INVALID_USER_UUID(HttpStatus.BAD_REQUEST, "U005", "유효하지 않은 사용자 식별자입니다."),
     OWNER_ROLE_MISSING_INFO(HttpStatus.BAD_REQUEST, "U006", "사장 권한을 부여하려면 이름과 전화번호 정보가 필요합니다."),
 
+    // Block
+    SELF_BLOCK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "B001", "자신을 차단할 수 없습니다."),
+    ALREADY_BLOCKED_USER(HttpStatus.BAD_REQUEST, "B002", "이미 차단한 사용자입니다."),
+    USER_BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "B003", "차단 정보를 찾을 수 없습니다."),
+
     // Preference
     PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 취향 태그입니다."),
     USER_PREFERENCES_NOT_FOUND(HttpStatus.NOT_FOUND, "P002", "취향을 등록하지 않은 사용자입니다."),

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserBlockController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserBlockController.java
@@ -1,0 +1,133 @@
+package org.swyp.dessertbee.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.user.dto.request.UserBlockRequest;
+import org.swyp.dessertbee.user.dto.response.UserBlockCheckResponse;
+import org.swyp.dessertbee.user.dto.response.UserBlockResponse;
+import org.swyp.dessertbee.user.service.UserBlockService;
+import org.swyp.dessertbee.user.service.UserService;
+
+import java.util.UUID;
+
+/**
+ * 사용자 차단 관련 컨트롤러
+ */
+@Tag(name = "UserBlock", description = "사용자 차단 관련 API")
+@RestController
+@RequestMapping("/api/users/blocks")
+@RequiredArgsConstructor
+@Slf4j
+public class UserBlockController {
+
+    private final UserBlockService userBlockService;
+    private final UserService userService;
+
+    /**
+     * 사용자 차단하기
+     */
+    @Operation(
+            summary = "사용자 차단하기",
+            description = "특정 사용자를 차단합니다."
+    )
+    @ApiResponse(
+            responseCode = "201",
+            description = "사용자 차단 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = UserBlockResponse.class)
+            )
+    )
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED_ACCESS,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.SELF_BLOCK_NOT_ALLOWED,
+            ErrorCode.ALREADY_BLOCKED_USER
+    })
+    @PostMapping
+    public ResponseEntity<UserBlockResponse> blockUser(@RequestBody UserBlockRequest request) {
+        // 현재 로그인된 사용자 정보 가져오기
+        UUID currentUserUuid = userService.getCurrentUser().getUserUuid();
+        UserBlockResponse response = userBlockService.blockUser(currentUserUuid, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 사용자 차단 해제하기
+     */
+    @Operation(
+            summary = "사용자 차단 해제하기",
+            description = "차단한 사용자를 해제합니다."
+    )
+    @ApiResponse(responseCode = "204", description = "사용자 차단 해제 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED_ACCESS,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.USER_BLOCK_NOT_FOUND,
+    })
+    @DeleteMapping("/{blockId}")
+    public ResponseEntity<Void> unblockUser(@PathVariable Long blockId) {
+        // 현재 로그인된 사용자 정보 가져오기
+        UUID currentUserUuid = userService.getCurrentUser().getUserUuid();
+        userBlockService.unblockUser(currentUserUuid, blockId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 차단한 사용자 목록 조회
+     */
+    @Operation(
+            summary = "차단한 사용자 목록 조회",
+            description = "현재 사용자가 차단한 사용자 목록을 조회합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "차단 목록 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = UserBlockResponse.ListResponse.class)
+            )
+    )
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED_ACCESS, ErrorCode.USER_NOT_FOUND})
+    @GetMapping
+    public ResponseEntity<UserBlockResponse.ListResponse> getBlockedUsers() {
+        // 현재 로그인된 사용자 정보 가져오기
+        UUID currentUserUuid = userService.getCurrentUser().getUserUuid();
+        UserBlockResponse.ListResponse response = userBlockService.getBlockedUsers(currentUserUuid);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "차단 여부 확인",
+            description = "특정 사용자를 차단했는지 여부와 차단 정보를 확인합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "차단 여부 확인 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = UserBlockCheckResponse.class)
+            )
+    )
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED_ACCESS, ErrorCode.USER_NOT_FOUND, ErrorCode.INVALID_USER_UUID})
+    @GetMapping("/check/{blockedUserUuid}")
+    public ResponseEntity<UserBlockCheckResponse> isBlocked(@PathVariable String blockedUserUuid) {
+        // 현재 로그인된 사용자 정보 가져오기
+        UUID currentUserUuid = userService.getCurrentUser().getUserUuid();
+        UserBlockCheckResponse response = userBlockService.checkBlockStatus(
+                currentUserUuid,
+                UUID.fromString(blockedUserUuid)
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/dto/request/UserBlockRequest.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/request/UserBlockRequest.java
@@ -1,0 +1,21 @@
+package org.swyp.dessertbee.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserBlockRequest {
+    @NotNull
+    @Schema(description = "차단할 사용자의 UUID",
+            example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+    private UUID blockedUserUuid;
+}

--- a/src/main/java/org/swyp/dessertbee/user/dto/response/UserBlockCheckResponse.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/response/UserBlockCheckResponse.java
@@ -1,0 +1,36 @@
+package org.swyp.dessertbee.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "차단 여부 확인 응답")
+public class UserBlockCheckResponse {
+
+    @Schema(description = "차단 여부", example = "true")
+    private boolean isBlocked;
+
+    @Schema(description = "차단 ID (차단된 경우에만 값이 있음)", example = "2")
+    private Long id;
+
+    @Schema(description = "차단한 사용자 UUID", example = "46743110-931e-404b-a2cb-02e5634e2423")
+    private UUID blockerUserUuid;
+
+    @Schema(description = "차단된 사용자 UUID", example = "4e80465b-c081-432b-a97f-f89edec5c1e3")
+    private UUID blockedUserUuid;
+
+    @Schema(description = "차단된 사용자 닉네임", example = "매력적인케이크4135")
+    private String blockedUserNickname;
+
+    @Schema(description = "차단 일시 (차단된 경우에만 값이 있음)", example = "2025-05-17T00:30:58.742684")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/swyp/dessertbee/user/dto/response/UserBlockResponse.java
+++ b/src/main/java/org/swyp/dessertbee/user/dto/response/UserBlockResponse.java
@@ -1,0 +1,55 @@
+package org.swyp.dessertbee.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 사용자 차단 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사용자 차단 응답")
+public class UserBlockResponse {
+
+    @Schema(description = "차단 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "차단한 사용자 UUID", example = "e47ac10b-58cc-4372-a567-0e02b2c3d478")
+    private UUID blockerUserUuid;
+
+    @Schema(description = "차단된 사용자 UUID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+    private UUID blockedUserUuid;
+
+    @Schema(description = "차단된 사용자 닉네임", example = "디저트비")
+    private String blockedUserNickname;
+
+    @Schema(description = "차단 일시", example = "2023-06-15T14:30:00")
+    private LocalDateTime createdAt;
+
+    /**
+     * 차단 목록 응답 DTO
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "차단한 사용자 목록 응답")
+    public static class ListResponse {
+
+        @Schema(description = "차단한 사용자 목록")
+        private List<UserBlockResponse> blockedUsers;
+
+        @Schema(description = "총 차단 사용자 수", example = "3")
+        private int totalCount;
+
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserBlock.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserBlock.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @Table(
         name = "user_block",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_user_block", columnNames = {"blocker_id", "blocked_id"})
+                @UniqueConstraint(name = "uk_user_block", columnNames = {"blocker_user_id", "blocked_user_id"})
         }
 )
 @Getter
@@ -29,16 +29,30 @@ public class UserBlock {
     private Long id;
 
     /**
-     * 차단한 사용자 ID
+     * 차단한 사용자 ID (FK)
      */
-    @Column(name = "blocker_id", nullable = false)
-    private Long blockerId;
+    @Column(name = "blocker_user_id", nullable = false)
+    private Long blockerUserId;
 
     /**
-     * 차단된 사용자 ID
+     * 차단된 사용자 ID (FK)
      */
-    @Column(name = "blocked_id", nullable = false)
-    private Long blockedId;
+    @Column(name = "blocked_user_id", nullable = false)
+    private Long blockedUserId;
+
+    /**
+     * 차단한 사용자 (관계 매핑)
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_user_id", insertable = false, updatable = false)
+    private UserEntity blockerUser;
+
+    /**
+     * 차단된 사용자 (관계 매핑)
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_user_id", insertable = false, updatable = false)
+    private UserEntity blockedUser;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserBlock.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserBlock.java
@@ -1,0 +1,46 @@
+package org.swyp.dessertbee.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "user_block",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_block", columnNames = {"blocker_id", "blocked_id"})
+        }
+)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class UserBlock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 차단한 사용자 ID
+     */
+    @Column(name = "blocker_id", nullable = false)
+    private Long blockerId;
+
+    /**
+     * 차단된 사용자 ID
+     */
+    @Column(name = "blocked_id", nullable = false)
+    private Long blockedId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserBlockRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserBlockRepository.java
@@ -16,51 +16,51 @@ public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
     /**
      * UUID 기반: 특정 사용자가 차단한 사용자 목록 조회
      */
-    @Query("SELECT ub FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id WHERE blocker.userUuid = :blockerUuid")
+    @Query("SELECT ub FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerUserId = blocker.id WHERE blocker.userUuid = :blockerUuid")
     List<UserBlock> findByBlockerUuid(@Param("blockerUuid") UUID blockerUuid);
 
     /**
      * UUID 기반: 특정 사용자가 차단한 사용자 ID 목록 조회
      */
-    @Query("SELECT ub.blockedId FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id WHERE blocker.userUuid = :blockerUuid")
+    @Query("SELECT ub.blockedUserId FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerUserId = blocker.id WHERE blocker.userUuid = :blockerUuid")
     List<Long> findBlockedUserIdsByBlockerUuid(@Param("blockerUuid") UUID blockerUuid);
 
     /**
      * UUID 기반: 특정 사용자가 차단한 사용자 UUID 목록 조회
      */
-    @Query("SELECT blocked.userUuid FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id JOIN UserEntity blocked ON ub.blockedId = blocked.id WHERE blocker.userUuid = :blockerUuid")
+    @Query("SELECT blocked.userUuid FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerUserId = blocker.id JOIN UserEntity blocked ON ub.blockedUserId = blocked.id WHERE blocker.userUuid = :blockerUuid")
     List<UUID> findBlockedUserUuidsByBlockerUuid(@Param("blockerUuid") UUID blockerUuid);
 
     /**
      * UUID 기반: 특정 사용자의 차단 여부 확인 (blockerUuid가 blockedUuid를 차단했는지)
      */
-    @Query("SELECT COUNT(ub) > 0 FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id JOIN UserEntity blocked ON ub.blockedId = blocked.id WHERE blocker.userUuid = :blockerUuid AND blocked.userUuid = :blockedUuid")
+    @Query("SELECT COUNT(ub) > 0 FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerUserId = blocker.id JOIN UserEntity blocked ON ub.blockedUserId = blocked.id WHERE blocker.userUuid = :blockerUuid AND blocked.userUuid = :blockedUuid")
     boolean existsByBlockerUuidAndBlockedUuid(@Param("blockerUuid") UUID blockerUuid, @Param("blockedUuid") UUID blockedUuid);
 
     /**
      * UUID 기반: 특정 사용자가 특정 사용자를 차단한 내역 조회
      */
-    @Query("SELECT ub FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id JOIN UserEntity blocked ON ub.blockedId = blocked.id WHERE blocker.userUuid = :blockerUuid AND blocked.userUuid = :blockedUuid")
+    @Query("SELECT ub FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerUserId = blocker.id JOIN UserEntity blocked ON ub.blockedUserId = blocked.id WHERE blocker.userUuid = :blockerUuid AND blocked.userUuid = :blockedUuid")
     Optional<UserBlock> findByBlockerUuidAndBlockedUuid(@Param("blockerUuid") UUID blockerUuid, @Param("blockedUuid") UUID blockedUuid);
 
     /**
      * ID 기반: 특정 사용자가 차단한 사용자 목록 조회
      */
-    List<UserBlock> findByBlockerId(Long blockerId);
+    List<UserBlock> findByBlockerUserId(Long blockerUserId);
 
     /**
      * ID 기반: 특정 사용자가 차단한 사용자 ID 목록 조회
      */
-    @Query("SELECT ub.blockedId FROM UserBlock ub WHERE ub.blockerId = :blockerId")
-    List<Long> findBlockedUserIdsByBlockerId(@Param("blockerId") Long blockerId);
+    @Query("SELECT ub.blockedUserId FROM UserBlock ub WHERE ub.blockerUserId = :blockerUserId")
+    List<Long> findBlockedUserIdsByBlockerUserId(@Param("blockerUserId") Long blockerUserId);
 
     /**
-     * ID 기반: 특정 사용자의 차단 여부 확인 (blockerId가 blockedId를 차단했는지)
+     * ID 기반: 특정 사용자의 차단 여부 확인 (blockerUserId가 blockedUserId를 차단했는지)
      */
-    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+    boolean existsByBlockerUserIdAndBlockedUserId(Long blockerUserId, Long blockedUserId);
 
     /**
      * ID 기반: 특정 사용자가 특정 사용자를 차단한 내역 조회
      */
-    Optional<UserBlock> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+    Optional<UserBlock> findByBlockerUserIdAndBlockedUserId(Long blockerUserId, Long blockedUserId);
 }

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserBlockRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserBlockRepository.java
@@ -1,0 +1,66 @@
+package org.swyp.dessertbee.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.swyp.dessertbee.user.entity.UserBlock;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+
+    /**
+     * UUID 기반: 특정 사용자가 차단한 사용자 목록 조회
+     */
+    @Query("SELECT ub FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id WHERE blocker.userUuid = :blockerUuid")
+    List<UserBlock> findByBlockerUuid(@Param("blockerUuid") UUID blockerUuid);
+
+    /**
+     * UUID 기반: 특정 사용자가 차단한 사용자 ID 목록 조회
+     */
+    @Query("SELECT ub.blockedId FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id WHERE blocker.userUuid = :blockerUuid")
+    List<Long> findBlockedUserIdsByBlockerUuid(@Param("blockerUuid") UUID blockerUuid);
+
+    /**
+     * UUID 기반: 특정 사용자가 차단한 사용자 UUID 목록 조회
+     */
+    @Query("SELECT blocked.userUuid FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id JOIN UserEntity blocked ON ub.blockedId = blocked.id WHERE blocker.userUuid = :blockerUuid")
+    List<UUID> findBlockedUserUuidsByBlockerUuid(@Param("blockerUuid") UUID blockerUuid);
+
+    /**
+     * UUID 기반: 특정 사용자의 차단 여부 확인 (blockerUuid가 blockedUuid를 차단했는지)
+     */
+    @Query("SELECT COUNT(ub) > 0 FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id JOIN UserEntity blocked ON ub.blockedId = blocked.id WHERE blocker.userUuid = :blockerUuid AND blocked.userUuid = :blockedUuid")
+    boolean existsByBlockerUuidAndBlockedUuid(@Param("blockerUuid") UUID blockerUuid, @Param("blockedUuid") UUID blockedUuid);
+
+    /**
+     * UUID 기반: 특정 사용자가 특정 사용자를 차단한 내역 조회
+     */
+    @Query("SELECT ub FROM UserBlock ub JOIN UserEntity blocker ON ub.blockerId = blocker.id JOIN UserEntity blocked ON ub.blockedId = blocked.id WHERE blocker.userUuid = :blockerUuid AND blocked.userUuid = :blockedUuid")
+    Optional<UserBlock> findByBlockerUuidAndBlockedUuid(@Param("blockerUuid") UUID blockerUuid, @Param("blockedUuid") UUID blockedUuid);
+
+    /**
+     * ID 기반: 특정 사용자가 차단한 사용자 목록 조회
+     */
+    List<UserBlock> findByBlockerId(Long blockerId);
+
+    /**
+     * ID 기반: 특정 사용자가 차단한 사용자 ID 목록 조회
+     */
+    @Query("SELECT ub.blockedId FROM UserBlock ub WHERE ub.blockerId = :blockerId")
+    List<Long> findBlockedUserIdsByBlockerId(@Param("blockerId") Long blockerId);
+
+    /**
+     * ID 기반: 특정 사용자의 차단 여부 확인 (blockerId가 blockedId를 차단했는지)
+     */
+    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    /**
+     * ID 기반: 특정 사용자가 특정 사용자를 차단한 내역 조회
+     */
+    Optional<UserBlock> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+}

--- a/src/main/java/org/swyp/dessertbee/user/service/UserBlockService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserBlockService.java
@@ -1,0 +1,88 @@
+package org.swyp.dessertbee.user.service;
+
+import org.swyp.dessertbee.user.dto.request.UserBlockRequest;
+import org.swyp.dessertbee.user.dto.response.UserBlockCheckResponse;
+import org.swyp.dessertbee.user.dto.response.UserBlockResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserBlockService {
+
+    /**
+     * 사용자 차단하기
+     * @param blockerUuid 차단하는 사용자 UUID
+     * @param request 차단 요청 DTO (차단될 사용자 UUID 포함)
+     * @return 차단 정보 응답 DTO
+     */
+    UserBlockResponse blockUser(UUID blockerUuid, UserBlockRequest request);
+
+    /**
+     * 사용자 차단 해제하기
+     * @param blockerUuid 차단 해제하는 사용자 UUID
+     * @param blockId 차단 ID
+     */
+    void unblockUser(UUID blockerUuid, Long blockId);
+
+    /**
+     * 차단한 사용자 목록 조회
+     * @param blockerUuid 조회하는 사용자 UUID
+     * @return 차단 목록 응답 DTO
+     */
+    UserBlockResponse.ListResponse getBlockedUsers(UUID blockerUuid);
+
+    /**
+     * 특정 사용자가 차단한 사용자 ID 목록 조회
+     * @param blockerUuid 조회하는 사용자 UUID
+     * @return 차단한 사용자 ID 목록
+     */
+    List<Long> getBlockedUserIds(UUID blockerUuid);
+
+    /**
+     * 특정 사용자가 차단한 사용자 UUID 목록 조회
+     * @param blockerUuid 조회하는 사용자 UUID
+     * @return 차단한 사용자 UUID 목록
+     */
+    List<UUID> getBlockedUserUuids(UUID blockerUuid);
+
+    /**
+     * 차단 여부 확인
+     * @param blockerUuid 차단한 사용자 UUID
+     * @param blockedUuid 차단된 사용자 UUID
+     * @return 차단 여부
+     */
+    boolean isBlocked(UUID blockerUuid, UUID blockedUuid);
+
+    /**
+     * 차단 여부 및 상세 정보 확인
+     * @param blockerUuid 차단한 사용자 UUID
+     * @param blockedUuid 차단된 사용자 UUID
+     * @return 차단 여부 및 상세 정보
+     */
+    UserBlockCheckResponse checkBlockStatus(UUID blockerUuid, UUID blockedUuid);
+
+    // ID 기반 메서드
+
+    /**
+     * 사용자 차단하기 (ID 기반)
+     * @param blockerId 차단하는 사용자 ID
+     * @param blockedId 차단되는 사용자 ID
+     * @return 차단 정보 응답 DTO
+     */
+    UserBlockResponse blockUserById(Long blockerId, Long blockedId);
+
+    /**
+     * 특정 사용자가 차단한 사용자 ID 목록 조회 (ID 기반)
+     * @param blockerId 조회하는 사용자 ID
+     * @return 차단한 사용자 ID 목록
+     */
+    List<Long> getBlockedUserIdsByBlockerId(Long blockerId);
+
+    /**
+     * 차단 여부 확인 (ID 기반)
+     * @param blockerId 차단한 사용자 ID
+     * @param blockedId 차단된 사용자 ID
+     * @return 차단 여부
+     */
+    boolean isBlockedById(Long blockerId, Long blockedId);
+}

--- a/src/main/java/org/swyp/dessertbee/user/service/UserBlockService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserBlockService.java
@@ -32,6 +32,14 @@ public interface UserBlockService {
     UserBlockResponse.ListResponse getBlockedUsers(UUID blockerUuid);
 
     /**
+     * 차단 여부와 상세 정보 확인
+     * @param blockerUuid 차단한 사용자 UUID
+     * @param blockedUuid 차단된 사용자 UUID
+     * @return 차단 여부 및 상세 정보 응답 DTO
+     */
+    UserBlockCheckResponse checkBlockStatus(UUID blockerUuid, UUID blockedUuid);
+
+    /**
      * 특정 사용자가 차단한 사용자 ID 목록 조회
      * @param blockerUuid 조회하는 사용자 UUID
      * @return 차단한 사용자 ID 목록
@@ -54,35 +62,25 @@ public interface UserBlockService {
     boolean isBlocked(UUID blockerUuid, UUID blockedUuid);
 
     /**
-     * 차단 여부 및 상세 정보 확인
-     * @param blockerUuid 차단한 사용자 UUID
-     * @param blockedUuid 차단된 사용자 UUID
-     * @return 차단 여부 및 상세 정보
-     */
-    UserBlockCheckResponse checkBlockStatus(UUID blockerUuid, UUID blockedUuid);
-
-    // ID 기반 메서드
-
-    /**
-     * 사용자 차단하기 (ID 기반)
-     * @param blockerId 차단하는 사용자 ID
-     * @param blockedId 차단되는 사용자 ID
+     * ID 기반: 사용자 차단하기 (내부용)
+     * @param blockerUserId 차단하는 사용자 ID
+     * @param blockedUserId 차단되는 사용자 ID
      * @return 차단 정보 응답 DTO
      */
-    UserBlockResponse blockUserById(Long blockerId, Long blockedId);
+    UserBlockResponse blockUserById(Long blockerUserId, Long blockedUserId);
 
     /**
-     * 특정 사용자가 차단한 사용자 ID 목록 조회 (ID 기반)
-     * @param blockerId 조회하는 사용자 ID
+     * ID 기반: 특정 사용자가 차단한 사용자 ID 목록 조회 (내부용)
+     * @param blockerUserId 조회하는 사용자 ID
      * @return 차단한 사용자 ID 목록
      */
-    List<Long> getBlockedUserIdsByBlockerId(Long blockerId);
+    List<Long> getBlockedUserIdsByBlockerId(Long blockerUserId);
 
     /**
-     * 차단 여부 확인 (ID 기반)
-     * @param blockerId 차단한 사용자 ID
-     * @param blockedId 차단된 사용자 ID
+     * ID 기반: 차단 여부 확인 (내부용)
+     * @param blockerUserId 차단한 사용자 ID
+     * @param blockedUserId 차단된 사용자 ID
      * @return 차단 여부
      */
-    boolean isBlockedById(Long blockerId, Long blockedId);
+    boolean isBlockedById(Long blockerUserId, Long blockedUserId);
 }

--- a/src/main/java/org/swyp/dessertbee/user/service/UserBlockServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserBlockServiceImpl.java
@@ -1,0 +1,215 @@
+package org.swyp.dessertbee.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.user.dto.request.UserBlockRequest;
+import org.swyp.dessertbee.user.dto.response.UserBlockCheckResponse;
+import org.swyp.dessertbee.user.dto.response.UserBlockResponse;
+import org.swyp.dessertbee.user.repository.UserBlockRepository;
+import org.swyp.dessertbee.user.entity.UserBlock;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class UserBlockServiceImpl implements UserBlockService {
+
+    private final UserBlockRepository userBlockRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public UserBlockResponse blockUser(UUID blockerUuid, UserBlockRequest request) {
+        // 차단하는 사용자 조회
+        UserEntity blocker = userRepository.findByUserUuid(blockerUuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 차단될 사용자 조회
+        UserEntity blocked = userRepository.findByUserUuid(request.getBlockedUserUuid())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 자기 자신을 차단하려는 경우
+        if (blocker.getId().equals(blocked.getId())) {
+            throw new BusinessException(ErrorCode.SELF_BLOCK_NOT_ALLOWED);
+        }
+
+        // 이미 차단한 사용자인지 확인
+        if (userBlockRepository.existsByBlockerIdAndBlockedId(blocker.getId(), blocked.getId())) {
+            throw new BusinessException(ErrorCode.ALREADY_BLOCKED_USER);
+        }
+
+        // 차단 정보 저장
+        UserBlock userBlock = UserBlock.builder()
+                .blockerId(blocker.getId())
+                .blockedId(blocked.getId())
+                .build();
+
+        UserBlock savedUserBlock = userBlockRepository.save(userBlock);
+
+        return UserBlockResponse.builder()
+                .id(savedUserBlock.getId())
+                .blockerUserUuid(blocker.getUserUuid())
+                .blockedUserUuid(blocked.getUserUuid())
+                .blockedUserNickname(blocked.getNickname())
+                .createdAt(savedUserBlock.getCreatedAt())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void unblockUser(UUID blockerUuid, Long blockId) {
+        // 차단을 해제하려는 사용자 조회
+        UserEntity blocker = userRepository.findByUserUuid(blockerUuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 해당 차단 정보 조회
+        UserBlock userBlock = userBlockRepository.findById(blockId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_BLOCK_NOT_FOUND));
+
+        // 차단을 해제하려는 사용자가 차단을 등록한 사용자인지 확인
+        if (!userBlock.getBlockerId().equals(blocker.getId())) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS, "차단 해제 권한이 없습니다.");
+        }
+
+        userBlockRepository.delete(userBlock);
+    }
+
+    @Override
+    public UserBlockResponse.ListResponse getBlockedUsers(UUID blockerUuid) {
+        // 차단 목록을 조회하려는 사용자 조회
+        UserEntity blocker = userRepository.findByUserUuid(blockerUuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        List<UserBlock> userBlocks = userBlockRepository.findByBlockerId(blocker.getId());
+
+        List<UserBlockResponse> responses = userBlocks.stream().map(block -> {
+            // 차단된 사용자 정보 조회
+            UserEntity blocked = userRepository.findById(block.getBlockedId())
+                    .orElse(null);
+
+            String nickname = blocked != null ? blocked.getNickname() : "알 수 없음";
+            UUID blockedUuid = blocked != null ? blocked.getUserUuid() : null;
+
+            return UserBlockResponse.builder()
+                    .id(block.getId())
+                    .blockerUserUuid(blocker.getUserUuid())
+                    .blockedUserUuid(blockedUuid)
+                    .blockedUserNickname(nickname)
+                    .createdAt(block.getCreatedAt())
+                    .build();
+        }).collect(Collectors.toList());
+
+        return UserBlockResponse.ListResponse.builder()
+                .blockedUsers(responses)
+                .totalCount(responses.size())
+                .build();
+    }
+
+    @Override
+    public UserBlockCheckResponse checkBlockStatus(UUID blockerUuid, UUID blockedUuid) {
+        Optional<UserBlock> userBlockOpt = userBlockRepository.findByBlockerUuidAndBlockedUuid(blockerUuid, blockedUuid);
+
+        if (userBlockOpt.isPresent()) {
+            UserBlock userBlock = userBlockOpt.get();
+
+            // 차단된 사용자 정보 조회
+            UserEntity blocked = userRepository.findById(userBlock.getBlockedId())
+                    .orElse(null);
+
+            String nickname = blocked != null ? blocked.getNickname() : "알 수 없음";
+
+            return UserBlockCheckResponse.builder()
+                    .isBlocked(true)
+                    .id(userBlock.getId())
+                    .blockerUserUuid(blockerUuid)
+                    .blockedUserUuid(blockedUuid)
+                    .blockedUserNickname(nickname)
+                    .createdAt(userBlock.getCreatedAt())
+                    .build();
+        } else {
+            return UserBlockCheckResponse.builder()
+                    .isBlocked(false)
+                    .blockerUserUuid(blockerUuid)
+                    .blockedUserUuid(blockedUuid)
+                    .build();
+        }
+    }
+
+    @Override
+    public List<Long> getBlockedUserIds(UUID blockerUuid) {
+        // 사용자 조회
+        UserEntity blocker = userRepository.findByUserUuid(blockerUuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return userBlockRepository.findBlockedUserIdsByBlockerId(blocker.getId());
+    }
+
+    @Override
+    public List<UUID> getBlockedUserUuids(UUID blockerUuid) {
+        return userBlockRepository.findBlockedUserUuidsByBlockerUuid(blockerUuid);
+    }
+
+    @Override
+    public boolean isBlocked(UUID blockerUuid, UUID blockedUuid) {
+        return userBlockRepository.existsByBlockerUuidAndBlockedUuid(blockerUuid, blockedUuid);
+    }
+
+    @Override
+    @Transactional
+    public UserBlockResponse blockUserById(Long blockerId, Long blockedId) {
+        // 차단하는 사용자 조회
+        UserEntity blocker = userRepository.findById(blockerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 차단될 사용자 조회
+        UserEntity blocked = userRepository.findById(blockedId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 자기 자신을 차단하려는 경우
+        if (blockerId.equals(blockedId)) {
+            throw new BusinessException(ErrorCode.SELF_BLOCK_NOT_ALLOWED);
+        }
+
+        // 이미 차단한 사용자인지 확인
+        if (userBlockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)) {
+            throw new BusinessException(ErrorCode.ALREADY_BLOCKED_USER);
+        }
+
+        // 차단 정보 저장
+        UserBlock userBlock = UserBlock.builder()
+                .blockerId(blockerId)
+                .blockedId(blockedId)
+                .build();
+
+        UserBlock savedUserBlock = userBlockRepository.save(userBlock);
+
+        return UserBlockResponse.builder()
+                .id(savedUserBlock.getId())
+                .blockerUserUuid(blocker.getUserUuid())
+                .blockedUserUuid(blocked.getUserUuid())
+                .blockedUserNickname(blocked.getNickname())
+                .createdAt(savedUserBlock.getCreatedAt())
+                .build();
+    }
+
+    @Override
+    public List<Long> getBlockedUserIdsByBlockerId(Long blockerId) {
+        return userBlockRepository.findBlockedUserIdsByBlockerId(blockerId);
+    }
+
+    @Override
+    public boolean isBlockedById(Long blockerId, Long blockedId) {
+        return userBlockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId);
+    }
+}


### PR DESCRIPTION
## :hash: 연관된 이슈
#412 

## :memo: 작업 내용
- 사용자 차단 정보를 저장하기 위한 `UserBlock` 엔티티를 구현함.
- 한 사용자가 동일한 사용자를 여러 번 차단하지 못하도록 `blocker_id`, `blocked_id`에 유니크 제약 조건(`uk_user_block`)을 설정함.
- 차단 생성 시점을 저장하기 위해 `createdAt` 필드를 `@CreatedDate`로 처리
![image](https://github.com/user-attachments/assets/47670963-6a37-4453-9505-e61f2b6e7f35)
![image](https://github.com/user-attachments/assets/9d1c9318-091e-4b31-a987-c78a997dcf57)
![image](https://github.com/user-attachments/assets/6947941b-2f28-4d1d-956a-2116299d0e29)
![image](https://github.com/user-attachments/assets/343b7e40-58a4-4df0-8d4b-f85ff2788edd)
