### PR TITLE
[MERGE] Docker Compose --format 옵션 호환성 문제 해결 

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
+++ b/src/main/java/org/swyp/dessertbee/auth/repository/AuthRepository.java
@@ -3,6 +3,7 @@ package org.swyp.dessertbee.auth.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.auth.entity.AuthEntity;
 import org.swyp.dessertbee.user.entity.UserEntity;
 
@@ -10,6 +11,7 @@ import java.util.Optional;
 import java.util.List;
 import java.util.UUID;
 
+@Repository
 public interface AuthRepository extends JpaRepository<AuthEntity, Integer> {
     /**
      * 사용자와 인증 제공자로 인증 정보 조회


### PR DESCRIPTION
- health-check.sh에서 --format "table {{.State}}" 에러 해결
- Docker Compose v2.18.1에서 지원하지 않는 --format 옵션을 텍스트 파싱 방식으로 변경