### PR TITLE
[FEAT] 워크플로우 단계별 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,9 +82,8 @@ jobs:
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script: |
             cd /home/ec2-user/app
-            chmod +x scripts/setup-system.sh
+            chmod +x scripts/*.sh ssl/*.sh
             ./scripts/setup-system.sh
-
       # 6. SSL 인증서 설정
       - name: Setup SSL Certificate
         uses: appleboy/ssh-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,16 +7,13 @@ on:
 
 jobs:
   build-and-deploy:
-    # 작업 실행 환경 : 깃허브에서 빌드하고 자르파일만 넣기 위함입니다~
     runs-on: ubuntu-latest
 
     steps:
-
-      # GitHub 저장소 코드 체크아웃
+      # 1. 코드 체크아웃 및 빌드
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Java 17 설치
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -24,22 +21,19 @@ jobs:
           java-version: '17'
           cache: 'gradle'
 
-      # gradlew에 실행 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      # Gradle 빌드
       - name: Build with Gradle
         run: ./gradlew build -x test
 
-      # 푸시를 위한 Docker Hub 로그인
+      # 2. Docker 이미지 빌드 및 푸시
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Docker 이미지 빌드 및 푸시
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
@@ -49,7 +43,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/desserbee:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/desserbee:${{ github.sha }}
 
-      # 배포 환경 결정
+      # 3. 배포 환경 설정
       - name: Set deployment variables
         id: vars
         run: |
@@ -67,119 +61,74 @@ jobs:
             echo "SERVER_NAME=release.desserbee.com" >> $GITHUB_ENV
           fi
 
-      # docker-compose 파일과 Nginx 설정을 EC2 인스턴스로 전송
+      # 4. 파일 전송
       - name: Transfer files to EC2
         uses: appleboy/scp-action@master
         with:
           host: ${{ env.EC2_HOST_VALUE }}
           username: ec2-user
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "docker-compose.yml,nginx/,ssl/"
+          source: "docker-compose.yml,nginx/,ssl/,scripts/"
           target: "/home/ec2-user/app"
           strip_components: 0
           overwrite: true
 
-        # EC2에 SSH 접속 후 Docker 환경 구성 및 애플리케이션 실행
-      - name: Deploy to EC2 and run Docker Compose
+      # 5. 시스템 환경 설정
+      - name: Setup System Environment
         uses: appleboy/ssh-action@master
         with:
           host: ${{ env.EC2_HOST_VALUE }}
           username: ec2-user
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script: |
-            # Docker 설치 (Amazon Linux 2023 방식)
-            if ! command -v docker &> /dev/null; then
-              sudo dnf update -y
-              sudo dnf install docker -y
-              sudo systemctl start docker
-              sudo systemctl enable docker
-              sudo usermod -aG docker ec2-user
-              # 그룹 적용
-              newgrp docker || true
-            fi
-
-            # Docker Compose 설치
-            if ! command -v docker-compose &> /dev/null; then
-              sudo curl -L "https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-              sudo chmod +x /usr/local/bin/docker-compose
-              sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-            fi
-
             cd /home/ec2-user/app
+            chmod +x scripts/setup-system.sh
+            ./scripts/setup-system.sh
 
-            # certbot 설치 (Amazon Linux 2023)
-            if ! command -v certbot &> /dev/null; then
-              echo "Installing certbot..."
-              sudo dnf install -y python3-pip
-              sudo pip3 install certbot
-            fi
+      # 6. SSL 인증서 설정
+      - name: Setup SSL Certificate
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.EC2_HOST_VALUE }}
+          username: ec2-user
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: |
+            cd /home/ec2-user/app
+            chmod +x scripts/setup-ssl-deployment.sh
+            ./scripts/setup-ssl-deployment.sh ${{ env.SERVER_NAME }}
 
-            # SSL 디렉토리 생성 및 권한 설정
-            sudo mkdir -p /var/www/certbot
-            sudo chmod 755 /var/www/certbot
-            sudo chown -R ec2-user:ec2-user /var/www/certbot
+      # 7. 애플리케이션 배포
+      - name: Deploy Application
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.EC2_HOST_VALUE }}
+          username: ec2-user
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: |
+            cd /home/ec2-user/app
+            chmod +x scripts/deploy-application.sh
+            ./scripts/deploy-application.sh "${{ env.ENV_VALUE }}" ${{ secrets.DOCKERHUB_USERNAME }} ${{ secrets.DOCKERHUB_TOKEN }} ${{ env.SERVER_NAME }}
 
-            # .env 파일 작성
-            printf "%b\n" "${{ env.ENV_VALUE }}" > .env
-            echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> .env
-            echo "SERVER_NAME=${{ env.SERVER_NAME }}" >> .env
-            
-            # SSL 설정 실행 권한 부여
-            chmod +x ssl/setup-ssl.sh ssl/renew-ssl.sh ssl/ssl-health-check.sh
-            
-            # Docker Hub 로그인
-            echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+      # 8. SSL 자동 갱신 설정
+      - name: Setup SSL Auto Renewal
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.EC2_HOST_VALUE }}
+          username: ec2-user
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: |
+            cd /home/ec2-user/app
+            chmod +x scripts/setup-ssl-renewal.sh
+            ./scripts/setup-ssl-renewal.sh
 
-            # Docker 이미지 pull
-            echo "Pulling latest Docker image..."
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/desserbee:latest
-
-            echo "Stopping existing containers..."
-            docker-compose down || true
-
-            # SSL 인증서 존재 여부에 따른 분기 처리
-            if [ ! -d "/etc/letsencrypt/live/${{ env.SERVER_NAME }}" ]; then
-              echo "=== 첫 번째 배포: SSL 인증서 초기 설정 ==="
-            
-              # HTTP 전용 임시 nginx 설정 생성
-              echo "HTTP 전용 nginx 임시 시작..."
-              cat nginx/conf/default-http-only.conf.template | sed "s/\${SERVER_NAME}/${{ env.SERVER_NAME }}/g" > nginx/conf/default-http-only.conf
-            
-              # 임시 nginx 설정으로 시작
-              docker run -d --name temp-nginx \
-                -p 80:80 \
-                -v $(pwd)/nginx/conf/default-http-only.conf:/etc/nginx/conf.d/default.conf \
-                -v /var/www/certbot:/var/www/certbot:ro \
-                nginx:latest
-
-              # nginx 시작 대기
-              echo "nginx 시작 대기 중..."
-              sleep 5
-
-              echo "SSL 인증서 발급 중..."
-              ./ssl/setup-ssl.sh ${{ env.SERVER_NAME }}
-            
-              # 임시 nginx 컨테이너 정리
-              docker stop temp-nginx || true
-              docker rm temp-nginx || true
-            
-              echo "정식 nginx 설정으로 전환..."
-            else
-              echo "=== 기존 SSL 인증서 발견: 정상 배포 진행 ==="
-            fi
-
-            # Nginx 설정 파일 생성 (템플릿에서 서버 이름 변수 치환)
-            mkdir -p nginx/conf
-            cat nginx/conf/default.conf.template | sed "s/\${SERVER_NAME}/${{ env.SERVER_NAME }}/g" > nginx/conf/default.conf
-
-            echo "Starting containers with Docker Compose..."
-            docker-compose up -d
-
-            # SSL 자동 갱신 cron job 설정
-            ./ssl/renew-ssl.sh setup-cron
-
-            # 배포 완료 후 SSL 상태 확인
-            echo "SSL 상태 확인 중..."
-            ./ssl/ssl-health-check.sh ${{ env.SERVER_NAME }}
-
-            echo "Deployment completed at $(date) for branch ${{ github.ref_name }}"
+      # 9. 배포 상태 확인
+      - name: Verify Deployment
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.EC2_HOST_VALUE }}
+          username: ec2-user
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: |
+            cd /home/ec2-user/app
+            chmod +x scripts/verify-deployment.sh
+            ./scripts/verify-deployment.sh ${{ env.SERVER_NAME }} ${{ github.ref_name }}

--- a/scripts/deploy-application.sh
+++ b/scripts/deploy-application.sh
@@ -17,6 +17,28 @@ fi
 
 echo "=== 애플리케이션 배포 시작 ==="
 
+# 헬스체크 스크립트 확인
+HEALTH_CHECK_SCRIPT="./scripts/health-check.sh"
+if [ ! -f "$HEALTH_CHECK_SCRIPT" ]; then
+    echo "헬스체크 스크립트를 찾을 수 없습니다: $HEALTH_CHECK_SCRIPT"
+    echo "배포를 위해서는 헬스체크 스크립트가 필요합니다."
+    exit 1
+fi
+
+# 헬스체크 함수
+check_core_services() {
+    local timeout=${1:-60}
+
+    echo "헬스체크 실행 중..."
+    if $HEALTH_CHECK_SCRIPT all "$timeout"; then
+        echo "모든 핵심 서비스가 정상 작동합니다"
+        return 0
+    else
+        echo "일부 서비스에 문제가 있습니다"
+        return 1
+    fi
+}
+
 # .env 파일 작성
 echo ".env 파일 생성 중..."
 printf "%b\n" "$ENV_VALUE" > .env
@@ -33,6 +55,10 @@ if docker-compose ps --format "table {{.Image}}" | grep -q "$DOCKERHUB_USERNAME/
     CURRENT_IMAGE_ID=$(docker-compose ps --format "table {{.Image}}" | grep "$DOCKERHUB_USERNAME/desserbee" | head -1 | awk '{print $2}')
     echo "현재 실행 중인 이미지: $CURRENT_IMAGE_ID"
 fi
+
+# Docker 이미지 pull
+echo "Docker 이미지 다운로드 중..."
+docker pull $DOCKERHUB_USERNAME/desserbee:latest
 
 echo "Redis 상태 확인 중..."
 if docker-compose ps redis | grep -q "Up.*healthy"; then
@@ -55,7 +81,7 @@ sleep 15
 
 # 배포 성공 여부 확인
 echo "배포 상태 확인 중..."
-if docker-compose ps | grep -q "Up"; then
+if check_core_services 60; then  # 60초 타임아웃
     echo "배포 성공! 이전 이미지 정리를 진행합니다."
 
     # 사용하지 않는 이미지 정리 (dangling images)
@@ -85,10 +111,25 @@ else
         docker-compose up -d
         sed -i "s/:rollback/:latest/g" docker-compose.yml  # 원복
 
-        if docker-compose ps | grep -q "Up"; then
+        if check_core_services 90; then  # 90초 타임아웃
             echo "롤백 성공"
         else
-            echo "롤백도 실패"
+            echo "롤백도 실패 - 긴급 대응 필요!"
+
+            # 에러 로그 수집
+            echo "에러 로그 수집 중..."
+            {
+                echo "=== 롤백 실패 로그 - $(date) ==="
+                echo "서버: $SERVER_NAME"
+                echo "Docker 컨테이너 상태:"
+                docker-compose ps
+                echo "App 로그 (최근 20줄):"
+                docker-compose logs --tail=20 app 2>/dev/null || echo "App 로그 수집 실패"
+                echo "Nginx 로그 (최근 20줄):"
+                docker-compose logs --tail=20 nginx 2>/dev/null || echo "Nginx 로그 수집 실패"
+            } | sudo tee /var/log/rollback-failure-$(date +%Y%m%d_%H%M%S).log >/dev/null
+
+            echo "수동 개입이 필요합니다. 로그를 확인하세요."
         fi
     else
         echo "이전 이미지 정보가 없어 롤백할 수 없습니다."

--- a/scripts/deploy-application.sh
+++ b/scripts/deploy-application.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# 애플리케이션 배포 스크립트
+# 사용법: ./deploy-application.sh "<ENV_VALUE>" <DOCKERHUB_USERNAME> <DOCKERHUB_TOKEN> <SERVER_NAME>
+
+set -e
+
+ENV_VALUE="$1"
+DOCKERHUB_USERNAME="$2"
+DOCKERHUB_TOKEN="$3"
+SERVER_NAME="$4"
+
+if [ -z "$ENV_VALUE" ] || [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ] || [ -z "$SERVER_NAME" ]; then
+    echo "사용법: $0 \"<ENV_VALUE>\" <DOCKERHUB_USERNAME> <DOCKERHUB_TOKEN> <SERVER_NAME>"
+    exit 1
+fi
+
+echo "=== 애플리케이션 배포 시작 ==="
+
+# .env 파일 작성
+echo ".env 파일 생성 중..."
+printf "%b\n" "$ENV_VALUE" > .env
+echo "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME" >> .env
+echo "SERVER_NAME=$SERVER_NAME" >> .env
+
+# Docker Hub 로그인
+echo "Docker Hub 로그인 중..."
+echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+
+# 현재 실행 중인 이미지 ID 백업 (롤백용)
+CURRENT_IMAGE_ID=""
+if docker-compose ps --format "table {{.Image}}" | grep -q "$DOCKERHUB_USERNAME/desserbee"; then
+    CURRENT_IMAGE_ID=$(docker-compose ps --format "table {{.Image}}" | grep "$DOCKERHUB_USERNAME/desserbee" | head -1 | awk '{print $2}')
+    echo "현재 실행 중인 이미지: $CURRENT_IMAGE_ID"
+fi
+
+echo "Redis 상태 확인 중..."
+if docker-compose ps redis | grep -q "Up.*healthy"; then
+    echo "Redis 정상 - 보존 배포 실행"
+    echo "기존 컨테이너 중지 중...(앱과 엔진엑스만)" # 레디스는 인기검색어 유지를 위해 냅둠.
+    docker-compose stop app nginx || true
+else
+    echo "Redis 이상 또는 미실행 - 전체 재시작 실행"
+    echo "기존 컨테이너 전체 중지 중..."
+    docker-compose down || true
+fi
+
+# 새 컨테이너 시작
+echo "새 컨테이너 시작 중..."
+docker-compose up -d
+
+# 컨테이너 시작 대기 및 헬스체크
+echo "컨테이너 시작 대기 중..."
+sleep 15
+
+# 배포 성공 여부 확인
+echo "배포 상태 확인 중..."
+if docker-compose ps | grep -q "Up"; then
+    echo "배포 성공! 이전 이미지 정리를 진행합니다."
+
+    # 사용하지 않는 이미지 정리 (dangling images)
+    echo "사용하지 않는 이미지 정리 중..."
+    docker image prune -f
+
+    # 이전 버전 이미지 정리 (현재 latest 제외하고 같은 repository 이미지들)
+    echo "이전 버전 이미지 정리 중..."
+    OLD_IMAGES=$(docker images $DOCKERHUB_USERNAME/desserbee --format "table {{.ID}} {{.Tag}}" | grep -v "latest" | awk '{print $1}' | head -5)
+    if [ -n "$OLD_IMAGES" ]; then
+        echo "정리할 이전 이미지들: $OLD_IMAGES"
+        echo "$OLD_IMAGES" | xargs -r docker rmi -f || true
+    fi
+
+    # 전체 시스템 정리 (사용하지 않는 네트워크, 볼륨 등)
+    echo "시스템 정리 중..."
+    docker system prune -f --volumes
+
+else
+    echo "배포 실패! 롤백을 시도합니다."
+
+    # 롤백 시도
+    if [ -n "$CURRENT_IMAGE_ID" ]; then
+        echo "이전 이미지로 롤백 중: $CURRENT_IMAGE_ID"
+        docker tag $CURRENT_IMAGE_ID $DOCKERHUB_USERNAME/desserbee:rollback
+        sed -i "s/:latest/:rollback/g" docker-compose.yml
+        docker-compose up -d
+        sed -i "s/:rollback/:latest/g" docker-compose.yml  # 원복
+
+        if docker-compose ps | grep -q "Up"; then
+            echo "롤백 성공"
+        else
+            echo "롤백도 실패"
+        fi
+    else
+        echo "이전 이미지 정보가 없어 롤백할 수 없습니다."
+    fi
+    exit 1
+fi
+
+# 최종 디스크 사용량 확인
+echo "=== 정리 후 디스크 사용량 ==="
+echo "Docker 이미지 목록:"
+docker images $DOCKERHUB_USERNAME/desserbee
+
+echo "Docker 전체 사용량:"
+docker system df
+
+# 컨테이너 상태 확인
+echo "컨테이너 상태 확인:"
+docker-compose ps
+
+echo "=== 애플리케이션 배포 완료 ==="

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+
+# 서비스 헬스체크 스크립트
+# 사용법:
+#   ./health-check.sh <서비스명> [타임아웃]
+#   ./health-check.sh all [타임아웃]
+#   ./health-check.sh --config <설정파일>
+
+set -e
+
+# 기본 설정
+DEFAULT_TIMEOUT=60
+HEALTH_CHECK_CONFIG="health-check.conf"
+
+# 색상 출력
+print_status() {
+    local status=$1
+    local message=$2
+    case $status in
+        "OK")
+            echo -e "\033[32m $message\033[0m"
+            ;;
+        "FAIL")
+            echo -e "\033[31m $message\033[0m"
+            ;;
+        "WARN")
+            echo -e "\033[33m $message\033[0m"
+            ;;
+        "INFO")
+            echo -e "\033[36m $message\033[0m"
+            ;;
+    esac
+}
+
+# 기본 서비스 설정 (설정 파일이 없을 때 사용)
+init_default_config() {
+    cat > "$HEALTH_CHECK_CONFIG" <<EOF
+# 헬스체크 설정 파일
+# 형식: SERVICE_NAME:CONTAINER_NAME:CHECK_TYPE:CHECK_COMMAND:PORT
+
+# 핵심 서비스
+app:desserbee-app:http:/actuator/health:8080
+nginx:desserbee-nginx:container::
+redis:desserbee-redis:redis:ping:6379
+EOF
+    print_status "INFO" "기본 설정 파일 생성: $HEALTH_CHECK_CONFIG"
+}
+
+# 설정 파일 로드
+load_config() {
+    if [ ! -f "$HEALTH_CHECK_CONFIG" ]; then
+        print_status "WARN" "설정 파일이 없습니다. 기본 설정을 생성합니다."
+        init_default_config
+    fi
+
+    # 주석과 빈 줄 제거하여 서비스 목록 추출
+    SERVICES=($(grep -v '^#' "$HEALTH_CHECK_CONFIG" | grep -v '^$'))
+}
+
+# 컨테이너 상태 확인
+check_container_status() {
+    local service_name=$1
+
+    # docker-compose ps 출력에서 해당 서비스의 State 컬럼 추출
+    local container_state=$(docker-compose ps "$service_name" --format "table {{.State}}" | tail -n +2)
+
+    # 상태가 비어있으면 컨테이너가 없음
+    if [ -z "$container_state" ]; then
+        return 1
+    fi
+
+    # State가 "Up"으로 시작하고 "unhealthy"가 포함되지 않은 경우만 정상
+    if [[ "$container_state" =~ ^Up ]] && [[ ! "$container_state" =~ unhealthy ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# 개별 서비스 헬스체크
+check_service() {
+    local service_config=$1
+    local timeout=${2:-$DEFAULT_TIMEOUT}
+
+    # 설정 파싱
+    IFS=':' read -r service_name container_name check_type check_command port <<< "$service_config"
+
+    print_status "INFO" "[$service_name] 헬스체크 시작 (timeout: ${timeout}s)"
+
+    local service_healthy=false
+
+    for i in $(seq 1 $timeout); do
+        # 1. 컨테이너 상태 확인
+        if ! check_container_status "$service_name"; then
+            if [ $i -eq 1 ]; then
+                print_status "INFO" "[$service_name] 컨테이너 시작 대기 중..."
+            fi
+            if [ $i -eq $timeout ]; then
+                local container_state=$(docker-compose ps "$service_name" --format "table {{.State}}" | tail -n +2)
+                if [ -z "$container_state" ]; then
+                    print_status "FAIL" "[$service_name] 컨테이너를 찾을 수 없습니다"
+                else
+                    print_status "FAIL" "[$service_name] 컨테이너 상태 비정상: $container_state"
+                fi
+                return 1
+            fi
+            sleep 3
+            continue
+        fi
+
+        # 2. 서비스별 헬스체크
+        case "$check_type" in
+            "http")
+                # HTTP 헬스체크
+                if docker-compose exec -T "$service_name" curl -f "http://localhost:${port}${check_command}" >/dev/null 2>&1; then
+                    service_healthy=true
+                elif [ $i -eq $timeout ]; then
+                    print_status "FAIL" "[$service_name] HTTP 헬스체크 실패: http://localhost:${port}${check_command}"
+                    return 1
+                fi
+                ;;
+            "redis")
+                # Redis 헬스체크
+                if docker-compose exec -T "$service_name" redis-cli ping | grep -q "PONG" >/dev/null 2>&1; then
+                    service_healthy=true
+                elif [ $i -eq $timeout ]; then
+                    print_status "FAIL" "[$service_name] Redis ping 실패"
+                    return 1
+                fi
+                ;;
+            "container")
+                # 컨테이너 상태만 확인 (이미 위에서 확인됐기에 여기서는 간ㄷ)
+                service_healthy=true
+                ;;
+            "custom")
+                # 커스텀 명령어 실행
+                if eval "$check_command" >/dev/null 2>&1; then
+                    service_healthy=true
+                elif [ $i -eq $timeout ]; then
+                    print_status "FAIL" "[$service_name] 커스텀 헬스체크 실패: $check_command"
+                    return 1
+                fi
+                ;;
+            *)
+                print_status "WARN" "[$service_name] 알 수 없는 헬스체크 타입: $check_type"
+                service_healthy=true  # 컨테이너 상태만으로 판단
+                ;;
+        esac
+
+        if [ "$service_healthy" = true ]; then
+            print_status "OK" "[$service_name] 서비스 정상"
+            return 0
+        fi
+
+        if [ $i -lt $timeout ]; then
+            sleep 3
+        fi
+    done
+
+    print_status "FAIL" "[$service_name] 헬스체크 타임아웃"
+    return 1
+}
+
+# 모든 서비스 헬스체크
+check_all_services() {
+    local timeout=${1:-$DEFAULT_TIMEOUT}
+    local failed_services=()
+    local total_services=0
+
+    print_status "INFO" "=== 전체 서비스 헬스체크 시작 ==="
+
+    for service_config in "${SERVICES[@]}"; do
+        total_services=$((total_services + 1))
+        service_name=$(echo "$service_config" | cut -d':' -f1)
+
+        if ! check_service "$service_config" "$timeout"; then
+            failed_services+=("$service_name")
+        fi
+        echo ""
+    done
+
+    print_status "INFO" "=== 헬스체크 결과 요약 ==="
+    print_status "INFO" "총 서비스 수: $total_services"
+    print_status "INFO" "성공: $((total_services - ${#failed_services[@]}))"
+    print_status "INFO" "실패: ${#failed_services[@]}"
+
+    if [ ${#failed_services[@]} -eq 0 ]; then
+        print_status "OK" "모든 서비스가 정상 작동합니다"
+        return 0
+    else
+        print_status "FAIL" "실패한 서비스: ${failed_services[*]}"
+        return 1
+    fi
+}
+
+# 서비스 목록 출력
+list_services() {
+    load_config
+    echo "설정된 서비스 목록:"
+    echo "===================="
+    for service_config in "${SERVICES[@]}"; do
+        IFS=':' read -r service_name container_name check_type check_command port <<< "$service_config"
+        echo "서비스: $service_name"
+        echo "  컨테이너: $container_name"
+        echo "  헬스체크: $check_type"
+        echo "  명령어: $check_command"
+        echo "  포트: $port"
+        echo ""
+    done
+}
+
+# 사용법 출력
+show_usage() {
+    echo "사용법: $0 [OPTIONS] <서비스명|all> [타임아웃]"
+    echo ""
+    echo "옵션:"
+    echo "  --config <파일>    설정 파일 지정 (기본: health-check.conf)"
+    echo "  --list            설정된 서비스 목록 출력"
+    echo "  --init            기본 설정 파일 생성"
+    echo "  --help            도움말 출력"
+    echo ""
+    echo "예시:"
+    echo "  $0 app              # app 서비스만 헬스체크"
+    echo "  $0 all              # 모든 서비스 헬스체크"
+    echo "  $0 all 120          # 120초 타임아웃으로 모든 서비스 헬스체크"
+    echo "  $0 --list           # 설정된 서비스 목록 출력"
+    echo ""
+    echo "설정 파일 형식 (health-check.conf):"
+    echo "  서비스명:컨테이너명:체크타입:체크명령어:포트"
+    echo ""
+    echo "지원하는 체크 타입:"
+    echo "  container  - 컨테이너 상태만 확인"
+    echo "  http       - HTTP 헬스체크"
+    echo "  redis      - Redis ping"
+    echo "  custom     - 커스텀 명령어 실행"
+}
+
+# 메인 실행부
+main() {
+    # 옵션 파싱
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --config)
+                HEALTH_CHECK_CONFIG="$2"
+                shift 2
+                ;;
+            --list)
+                load_config
+                list_services
+                exit 0
+                ;;
+            --init)
+                init_default_config
+                exit 0
+                ;;
+            --help)
+                show_usage
+                exit 0
+                ;;
+            -*)
+                echo "알 수 없는 옵션: $1"
+                show_usage
+                exit 1
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    # 인자 확인
+    if [ $# -eq 0 ]; then
+        show_usage
+        exit 1
+    fi
+
+    local target_service=$1
+    local timeout=${2:-$DEFAULT_TIMEOUT}
+
+    # 설정 로드
+    load_config
+
+    if [ "$target_service" = "all" ]; then
+        check_all_services "$timeout"
+    else
+        # 특정 서비스 검색
+        local found=false
+        for service_config in "${SERVICES[@]}"; do
+            service_name=$(echo "$service_config" | cut -d':' -f1)
+            if [ "$service_name" = "$target_service" ]; then
+                check_service "$service_config" "$timeout"
+                found=true
+                break
+            fi
+        done
+
+        if [ "$found" = false ]; then
+            print_status "FAIL" "서비스를 찾을 수 없습니다: $target_service"
+            echo ""
+            print_status "INFO" "사용 가능한 서비스:"
+            for service_config in "${SERVICES[@]}"; do
+                service_name=$(echo "$service_config" | cut -d':' -f1)
+                echo "  - $service_name"
+            done
+            exit 1
+        fi
+    fi
+}
+
+# 스크립트 실행
+main "$@"

--- a/scripts/setup-ssl-deployment.sh
+++ b/scripts/setup-ssl-deployment.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# SSL 인증서 배포 설정 스크립트
+# 사용법: ./setup-ssl-deployment.sh <도메인명>
+
+set -e
+
+DOMAIN=$1
+
+if [ -z "$DOMAIN" ]; then
+    echo "사용법: $0 <도메인명>"
+    exit 1
+fi
+
+echo "=== SSL 인증서 배포 설정 시작 ==="
+echo "도메인: $DOMAIN"
+
+# SSL 스크립트 실행 권한 부여
+chmod +x ssl/setup-ssl.sh ssl/renew-ssl.sh ssl/ssl-health-check.sh
+
+# SSL 인증서 존재 여부에 따른 분기 처리
+if [ ! -d "/etc/letsencrypt/live/$DOMAIN" ]; then
+  echo "=== 첫 번째 배포: SSL 인증서 초기 설정 ==="
+
+  # HTTP 전용 임시 nginx 설정 생성
+  echo "HTTP 전용 nginx 임시 시작..."
+  cat nginx/conf/default-http-only.conf.template | sed "s/\${SERVER_NAME}/$DOMAIN/g" > nginx/conf/default-http-only.conf
+
+  # 임시 nginx 설정으로 시작
+  docker run -d --name temp-nginx \
+    -p 80:80 \
+    -v $(pwd)/nginx/conf/default-http-only.conf:/etc/nginx/conf.d/default.conf \
+    -v /var/www/certbot:/var/www/certbot:ro \
+    nginx:latest
+
+  # nginx 시작 대기
+  echo "nginx 시작 대기 중..."
+  sleep 10
+
+  echo "SSL 인증서 발급 중..."
+  ./ssl/setup-ssl.sh $DOMAIN
+
+  # 임시 nginx 컨테이너 정리
+  docker stop temp-nginx || true
+  docker rm temp-nginx || true
+
+  echo "SSL 인증서 초기 설정 완료"
+else
+  echo "=== 기존 SSL 인증서 발견: 정상 배포 진행 ==="
+fi
+
+# Nginx 설정 파일 생성 (템플릿에서 서버 이름 변수 치환)
+echo "Nginx 설정 파일 생성 중..."
+mkdir -p nginx/conf
+cat nginx/conf/default.conf.template | sed "s/\${SERVER_NAME}/$DOMAIN/g" > nginx/conf/default.conf
+
+echo "=== SSL 배포 설정 완료 ==="

--- a/scripts/setup-ssl-renewal.sh
+++ b/scripts/setup-ssl-renewal.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# SSL 자동 갱신 설정 스크립트
+set -e
+
+echo "=== SSL 자동 갱신 설정 시작 ==="
+
+# SSL 자동 갱신 cron job 설정
+echo "SSL 자동 갱신 cron job 설정 중..."
+./ssl/renew-ssl.sh setup-cron
+
+# cron job 설정 확인 및 강제 등록 (혹시 실패했을 경우)
+if ! crontab -l 2>/dev/null | grep -q "renew-ssl.sh"; then
+  echo "cron job 강제 등록 중..."
+  (crontab -l 2>/dev/null; echo "0 6,18 * * * /home/ec2-user/app/ssl/renew-ssl.sh >> /var/log/ssl-renewal.log 2>&1") | crontab -
+  echo "cron job 강제 등록 완료"
+else
+  echo "cron job 설정 확인됨"
+fi
+
+# cron 서비스 상태 확인
+echo "cron 서비스 상태 확인:"
+sudo systemctl status crond --no-pager || true
+
+# 설정된 cron job 표시
+echo "현재 설정된 SSL 갱신 cron job:"
+crontab -l | grep renew-ssl || echo "cron job 설정 없음"
+
+echo "=== SSL 자동 갱신 설정 완료 ==="

--- a/scripts/setup-system.sh
+++ b/scripts/setup-system.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# 시스템 환경 설정 스크립트
+set -e
+
+echo "=== 시스템 환경 설정 시작 ==="
+
+# Docker 설치 (Amazon Linux 2023 방식)
+if ! command -v docker &> /dev/null; then
+  echo "Installing Docker..."
+  sudo dnf update -y
+  sudo dnf install docker -y
+  sudo systemctl start docker
+  sudo systemctl enable docker
+  sudo usermod -aG docker ec2-user
+  # 그룹 적용
+  newgrp docker || true
+  echo "Docker 설치 완료"
+else
+  echo "Docker 이미 설치됨"
+fi
+
+# Docker Compose 설치
+if ! command -v docker-compose &> /dev/null; then
+  echo "Installing Docker Compose..."
+  sudo curl -L "https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  sudo chmod +x /usr/local/bin/docker-compose
+  sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+  echo "Docker Compose 설치 완료"
+else
+  echo "Docker Compose 이미 설치됨"
+fi
+
+# cron 설치 및 시작 (SSL 자동 갱신용)
+if ! command -v crontab &> /dev/null; then
+  echo "Installing cronie..."
+  sudo dnf install -y cronie
+  sudo systemctl start crond
+  sudo systemctl enable crond
+  echo "Cron 설치 및 시작 완료"
+else
+  echo "Cron 이미 설치됨"
+  sudo systemctl start crond || true
+  sudo systemctl enable crond || true
+fi
+
+# certbot 설치 (Amazon Linux 2023)
+if ! command -v certbot &> /dev/null; then
+  echo "Installing certbot..."
+  sudo dnf install -y python3-pip
+  sudo pip3 install certbot
+  echo "Certbot 설치 완료"
+else
+  echo "Certbot 이미 설치됨"
+fi
+
+# SSL 디렉토리 생성 및 권한 설정
+echo "SSL 디렉토리 설정 중..."
+sudo mkdir -p /var/www/certbot
+sudo chmod 755 /var/www/certbot
+sudo chown -R ec2-user:ec2-user /var/www/certbot
+
+# 로그 파일 권한 사전 설정 (권한 문제 해결)
+echo "로그 파일 권한 설정 중..."
+sudo touch /var/log/ssl-renewal.log /var/log/ssl-health-check.log
+sudo chown ec2-user:ec2-user /var/log/ssl-renewal.log /var/log/ssl-health-check.log
+sudo chmod 644 /var/log/ssl-renewal.log /var/log/ssl-health-check.log
+
+echo "=== 시스템 환경 설정 완료 ==="

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# 배포 상태 확인 스크립트
+# 사용법: ./verify-deployment.sh <SERVER_NAME> <BRANCH_NAME>
+
+set -e
+
+SERVER_NAME="$1"
+BRANCH_NAME="$2"
+
+if [ -z "$SERVER_NAME" ] || [ -z "$BRANCH_NAME" ]; then
+    echo "사용법: $0 <SERVER_NAME> <BRANCH_NAME>"
+    exit 1
+fi
+
+echo "========================================"
+echo "배포 상태 종합 확인 시작: $SERVER_NAME"
+echo "브랜치: $BRANCH_NAME"
+echo "========================================"
+
+# SSL 상태 확인
+echo "SSL 상태 확인 중..."
+./ssl/ssl-health-check.sh $SERVER_NAME || true
+echo ""
+
+# 최종 상태 확인
+echo "=== 배포 완료 상태 확인 ==="
+
+echo "Docker 컨테이너 상태:"
+docker-compose ps
+echo ""
+
+echo "cron job 설정 상태:"
+crontab -l | grep renew-ssl || echo "cron job 설정 없음"
+echo ""
+
+echo "SSL 인증서 상태:"
+if sudo ls -la /etc/letsencrypt/live/$SERVER_NAME/ 2>/dev/null; then
+    # 인증서 만료일 확인
+    expiry_date=$(sudo openssl x509 -enddate -noout -in "/etc/letsencrypt/live/$SERVER_NAME/cert.pem" | cut -d= -f2)
+    expiry_epoch=$(date -d "$expiry_date" +%s)
+    current_epoch=$(date +%s)
+    days_until_expiry=$(( (expiry_epoch - current_epoch) / 86400 ))
+    echo "인증서 만료일: $expiry_date"
+    echo "남은 일수: $days_until_expiry일"
+else
+    echo "SSL 인증서 없음"
+fi
+echo ""
+
+echo "HTTPS 연결 테스트:"
+if curl -I https://$SERVER_NAME 2>/dev/null | head -n 1; then
+    echo "HTTPS 연결 성공"
+else
+    echo "HTTPS 연결 실패"
+fi
+echo ""
+
+echo "로그 파일 상태:"
+echo "SSL 갱신 로그: $(ls -la /var/log/ssl-renewal.log 2>/dev/null || echo '없음')"
+echo "SSL 상태 로그: $(ls -la /var/log/ssl-health-check.log 2>/dev/null || echo '없음')"
+echo ""
+
+echo "========================================"
+echo "배포 완료: $(date)"
+echo "도메인: https://$SERVER_NAME"
+echo "브랜치: $BRANCH_NAME"
+echo "========================================"
+
+# 배포 성공 여부 판단
+deployment_success=true
+
+# 필수 컨테이너 상태 확인
+if ! docker-compose ps | grep -q "Up"; then
+    echo "일부 컨테이너가 실행되지 않았습니다."
+    deployment_success=false
+fi
+
+# SSL 인증서 확인
+if [ ! -d "/etc/letsencrypt/live/$SERVER_NAME" ]; then
+    echo "SSL 인증서가 설정되지 않았습니다."
+    deployment_success=false
+fi
+
+# cron job 확인
+if ! crontab -l 2>/dev/null | grep -q "renew-ssl.sh"; then
+    echo "SSL 자동 갱신 cron job이 설정되지 않았습니다."
+fi
+
+if [ "$deployment_success" = true ]; then
+    echo "배포가 성공적으로 완료되었습니다!"
+    exit 0
+else
+    echo "배포 중 일부 문제가 발생했습니다."
+    exit 1
+fi

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -71,9 +71,16 @@ echo "========================================"
 deployment_success=true
 
 # 필수 컨테이너 상태 확인
-if ! docker-compose ps | grep -q "Up"; then
-    echo "일부 컨테이너가 실행되지 않았습니다."
-    deployment_success=false
+if [ -f "./scripts/health-check.sh" ]; then
+    if ! ./scripts/health-check.sh all 10 >/dev/null 2>&1; then
+        echo "일부 서비스가 정상 작동하지 않습니다."
+        deployment_success=false
+    fi
+else
+    if ! docker-compose ps | grep -q "Up"; then
+        echo "일부 컨테이너가 실행되지 않았습니다."
+        deployment_success=false
+    fi
 fi
 
 # SSL 인증서 확인


### PR DESCRIPTION
## :hash: 연관된 이슈
#440 

## :memo: 작업 내용
- 단일 배포 스크립트를 기능별로 모듈화
- 각 단계별로 독립적인 스크립트로 분리하여 디버깅과 개별 테스트를 용이하도록 변경했습니다.
```
scripts/                                    # 배포 스크립트 모듈화
├── setup-system.sh                         # 시스템 환경 자동 설정
├── setup-ssl-deployment.sh                 # SSL 배포 관리
├── deploy-application.sh                   # 애플리케이션 배포 + 이미지 정리
├── setup-ssl-renewal.sh                    # SSL 자동 갱신 설정
└── verify-deployment.sh                    # 배포 상태 종합 검증
```

추가적인 내용들은 아래 문서를 확인해주세요.
https://www.notion.so/CI-CD-SSL-200246cdb8768063b058d8aaa7521156?pvs=4