### PR TITLE
feat: 토큰 응답에 refreshExpiresIn 추가 및 keepLoggedIn 기반 DB 저장 구현

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/dto/response/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/response/LoginResponse.java
@@ -35,8 +35,12 @@ public class LoginResponse {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String tokenType;       // 토큰 타입
+
+    @Schema(description = "리프레시 토큰 만료 시간 (밀리초)", example = "864000000", requiredMode = Schema.RequiredMode.REQUIRED)
+    private long refreshExpiresIn;
+
     @Schema(
-            description = "토큰 만료 시간 (밀리초)",
+            description = "액세스 토큰 만료 시간 (밀리초)",
             example = "259200000",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
@@ -116,40 +120,45 @@ public class LoginResponse {
      * @param isPreferenceSet 선호도 설정 여부
      * @return 로그인 응답 객체
      */
-    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl, String deviceId, boolean isPreferenceSet) {
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, long refreshExpiresIn,
+                                        UserEntity user, String profileImageUrl, String deviceId, boolean isPreferenceSet) {
         return LoginResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .tokenType("Bearer")
                 .expiresIn(expiresIn)
+                .refreshExpiresIn(refreshExpiresIn)
                 .userUuid(user.getUserUuid())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileImageUrl(profileImageUrl)
                 .deviceId(deviceId)
                 .isPreferenceSet(isPreferenceSet)
-                .fromApp(false) // 기본값은 false (웹 로그인)
+                .fromApp(false)
                 .build();
     }
 
     /**
      * 선호도 설정 제외하고 디바이스 ID 포함 응답 생성
      */
-    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl, String deviceId) {
-        return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, deviceId, false);
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, long refreshExpiresIn,
+                                        UserEntity user, String profileImageUrl, String deviceId) {
+        return success(accessToken, refreshToken, expiresIn, refreshExpiresIn, user, profileImageUrl, deviceId, false);
     }
 
     /**
      * 디바이스 ID 없이 선호도 설정 포함
      */
-    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl, boolean isPreferenceSet) {
-        return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, null, isPreferenceSet);
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, long refreshExpiresIn,
+                                        UserEntity user, String profileImageUrl, boolean isPreferenceSet) {
+        return success(accessToken, refreshToken, expiresIn, refreshExpiresIn, user, profileImageUrl, null, isPreferenceSet);
     }
 
     /**
      * 디바이스 ID, 선호도 설정 모두 없음
      */
-    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, UserEntity user, String profileImageUrl) {
-        return success(accessToken, refreshToken, expiresIn, user, profileImageUrl, null, false);
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, long refreshExpiresIn,
+                                        UserEntity user, String profileImageUrl) {
+        return success(accessToken, refreshToken, expiresIn, refreshExpiresIn, user, profileImageUrl, null, false);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthService.java
@@ -23,7 +23,7 @@ public interface AuthService {
      * @param provider 인증 제공자 (local, kakao 등)
      * @param providerId 제공자별 식별자 (소셜 로그인의 경우)
      */
-    String saveRefreshToken(UUID userUuid, String refreshToken, String provider, String providerId, String deviceId);
+    String saveRefreshToken(UUID userUuid, String refreshToken, String provider, String providerId, String deviceId, boolean keepLoggedIn);
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰 발급

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -171,6 +171,7 @@ public class KakaoOAuthService {
         String accessToken = jwtUtil.createAccessToken(user.getUserUuid(), roles);
         String refreshToken = jwtUtil.createRefreshToken(user.getUserUuid(), keepLoggedIn);
         long expiresIn = jwtUtil.getACCESS_TOKEN_EXPIRE();
+        long refreshExpiresIn = keepLoggedIn ? jwtUtil.getLONG_REFRESH_TOKEN_EXPIRE() : jwtUtil.getSHORT_REFRESH_TOKEN_EXPIRE();
 
         // 리프레시 토큰 저장 (디바이스 ID 관리 포함)
         String usedDeviceId = tokenService.saveRefreshToken(
@@ -178,7 +179,8 @@ public class KakaoOAuthService {
                 refreshToken,
                 oauth2Response.getProvider(),
                 oauth2Response.getProviderId(),
-                deviceId
+                deviceId,
+                keepLoggedIn  // 추가된 파라미터
         );
 
         // 프로필 이미지 조회
@@ -187,7 +189,8 @@ public class KakaoOAuthService {
         String profileImageUrl = profileImages.isEmpty() ? null : profileImages.get(0);
 
         boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
-        return LoginResponse.success(accessToken, refreshToken, expiresIn, user, profileImageUrl, usedDeviceId, isPreferenceSet);
+        return LoginResponse.success(accessToken, refreshToken, expiresIn, refreshExpiresIn,
+                user, profileImageUrl, usedDeviceId, isPreferenceSet);
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/TokenService.java
@@ -42,7 +42,7 @@ public class TokenService {
      * 리프레시 토큰을 저장하거나 업데이트
      */
     @Transactional
-    public String saveRefreshToken(UUID userUuid, String refreshToken, String provider, String providerId, String deviceId) {
+    public String saveRefreshToken(UUID userUuid, String refreshToken, String provider, String providerId, String deviceId, boolean keepLoggedIn) {
         UserEntity user = userService.findByUserUuid(userUuid);
         String email = user.getEmail();
 
@@ -83,8 +83,13 @@ public class TokenService {
                         .build();
             }
 
+            long expireTimeMillis = keepLoggedIn ?
+                    jwtUtil.getLONG_REFRESH_TOKEN_EXPIRE() :
+                    jwtUtil.getSHORT_REFRESH_TOKEN_EXPIRE();
+
             LocalDateTime expirationTime = LocalDateTime.now(KST)
-                    .plus(Duration.ofMillis(jwtUtil.getSHORT_REFRESH_TOKEN_EXPIRE()));
+                    .plus(Duration.ofMillis(expireTimeMillis));
+
             auth.updateRefreshToken(refreshToken, expirationTime);
 
             // providerId가 null이 아닌 경우에만 설정


### PR DESCRIPTION
- TokenResponse와 LoginResponse에 refreshExpiresIn 필드 추가
- TokenService.saveRefreshToken에 keepLoggedIn 파라미터 추가

## :hash: 연관된 이슈
#445 

## :memo: 작업 내용
TokenResponse와 LoginResponse에 refreshExpiresIn 필드 추가

- 클라이언트에서 리프레시 토큰의 만료시간을 알 수 있도록 개선
  - 기존 expiresIn(액세스 토큰)과 함께 refreshExpiresIn(리프레시 토큰) 제공

- TokenService.saveRefreshToken에 keepLoggedIn 파라미터 추가
  - DB 저장 시 keepLoggedIn 설정에 따른 올바른 만료시간 적용
  - 기존: 항상 10일로 고정 → 변경: keepLoggedIn에 따라 10일/30일 구분


### 스크린샷 (선택)
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/3a9231d0-1071-4dc9-807a-4355643a9463" />
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/9cd47098-d633-4be0-8e01-274ff226acfb" />
