### PR TITLE
[FIX] 차단한 사용자가 작성한 한줄리뷰 필터링

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewServiceImpl.java
@@ -29,11 +29,11 @@ import org.swyp.dessertbee.store.review.entity.StoreReview;
 import org.swyp.dessertbee.store.review.repository.StoreReviewRepository;
 import org.swyp.dessertbee.store.store.repository.StoreRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserBlockRepository;
 import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.user.service.UserService;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -52,6 +52,7 @@ public class StoreReviewServiceImpl implements StoreReviewService {
     private final UserService userService;
     private final StoreReviewReportRepository storeReviewReportRepository;
     private final ReportRepository reportRepository;
+    private final UserBlockRepository userBlockRepository;
 
     /** 오늘 작성한 리뷰 여부 확인 */
     public boolean hasTodayReview(UUID storeUuid, UUID userUuid) {
@@ -142,9 +143,16 @@ public class StoreReviewServiceImpl implements StoreReviewService {
             if (storeId == null) {
                 throw new InvalidStoreUuidException();
             }
+
+            UserEntity currentUser = userService.getCurrentUser();
+            final Set<UUID> blockedUserUuids = currentUser != null
+                    ? new HashSet<>(userBlockRepository.findBlockedUserUuidsByBlockerUuid(currentUser.getUserUuid()))
+                    : Collections.emptySet();
+
             List<StoreReview> reviews = storeReviewRepository.findByStoreIdAndDeletedAtIsNull(storeId);
 
             return reviews.stream()
+                    .filter(review -> !blockedUserUuids.contains(review.getUserUuid())) // 내가 차단한 사용자 제외
                     .map(review -> {
                         List<String> images = imageService.getImagesByTypeAndId(ImageType.SHORT, review.getReviewId());
 
@@ -157,10 +165,13 @@ public class StoreReviewServiceImpl implements StoreReviewService {
                                 profileImage.isEmpty() ? null : profileImage.get(0), images);
                     })
                     .collect(Collectors.toList());
+        } catch (InvalidStoreUuidException | UserNotFoundException e) {
+            throw e;
         } catch (Exception e) {
-            log.error("가게 한줄리뷰 조회 처리 중 오류 발생", e);
+            log.error("가게 한줄리뷰 조회 중 알 수 없는 오류", e);
             throw new StoreReviewServiceException("가게 한줄리뷰 조회 처리 중 오류가 발생했습니다.");
         }
+
     }
 
     /** 리뷰 수정 */

--- a/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/review/service/StoreReviewServiceImpl.java
@@ -31,6 +31,7 @@ import org.swyp.dessertbee.store.store.repository.StoreRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserBlockRepository;
 import org.swyp.dessertbee.user.repository.UserRepository;
+import org.swyp.dessertbee.user.service.UserBlockService;
 import org.swyp.dessertbee.user.service.UserService;
 
 import java.util.*;
@@ -52,7 +53,7 @@ public class StoreReviewServiceImpl implements StoreReviewService {
     private final UserService userService;
     private final StoreReviewReportRepository storeReviewReportRepository;
     private final ReportRepository reportRepository;
-    private final UserBlockRepository userBlockRepository;
+    private final UserBlockService userBlockService;
 
     /** 오늘 작성한 리뷰 여부 확인 */
     public boolean hasTodayReview(UUID storeUuid, UUID userUuid) {
@@ -145,9 +146,7 @@ public class StoreReviewServiceImpl implements StoreReviewService {
             }
 
             UserEntity currentUser = userService.getCurrentUser();
-            final Set<UUID> blockedUserUuids = currentUser != null
-                    ? new HashSet<>(userBlockRepository.findBlockedUserUuidsByBlockerUuid(currentUser.getUserUuid()))
-                    : Collections.emptySet();
+            List<UUID> blockedUserUuids = userBlockService.getBlockedUserUuids(currentUser.getUserUuid());
 
             List<StoreReview> reviews = storeReviewRepository.findByStoreIdAndDeletedAtIsNull(storeId);
 


### PR DESCRIPTION
## :hash: 연관된 이슈

> #429 

## :memo: 작업 내용

> 한줄리뷰 목록 조회 시 차단한 유저가 작성한 리뷰를 제외하도록 했습니다.