### PR TITLE
[Feature] 디저트메이트 요청현황에 차단자 뜨지 않도록 작업

### DIFF
--- a/src/main/java/org/swyp/dessertbee/community/mate/repository/MateMemberRepository.java
+++ b/src/main/java/org/swyp/dessertbee/community/mate/repository/MateMemberRepository.java
@@ -49,4 +49,6 @@ public interface MateMemberRepository extends JpaRepository<MateMember, Long> {
     Long countByMateId(Long mateId);
 
     Page<MateMember> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
+
+    List<MateMember> findByMateIdAndDeletedAtIsNullAndApplyStatusAndUserIdNotIn(Long mateId, MateApplyStatus mateApplyStatus, List<Long> blockedUserIds);
 }


### PR DESCRIPTION
## :hash: 연관된 이슈

> 442

## :memo: 작업 내용

> 디저트메이트 차단한 사람이 신청을 했을 때 "차단자"에게 요청이 뜨지 않도록 작업(신청 데이터는 들어가되 조회는 x)

### 스크린샷 (선택)

> 차단하기 전(디저트 메이트 요청 현황 api)
<img width="753" alt="스크린샷 2025-06-06 오전 2 16 14" src="https://github.com/user-attachments/assets/4f456580-cf5e-4b1d-97b3-d921facbf3e7" />

> 차단
<img width="637" alt="스크린샷 2025-06-06 오전 2 16 20" src="https://github.com/user-attachments/assets/a7654df1-1f37-4be8-851d-b5ba8cf8b3e4" />

> 차단 후(디저트 메이트 요청 현황 api)
<img width="627" alt="스크린샷 2025-06-06 오전 2 16 25" src="https://github.com/user-attachments/assets/bd0800dc-722b-424d-b02f-3ecc244eb061" />

