### PR TITLE
[FIX] 가게 휴무일 등록 양식 수정

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/schedule/dto/HolidayResponse.java
+++ b/src/main/java/org/swyp/dessertbee/store/schedule/dto/HolidayResponse.java
@@ -11,8 +11,12 @@ import lombok.Data;
 @AllArgsConstructor
 public class HolidayResponse {
     @NotNull
-    @Schema(description = "휴무 일자 (yyyy.MM.dd)", example = "2025.01.01")
-    private String date;
+    @Schema(description = "휴무 시작일 (yyyy.MM.dd)", example = "2025.01.01")
+    private String startDate;
+
+    @NotNull
+    @Schema(description = "휴무 종료일 (yyyy.MM.dd)", example = "2025.01.03")
+    private String endDate;
 
     @Schema(description = "휴무 사유", example = "신정", nullable = true)
     private String reason;

--- a/src/main/java/org/swyp/dessertbee/store/schedule/entity/StoreHoliday.java
+++ b/src/main/java/org/swyp/dessertbee/store/schedule/entity/StoreHoliday.java
@@ -23,7 +23,10 @@ public class StoreHoliday {
     private Long storeId;
 
     @Column(nullable = false)
-    private LocalDate holidayDate; // 특정 휴무일
+    private LocalDate startDate; // 휴무기간 시작 일자
+
+    @Column(nullable = false)
+    private LocalDate endDate; // 휴무기간 종료 일자
 
     private String reason; // 휴무 사유
 

--- a/src/main/java/org/swyp/dessertbee/store/store/dto/request/BaseStoreRequest.java
+++ b/src/main/java/org/swyp/dessertbee/store/store/dto/request/BaseStoreRequest.java
@@ -15,6 +15,7 @@ import org.swyp.dessertbee.store.schedule.entity.RegularClosureType;
 
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
@@ -152,12 +153,15 @@ public abstract class BaseStoreRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class HolidayRequest {
+        @NotNull
+        @JsonFormat(pattern = "yyyy.MM.dd")
+        @Schema(description = "휴무 시작일", example = "2025.02.10")
+        private LocalDate startDate;
 
-        @Schema(
-                description = "휴무일 입력 (예: '2025.02.10-2025.02.14 또는 2025.02.14')",
-                example = "2025.02.10-2025.02.14"
-        )
-        private String date; // 입력값을 파싱해서 LocalDate로 변환
+        @NotNull
+        @JsonFormat(pattern = "yyyy.MM.dd")
+        @Schema(description = "휴무 종료일", example = "2025.02.14")
+        private LocalDate endDate;
 
         @Schema(description = "휴무 사유", example = "내부 공사")
         private String reason;


### PR DESCRIPTION
## :hash: 연관된 이슈

> #417 

## :memo: 작업 내용

> 가게 휴무일 등록시 기존 일자별로 일일히 저장하던 방식에서 기간별(시작 날짜, 종료날짜)로 저장 및 조회하는 방식으로 변경했습니다.