### PR TITLE
[FIX] reset password request dto update

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -281,7 +281,11 @@ public class AuthController {
                     )
             }
     )
-    @ApiResponse(responseCode = "200", description = "비밀번호 재설정 성공")
+    @ApiResponse(
+            responseCode = "200",
+            description = "비밀번호 재설정 성공",
+            content = @Content(schema = @Schema(implementation = PasswordResetResponse.class))
+    )
     @ApiErrorResponses({ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.USER_NOT_FOUND, ErrorCode.PASSWORD_MISMATCH})
     @PostMapping("/password/reset")
     public ResponseEntity<PasswordResetResponse> resetPassword(
@@ -294,8 +298,7 @@ public class AuthController {
             )
             @Valid @RequestBody PasswordResetRequest request
     ) {
-        authService.resetPassword(request, verificationToken);
-        return ResponseEntity.ok().build();
+        PasswordResetResponse response = authService.resetPassword(request, verificationToken);
+        return ResponseEntity.ok(response);
     }
-
 }

--- a/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/AuthController.java
@@ -282,7 +282,7 @@ public class AuthController {
             }
     )
     @ApiResponse(responseCode = "200", description = "비밀번호 재설정 성공")
-    @ApiErrorResponses({ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.USER_NOT_FOUND})
+    @ApiErrorResponses({ErrorCode.INVALID_VERIFICATION_TOKEN, ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.USER_NOT_FOUND, ErrorCode.PASSWORD_MISMATCH})
     @PostMapping("/password/reset")
     public ResponseEntity<PasswordResetResponse> resetPassword(
             @Parameter(description = "이메일 인증 토큰", required = true)

--- a/src/main/java/org/swyp/dessertbee/auth/dto/request/PasswordResetRequest.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/request/PasswordResetRequest.java
@@ -19,13 +19,13 @@ public class PasswordResetRequest {
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;            // 사용자 이메일
 
-    @NotBlank(message = "현재 비밀번호는 필수 입력값입니다.")
-    private String currentPassword;  // 현재 비밀번호
-
     @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
     @Pattern(
             regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
             message = "비밀번호는 8자 이상, 영문자, 숫자, 특수문자를 포함해야 합니다."
     )
     private String newPassword;      // 새로운 비밀번호
+
+    @NotBlank(message = "비밀번호 확인은 필수 입력값입니다.")
+    private String confirmNewPassword;  // 비밀번호 확인
 }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/response/PasswordResetResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/response/PasswordResetResponse.java
@@ -5,6 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -12,11 +15,15 @@ import lombok.NoArgsConstructor;
 public class PasswordResetResponse {
     private boolean success;
     private String message;
+    private int status;
+    private LocalDateTime timestamp;
 
     public static PasswordResetResponse success() {
         return PasswordResetResponse.builder()
                 .success(true)
                 .message("비밀번호가 성공적으로 변경되었습니다.")
+                .status(200)
+                .timestamp(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
                 .build();
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -300,6 +300,10 @@ public class AuthServiceImpl implements AuthService {
                     EmailVerificationPurpose.PASSWORD_RESET
             );
 
+            if (!request.getNewPassword().equals(request.getConfirmNewPassword())) {
+                throw new PasswordMismatchException();
+            }
+
             // 사용자 조회
             UserEntity user = userService.findUserByEmail(request.getEmail());
 


### PR DESCRIPTION
## :hash: 연관된 이슈
#455 
## :memo: 작업 내용
-  불필요한 현재 비밀번호 필드를 제거, 비밀번호 확인 검증 로직을 추가
- PasswordResetResponse에 status, timestamp 필드 추가 응답 구조 표준화
- API 문서에 PASSWORD_MISMATCH 에러 케이스 추가

### 스크린샷 (선택)
<img width="755" alt="image" src="https://github.com/user-attachments/assets/d8f54bd3-e68f-4e5e-bebd-adc7ba7779a0" />
