### PR TITLE
[FIX] 인증서 갱신 자동화 Flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,18 @@ jobs:
             echo "Stopping existing containers..."
             docker-compose down || true
 
+            # certbot 설치 (Amazon Linux 2023)
+            if ! command -v certbot &> /dev/null; then
+              echo "Installing certbot..."
+              sudo dnf install -y python3-pip
+              sudo pip3 install certbot
+            fi
+
+            # SSL 디렉토리 생성 및 권한 설정
+            sudo mkdir -p /var/www/certbot
+            sudo chmod 755 /var/www/certbot
+            sudo chown -R ec2-user:ec2-user /var/www/certbot
+
             # SSL 인증서 초기 설정 (인증서가 없는 경우에만)
             if [ ! -d "/etc/letsencrypt/live/${{ env.SERVER_NAME }}" ]; then
               echo "Setting up SSL certificate for the first time..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,28 +107,6 @@ jobs:
 
             cd /home/ec2-user/app
 
-            # .env 파일 작성
-            printf "%b\n" "${{ env.ENV_VALUE }}" > .env
-            echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> .env
-            echo "SERVER_NAME=${{ env.SERVER_NAME }}" >> .env
-            
-            # Nginx 설정 파일 생성 (템플릿에서 서버 이름 변수 치환)
-            mkdir -p nginx/conf
-            cat nginx/conf/default.conf.template | sed "s/\${SERVER_NAME}/${{ env.SERVER_NAME }}/g" > nginx/conf/default.conf
-            
-            # SSL 설정 실행 권한 부여
-            chmod +x ssl/setup-ssl.sh ssl/renew-ssl.sh
-            
-            # Docker Hub 로그인
-            echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-
-            # Docker 이미지 pull 및 Compose 실행
-            echo "Pulling latest Docker image..."
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/desserbee:latest
-
-            echo "Stopping existing containers..."
-            docker-compose down || true
-
             # certbot 설치 (Amazon Linux 2023)
             if ! command -v certbot &> /dev/null; then
               echo "Installing certbot..."
@@ -141,16 +119,67 @@ jobs:
             sudo chmod 755 /var/www/certbot
             sudo chown -R ec2-user:ec2-user /var/www/certbot
 
-            # SSL 인증서 초기 설정 (인증서가 없는 경우에만)
+            # .env 파일 작성
+            printf "%b\n" "${{ env.ENV_VALUE }}" > .env
+            echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> .env
+            echo "SERVER_NAME=${{ env.SERVER_NAME }}" >> .env
+            
+            # SSL 설정 실행 권한 부여
+            chmod +x ssl/setup-ssl.sh ssl/renew-ssl.sh ssl/ssl-health-check.sh
+            
+            # Docker Hub 로그인
+            echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+            # Docker 이미지 pull
+            echo "Pulling latest Docker image..."
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/desserbee:latest
+
+            echo "Stopping existing containers..."
+            docker-compose down || true
+
+            # SSL 인증서 존재 여부에 따른 분기 처리
             if [ ! -d "/etc/letsencrypt/live/${{ env.SERVER_NAME }}" ]; then
-              echo "Setting up SSL certificate for the first time..."
+              echo "=== 첫 번째 배포: SSL 인증서 초기 설정 ==="
+            
+              # HTTP 전용 임시 nginx 설정 생성
+              echo "HTTP 전용 nginx 임시 시작..."
+              cat nginx/conf/default-http-only.conf.template | sed "s/\${SERVER_NAME}/${{ env.SERVER_NAME }}/g" > nginx/conf/default-http-only.conf
+            
+              # 임시 nginx 설정으로 시작
+              docker run -d --name temp-nginx \
+                -p 80:80 \
+                -v $(pwd)/nginx/conf/default-http-only.conf:/etc/nginx/conf.d/default.conf \
+                -v /var/www/certbot:/var/www/certbot:ro \
+                nginx:latest
+
+              # nginx 시작 대기
+              echo "nginx 시작 대기 중..."
+              sleep 5
+
+              echo "SSL 인증서 발급 중..."
               ./ssl/setup-ssl.sh ${{ env.SERVER_NAME }}
+            
+              # 임시 nginx 컨테이너 정리
+              docker stop temp-nginx || true
+              docker rm temp-nginx || true
+            
+              echo "정식 nginx 설정으로 전환..."
+            else
+              echo "=== 기존 SSL 인증서 발견: 정상 배포 진행 ==="
             fi
+
+            # Nginx 설정 파일 생성 (템플릿에서 서버 이름 변수 치환)
+            mkdir -p nginx/conf
+            cat nginx/conf/default.conf.template | sed "s/\${SERVER_NAME}/${{ env.SERVER_NAME }}/g" > nginx/conf/default.conf
 
             echo "Starting containers with Docker Compose..."
             docker-compose up -d
 
             # SSL 자동 갱신 cron job 설정
             ./ssl/renew-ssl.sh setup-cron
+
+            # 배포 완료 후 SSL 상태 확인
+            echo "SSL 상태 확인 중..."
+            ./ssl/ssl-health-check.sh ${{ env.SERVER_NAME }}
 
             echo "Deployment completed at $(date) for branch ${{ github.ref_name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,11 +74,10 @@ jobs:
           host: ${{ env.EC2_HOST_VALUE }}
           username: ec2-user
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "docker-compose.yml,nginx/"
+          source: "docker-compose.yml,nginx/,ssl/"
           target: "/home/ec2-user/app"
           strip_components: 0
           overwrite: true
-
 
         # EC2에 SSH 접속 후 Docker 환경 구성 및 애플리케이션 실행
       - name: Deploy to EC2 and run Docker Compose
@@ -99,7 +98,6 @@ jobs:
               newgrp docker || true
             fi
 
-
             # Docker Compose 설치
             if ! command -v docker-compose &> /dev/null; then
               sudo curl -L "https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -118,6 +116,9 @@ jobs:
             mkdir -p nginx/conf
             cat nginx/conf/default.conf.template | sed "s/\${SERVER_NAME}/${{ env.SERVER_NAME }}/g" > nginx/conf/default.conf
             
+            # SSL 설정 실행 권한 부여
+            chmod +x ssl/setup-ssl.sh ssl/renew-ssl.sh
+            
             # Docker Hub 로그인
             echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
@@ -128,7 +129,16 @@ jobs:
             echo "Stopping existing containers..."
             docker-compose down || true
 
+            # SSL 인증서 초기 설정 (인증서가 없는 경우에만)
+            if [ ! -d "/etc/letsencrypt/live/${{ env.SERVER_NAME }}" ]; then
+              echo "Setting up SSL certificate for the first time..."
+              ./ssl/setup-ssl.sh ${{ env.SERVER_NAME }}
+            fi
+
             echo "Starting containers with Docker Compose..."
             docker-compose up -d
+
+            # SSL 자동 갱신 cron job 설정
+            ./ssl/renew-ssl.sh setup-cron
 
             echo "Deployment completed at $(date) for branch ${{ github.ref_name }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,13 +31,13 @@ services:
     volumes:
       - ./nginx/conf:/etc/nginx/conf.d
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - /etc/letsencrypt:/etc/letsencrypt # 호스트의 인증서를 컨테이너에 마운트
+      - /etc/letsencrypt:/etc/letsencrypt:ro # 호스트의 인증서를 읽기 전용으로 마운트
+      - /var/www/certbot:/var/www/certbot:ro # certbot webroot 마운트
     depends_on:
       - app
     restart: always
     networks:
       - app-network
-
 
   redis:
     image: redis:7.0
@@ -53,21 +53,6 @@ services:
     volumes:
       - redis-data:/data
     command: ["redis-server", "--appendonly", "yes"]
-
-#  elasticsearch:
-#    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.2
-#    container_name: desserbee-es
-#    environment:
-#      - discovery.type=single-node
-#      - xpack.security.enabled=false
-#      - ES_JAVA_OPTS=-Xms512m -Xmx512m
-#    ports:
-#      - "9200:9200"
-#    volumes:
-#      - es-data:/usr/share/elasticsearch/data
-#    networks:
-#      - app-network
-#    restart: always
 
 networks:
   app-network:

--- a/nginx/conf/default-http-only.conf.template
+++ b/nginx/conf/default-http-only.conf.template
@@ -1,0 +1,18 @@
+# HTTP 전용 임시 설정 (SSL 인증서 발급용)
+
+server {
+    listen 80;
+    server_name ${SERVER_NAME};
+
+    # Let's Encrypt webroot challenge 경로 (인증서 발급용)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        try_files $uri =404;
+    }
+
+    # 임시로 모든 요청을 502 응답으로 처리 (SSL 설정 전)
+    location / {
+        return 502 "SSL certificate setup in progress. Please wait a moment.";
+        add_header Content-Type text/plain;
+    }
+}

--- a/nginx/conf/default.conf.template
+++ b/nginx/conf/default.conf.template
@@ -19,6 +19,12 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+    # Let's Encrypt webroot challenge 경로
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        try_files $uri =404;
+    }
+
     # API 문서 접근 리다이렉트 예시
     location = /api-docs/ {
         return 301 /api-docs;
@@ -61,11 +67,18 @@ server {
     }
 }
 
-# HTTP → HTTPS 리디렉션
+# HTTP → HTTPS 리디렉션 (Let's Encrypt challenge 제외)
 server {
     listen 80;
     server_name ${SERVER_NAME};
 
+    # Let's Encrypt webroot challenge 경로
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        try_files $uri =404;
+    }
+
+    # 나머지 모든 HTTP 요청은 HTTPS로 리디렉션
     location / {
         return 301 https://$host$request_uri;
     }

--- a/ssl/renew-ssl.sh
+++ b/ssl/renew-ssl.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+# SSL 인증서 자동 갱신 스크립트 (호스트 기반)
+# 사용법:
+#   ./renew-ssl.sh                 # 갱신 실행
+#   ./renew-ssl.sh setup-cron      # cron job 설정
+#   ./renew-ssl.sh check           # 인증서 상태 확인
+
+set -e
+
+ACTION=${1:-renew}
+LOG_FILE="/var/log/ssl-renewal.log"
+COMPOSE_DIR="/home/ec2-user/app"
+
+# 로그 함수
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# 인증서 갱신 함수
+renew_certificates() {
+    log "=== SSL 인증서 갱신 시작 ==="
+
+    # certbot 설치 확인
+    if ! command -v certbot &> /dev/null; then
+        log "certbot이 설치되어 있지 않습니다."
+        return 1
+    fi
+
+    # certbot으로 인증서 갱신 시도
+    log "certbot으로 인증서 갱신 확인 중..."
+
+    # 갱신 전 인증서 상태 확인
+    RENEWAL_NEEDED=false
+
+    # 실제 갱신 실행 (30일 이내 만료 시에만 갱신됨)
+    if sudo certbot renew --webroot --webroot-path=/var/www/certbot --quiet --no-self-upgrade; then
+        log "인증서 갱신 확인 완료"
+
+        # 갱신 여부 확인 (로그 파일 체크)
+        if sudo grep -q "renewed" /var/log/letsencrypt/letsencrypt.log 2>/dev/null; then
+            RENEWAL_NEEDED=true
+            log "새로운 인증서가 발급되었습니다"
+        else
+            log "갱신이 필요한 인증서가 없습니다"
+        fi
+    else
+        log "인증서 갱신 실패"
+        return 1
+    fi
+
+    # nginx 재시작 (새로운 인증서가 있는 경우 또는 강제 재시작)
+    if [ "$RENEWAL_NEEDED" = true ] || [ "$2" = "--force-restart" ]; then
+        log "nginx 컨테이너 재시작 중..."
+
+        cd "$COMPOSE_DIR"
+        if docker-compose ps nginx | grep -q "Up"; then
+            # nginx만 재시작 (다른 서비스에 영향 없음)
+            if docker-compose restart nginx; then
+                log "nginx 재시작 완료 - 새 인증서가 적용되었습니다"
+            else
+                log "nginx 재시작 실패"
+                return 1
+            fi
+        else
+            log "nginx 컨테이너가 실행 중이지 않습니다."
+            # nginx가 죽어있다면 전체 재시작
+            docker-compose up -d nginx
+            log "nginx 컨테이너 재시작 완료"
+        fi
+    fi
+
+    log "SSL 인증서 갱신 프로세스 완료"
+}
+
+# 인증서 상태 확인 함수
+check_certificates() {
+    log "=== SSL 인증서 상태 확인 ==="
+
+    if command -v certbot &> /dev/null; then
+        log "현재 설치된 인증서 목록:"
+        sudo certbot certificates
+
+        log "갱신 예정 확인 (dry-run):"
+        sudo certbot renew --dry-run
+
+        log "만료일 확인:"
+        for cert_dir in /etc/letsencrypt/live/*/; do
+            if [ -d "$cert_dir" ]; then
+                domain=$(basename "$cert_dir")
+                if [ -f "$cert_dir/cert.pem" ]; then
+                    expiry=$(sudo openssl x509 -enddate -noout -in "$cert_dir/cert.pem" | cut -d= -f2)
+                    log "도메인 $domain 만료일: $expiry"
+                fi
+            fi
+        done
+    else
+        log "certbot이 설치되어 있지 않습니다."
+        exit 1
+    fi
+}
+
+# cron job 설정 함수
+setup_cron() {
+    log "=== SSL 갱신 cron job 설정 ==="
+
+    # 매일 오전 3시와 오후 3시에 2번 체크 (Let's Encrypt 권장사항)
+    CRON_JOB="0 3,15 * * * /home/ec2-user/app/ssl/renew-ssl.sh >> /var/log/ssl-renewal.log 2>&1"
+
+    # 기존 cron job 확인
+    if crontab -l 2>/dev/null | grep -q "renew-ssl.sh"; then
+        log "SSL 갱신 cron job이 이미 설정되어 있습니다."
+        log "기존 cron jobs:"
+        crontab -l | grep "renew-ssl.sh" || true
+
+        # 기존 것을 제거하고 새로 설정할지 묻기
+        log "기존 설정을 업데이트합니다..."
+        crontab -l 2>/dev/null | grep -v "renew-ssl.sh" | crontab -
+    fi
+
+    # 새로운 cron job 추가
+    (crontab -l 2>/dev/null; echo "$CRON_JOB") | crontab -
+    log "SSL 갱신 cron job이 설정되었습니다."
+    log "매일 오전 3시와 오후 3시에 인증서 갱신을 확인합니다."
+
+    # 현재 cron jobs 표시
+    log "현재 설정된 cron jobs:"
+    crontab -l || log "설정된 cron job이 없습니다."
+
+    # 로그 파일 권한 설정
+    sudo touch "$LOG_FILE"
+    sudo chown ec2-user:ec2-user "$LOG_FILE"
+    sudo chmod 644 "$LOG_FILE"
+
+    # 로그 로테이션 설정
+    setup_log_rotation
+}
+
+# 로그 로테이션 설정 함수
+setup_log_rotation() {
+    log "로그 로테이션 설정 중..."
+
+    sudo tee /etc/logrotate.d/ssl-renewal > /dev/null <<EOF
+/var/log/ssl-renewal.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    delaycompress
+    copytruncate
+    notifempty
+}
+EOF
+
+    log "로그 로테이션 설정 완료 (30일 보관)"
+}
+
+# 메인 실행부
+case "$ACTION" in
+    "renew")
+        renew_certificates "$@"
+        ;;
+    "check")
+        check_certificates
+        ;;
+    "setup-cron")
+        setup_cron
+        ;;
+    *)
+        echo "사용법: $0 [renew|check|setup-cron]"
+        echo ""
+        echo "옵션:"
+        echo "  renew      - SSL 인증서 갱신 실행 (기본값)"
+        echo "  check      - 인증서 상태 확인"
+        echo "  setup-cron - 자동 갱신 cron job 설정"
+        echo ""
+        echo "추가 옵션:"
+        echo "  renew --force-restart - 갱신 여부와 상관없이 nginx 재시작"
+        exit 1
+        ;;
+esac

--- a/ssl/setup-ssl.sh
+++ b/ssl/setup-ssl.sh
@@ -10,7 +10,7 @@ DOMAIN=$1
 echo "=== SSL 인증서 초기 설정 시작 ==="
 echo "도메인: $DOMAIN"
 
-# 도메인 유효성 간단 확인 (선택적)
+# 도메인 유효성 확인
 if [ -z "$DOMAIN" ] || [[ ! "$DOMAIN" =~ ^[a-zA-Z0-9.-]+$ ]]; then
     echo "유효하지 않은 도메인: $DOMAIN"
     exit 1

--- a/ssl/setup-ssl.sh
+++ b/ssl/setup-ssl.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# SSL 초기 설정 스크립트
+# 사용법: ./setup-ssl.sh <도메인명>
+
+set -e
+
+DOMAIN=$1
+
+echo "=== SSL 인증서 초기 설정 시작 ==="
+echo "도메인: $DOMAIN"
+
+# 도메인 유효성 간단 확인 (선택적)
+if [ -z "$DOMAIN" ] || [[ ! "$DOMAIN" =~ ^[a-zA-Z0-9.-]+$ ]]; then
+    echo "유효하지 않은 도메인: $DOMAIN"
+    exit 1
+fi
+
+# 필요한 디렉토리 생성
+sudo mkdir -p /var/www/certbot
+sudo mkdir -p /etc/letsencrypt
+sudo mkdir -p /var/lib/letsencrypt
+
+# certbot - 깃허브 액션 워크 플로우에서 설치 명령어 삽입
+if ! command -v certbot &> /dev/null; then
+    echo "certbot이 설치되어 있지 않습니다. CI/CD 스크립트를 확인하세요."
+    exit 1
+fi
+
+# webroot - 깃허브 액션 워크 플로우에서 디렉토리 권한 설정
+if [ ! -d "/var/www/certbot" ]; then
+    echo "/var/www/certbot 디렉토리가 없습니다. CI/CD 스크립트를 확인하세요."
+    exit 1
+fi
+
+# HTTP 서버 접근 가능 여부 확인 (Let's Encrypt 검증 준비)
+echo "HTTP 서버 접근성 확인 중..."
+for i in {1..6}; do
+    if curl -sSf --connect-timeout 5 "http://$DOMAIN/.well-known/acme-challenge/" > /dev/null 2>&1; then
+        echo "HTTP 서버가 준비되었습니다."
+        break
+    else
+        echo "HTTP 서버 준비 대기 중... ($i/6)"
+        sleep 10
+    fi
+    if [ $i -eq 6 ]; then
+        echo "⚠️  HTTP 서버 준비 확인에 실패했습니다. 인증서 발급을 시도합니다..."
+    fi
+done
+
+echo "Let's Encrypt 인증서 발급 중..."
+
+# 초기 인증서 발급 (webroot 방식)
+sudo certbot certonly \
+    --webroot \
+    --webroot-path=/var/www/certbot \
+    --email admin@desserbee.com \
+    --agree-tos \
+    --no-eff-email \
+    --keep-until-expiring \
+    --non-interactive \
+    -d $DOMAIN
+
+if [ $? -eq 0 ]; then
+    echo "SSL 인증서가 성공적으로 발급되었습니다!"
+    echo "인증서 경로: /etc/letsencrypt/live/$DOMAIN/"
+
+    # 인증서 파일 권한 설정
+    sudo chmod -R 755 /etc/letsencrypt
+
+    echo "인증서 만료일 확인:"
+    sudo certbot certificates -d $DOMAIN
+else
+    echo "SSL 인증서 발급에 실패했습니다."
+    echo "다음을 확인해주세요:"
+    echo "1. 도메인 DNS가 올바르게 설정되어 있는지"
+    echo "2. 80번 포트가 열려있고 nginx가 실행 중인지"
+    echo "3. /.well-known/acme-challenge/ 경로가 접근 가능한지"
+    exit 1
+fi
+
+echo "=== SSL 인증서 초기 설정 완료 ==="

--- a/ssl/ssl-health-check.sh
+++ b/ssl/ssl-health-check.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+
+# SSL 인증서 상태 모니터링 스크립트
+DOMAIN=${1:-$(hostname -f)}
+LOG_FILE="/var/log/ssl-health-check.log"
+
+# 로그 함수
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# 색상 출력 함수
+print_status() {
+    local status=$1
+    local message=$2
+    case $status in
+        "OK")
+            echo -e "\033[32m  $message\033[0m"
+            ;;
+        "WARNING")
+            echo -e "\033[33m  $message\033[0m"
+            ;;
+        "ERROR")
+            echo -e "\033[31m $message\033[0m"
+            ;;
+        "INFO")
+            echo -e "\033[36m  $message\033[0m"
+            ;;
+    esac
+}
+
+# 인증서 만료일 확인
+check_cert_expiry() {
+    log "=== SSL 인증서 만료일 확인: $DOMAIN ==="
+
+    if [ ! -f "/etc/letsencrypt/live/$DOMAIN/cert.pem" ]; then
+        print_status "ERROR" "인증서 파일을 찾을 수 없습니다: /etc/letsencrypt/live/$DOMAIN/cert.pem"
+        return 1
+    fi
+
+    # 인증서 만료일 추출
+    expiry_date=$(sudo openssl x509 -enddate -noout -in "/etc/letsencrypt/live/$DOMAIN/cert.pem" | cut -d= -f2)
+    expiry_epoch=$(date -d "$expiry_date" +%s)
+    current_epoch=$(date +%s)
+    days_until_expiry=$(( (expiry_epoch - current_epoch) / 86400 ))
+
+    print_status "INFO" "인증서 만료일: $expiry_date"
+    print_status "INFO" "남은 일수: $days_until_expiry일"
+
+    if [ $days_until_expiry -le 7 ]; then
+        print_status "ERROR" "인증서가 7일 이내에 만료됩니다! 즉시 갱신이 필요합니다."
+        return 2
+    elif [ $days_until_expiry -le 30 ]; then
+        print_status "WARNING" "인증서가 30일 이내에 만료됩니다. 갱신을 확인하세요."
+        return 1
+    else
+        print_status "OK" "인증서 상태가 양호합니다."
+        return 0
+    fi
+}
+
+# 웹서버 SSL 연결 테스트
+check_ssl_connection() {
+    log "=== SSL 연결 테스트: https://$DOMAIN ==="
+
+    # curl로 SSL 연결 테스트
+    if curl -sSf --connect-timeout 10 "https://$DOMAIN" > /dev/null 2>&1; then
+        print_status "OK" "HTTPS 연결이 정상적으로 작동합니다."
+    else
+        print_status "ERROR" "HTTPS 연결에 실패했습니다."
+        return 1
+    fi
+
+    # openssl로 상세 SSL 정보 확인
+    ssl_info=$(echo | timeout 10 openssl s_client -connect "$DOMAIN:443" -servername "$DOMAIN" 2>/dev/null | openssl x509 -noout -subject -issuer 2>/dev/null)
+
+    if [ $? -eq 0 ] && [ -n "$ssl_info" ]; then
+        print_status "OK" "SSL 인증서 정보:"
+        echo "$ssl_info" | while read line; do
+            print_status "INFO" "  $line"
+        done
+    else
+        print_status "WARNING" "SSL 연결 상세 정보를 가져올 수 없습니다."
+    fi
+}
+
+# certbot 상태 확인
+check_certbot_status() {
+    log "=== certbot 상태 확인 ==="
+
+    if ! command -v certbot &> /dev/null; then
+        print_status "ERROR" "certbot이 설치되어 있지 않습니다."
+        return 1
+    fi
+
+    print_status "OK" "certbot이 설치되어 있습니다."
+
+    # certbot 인증서 목록 확인
+    cert_list=$(sudo certbot certificates 2>/dev/null | grep "Certificate Name" | wc -l)
+    print_status "INFO" "관리 중인 인증서 수: $cert_list개"
+
+    # 갱신 가능 여부 확인 (dry-run)
+    if sudo certbot renew --dry-run --quiet 2>/dev/null; then
+        print_status "OK" "인증서 갱신 테스트가 성공했습니다."
+    else
+        print_status "ERROR" "인증서 갱신 테스트가 실패했습니다."
+        return 1
+    fi
+}
+
+# nginx 컨테이너 상태 확인
+check_nginx_status() {
+    log "=== nginx 컨테이너 상태 확인 ==="
+
+    if docker-compose -f /home/ec2-user/app/docker-compose.yml ps nginx | grep -q "Up"; then
+        print_status "OK" "nginx 컨테이너가 정상적으로 실행 중입니다."
+
+        # nginx 설정 테스트
+        if docker exec desserbee-nginx nginx -t 2>/dev/null; then
+            print_status "OK" "nginx 설정이 유효합니다."
+        else
+            print_status "ERROR" "nginx 설정에 오류가 있습니다."
+            return 1
+        fi
+    else
+        print_status "ERROR" "nginx 컨테이너가 실행되지 않았습니다."
+        return 1
+    fi
+}
+
+# cron job 상태 확인
+check_cron_status() {
+    log "=== SSL 갱신 cron job 확인 ==="
+
+    cron_count=$(crontab -l 2>/dev/null | grep -c "renew-ssl.sh")
+
+    if [ $cron_count -gt 0 ]; then
+        print_status "OK" "SSL 갱신 cron job이 설정되어 있습니다."
+        print_status "INFO" "설정된 cron job:"
+        crontab -l | grep "renew-ssl.sh" | while read line; do
+            print_status "INFO" "  $line"
+        done
+    else
+        print_status "WARNING" "SSL 갱신 cron job이 설정되어 있지 않습니다."
+        return 1
+    fi
+}
+
+# 로그 파일 확인
+check_renewal_logs() {
+    log "=== 최근 갱신 로그 확인 ==="
+
+    if [ -f "/var/log/ssl-renewal.log" ]; then
+        last_renewal=$(tail -n 20 "/var/log/ssl-renewal.log" | grep "갱신 프로세스 완료" | tail -n 1)
+        if [ -n "$last_renewal" ]; then
+            print_status "OK" "마지막 갱신 확인: $last_renewal"
+        else
+            print_status "INFO" "최근 갱신 기록이 없습니다."
+        fi
+    else
+        print_status "WARNING" "갱신 로그 파일이 없습니다: /var/log/ssl-renewal.log"
+    fi
+
+    # Let's Encrypt 로그 확인
+    if [ -f "/var/log/letsencrypt/letsencrypt.log" ]; then
+        recent_errors=$(sudo tail -n 50 "/var/log/letsencrypt/letsencrypt.log" | grep -i "error\|failed" | tail -n 3)
+        if [ -n "$recent_errors" ]; then
+            print_status "WARNING" "최근 Let's Encrypt 오류:"
+            echo "$recent_errors" | while read line; do
+                print_status "WARNING" "  $line"
+            done
+        fi
+    fi
+}
+
+# 메인 실행부
+main() {
+    echo "========================================"
+    echo "SSL 상태 종합 점검 시작: $DOMAIN"
+    echo "========================================"
+
+    exit_code=0
+
+    check_cert_expiry || exit_code=$?
+    echo
+
+    check_ssl_connection || exit_code=$?
+    echo
+
+    check_certbot_status || exit_code=$?
+    echo
+
+    check_nginx_status || exit_code=$?
+    echo
+
+    check_cron_status || exit_code=$?
+    echo
+
+    check_renewal_logs
+    echo
+
+    echo "========================================"
+    if [ $exit_code -eq 0 ]; then
+        print_status "OK" "모든 SSL 상태 점검이 완료되었습니다."
+    elif [ $exit_code -eq 1 ]; then
+        print_status "WARNING" "일부 항목에 주의가 필요합니다."
+    else
+        print_status "ERROR" "긴급한 조치가 필요한 문제가 발견되었습니다."
+    fi
+    echo "========================================"
+
+    log "SSL 상태 점검 완료 (종료 코드: $exit_code)"
+    return $exit_code
+}
+
+# 스크립트 실행
+main "$@"


### PR DESCRIPTION
## :hash: 연관된 이슈
#440 
## :memo: 작업 내용
- Let's Encrypt webroot 방식으로 첫 배포 시 자동 발급
- 매일 오전 3시, 오후 3시 자동 갱신 확인
- 만료 30일 이내 시에만 실제 갱신 수행
- nginx 무중단 재시작으로 서비스 영향 최소화
- SSL 인증서 만료일 및 상태 확인
```bash
ssl/
├── setup-ssl.sh           # 초기 SSL 인증서 발급
├── renew-ssl.sh           # 자동 갱신 및 cron 관리
└── ssl-health-check.sh    # SSL 상태 종합 모니터링
```
```bash
nginx/conf/
├── default.conf.template                # 정식 HTTPS 설정 (갱신 경로 포함)
└── default-http-only.conf.template      # 임시 HTTP 설정 (첫 배포용)
```

## :speech_balloon: 리뷰 요구사항(선택)
https://www.notion.so/SSL-1ff246cdb876809e9151efed17fc6b53?pvs=4