### PR TITLE
[FIX] 유저 하드 삭제 에러 처리

### DIFF
--- a/src/main/java/org/swyp/dessertbee/store/saved/repository/UserStoreListRepository.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/repository/UserStoreListRepository.java
@@ -1,6 +1,9 @@
 package org.swyp.dessertbee.store.saved.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.swyp.dessertbee.store.saved.entity.UserStoreList;
 import org.swyp.dessertbee.user.entity.UserEntity;
@@ -13,4 +16,11 @@ public interface UserStoreListRepository extends JpaRepository<UserStoreList, Lo
 
     /** 특정 유저가 같은 이름을 가진 저장 리스트가 있는지 확인 */
     boolean existsByUserAndListName(UserEntity user, String listName);
+
+    /**
+     * 특정 사용자의 모든 스토어 리스트 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM UserStoreList usl WHERE usl.user.id = :userId")
+    int deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/saved/service/UserStoreService.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/service/UserStoreService.java
@@ -36,4 +36,7 @@ public interface UserStoreService {
 
     /** 리스트에서 가게 삭제 */
     void removeStoreFromList(Long listId, UUID storeUuid);
+
+    /** 특정 사용자의 모든 스토어 리스트 삭제 (Hard Delete용) */
+    int deleteAllUserStoreLists(Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/store/saved/service/UserStoreServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/store/saved/service/UserStoreServiceImpl.java
@@ -397,4 +397,31 @@ public class UserStoreServiceImpl implements UserStoreService {
             throw new UserStoreServiceException("리스트에 가게 저장 취소 처리 중 오류가 발생했습니다.");
         }
     }
+
+    /** 특정 사용자의 모든 스토어 리스트 삭제 (Hard Delete용) */
+    @Override
+    public int deleteAllUserStoreLists(Long userId) {
+        try {
+            UserEntity user = userRepository.findById(userId)
+                    .orElseThrow(UserNotFoundException::new);
+
+            // 해당 사용자의 모든 저장 리스트 조회
+            List<UserStoreList> userStoreLists = userStoreListRepository.findByUser(user);
+
+            // 각 리스트의 저장된 가게들 먼저 삭제
+            for (UserStoreList list : userStoreLists) {
+                savedStoreRepository.deleteByUserStoreList(list);
+            }
+
+            // 스토어 리스트 삭제
+            int deletedCount = userStoreListRepository.deleteByUserId(userId);
+
+            log.info("사용자 ID {} 의 모든 스토어 리스트 삭제 완료 - {} 개 리스트", userId, deletedCount);
+            return deletedCount;
+
+        } catch (Exception e) {
+            log.error("사용자 스토어 리스트 삭제 처리 중 오류 발생 - userId: {}", userId, e);
+            throw new UserStoreServiceException("사용자 스토어 리스트 삭제 처리 중 오류가 발생했습니다.");
+        }
+    }
 }

--- a/src/main/java/org/swyp/dessertbee/user/controller/UserTestController.java
+++ b/src/main/java/org/swyp/dessertbee/user/controller/UserTestController.java
@@ -1,0 +1,41 @@
+package org.swyp.dessertbee.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.swyp.dessertbee.user.service.UserTestService;
+import java.util.Map;
+
+/**
+ * 사용자 테스트용 컨트롤러
+ * 릴리즈 환경에서만 활성화되며, 테스트 사용자 데이터 정리를 위한 Hard Delete 기능을 제공
+ */
+@RestController
+@RequestMapping("/api/users/test")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "User Test", description = "사용자 테스트 API (릴리즈 환경 전용)")
+public class UserTestController {
+
+    private final UserTestService userTestService;
+
+    @Operation(
+            summary = "현재 로그인 사용자 완전 삭제 (Hard Delete)",
+            description = "JWT 토큰 기반으로 현재 로그인한 사용자와 관련된 모든 데이터를 완전히 삭제합니다. 관리자 권한 필요."
+    )
+    @DeleteMapping("/me/hard-delete")
+    public ResponseEntity<Map<String, String>> hardDeleteMyAccount() {
+
+        log.warn("현재 로그인 사용자 테스트용 Hard Delete API 호출");
+
+        String deletedEmail = userTestService.hardDeleteCurrentUserWithAllRelatedData();
+
+        return ResponseEntity.ok(
+                Map.of("message", "현재 사용자가 완전히 삭제되었습니다.", "email", deletedEmail)
+        );
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserBlockRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserBlockRepository.java
@@ -1,6 +1,7 @@
 package org.swyp.dessertbee.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -63,4 +64,11 @@ public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
      * ID 기반: 특정 사용자가 특정 사용자를 차단한 내역 조회
      */
     Optional<UserBlock> findByBlockerUserIdAndBlockedUserId(Long blockerUserId, Long blockedUserId);
+
+    /**
+     * ID 기반: 특정 사용자와 관련된 모든 차단 레코드 삭제 (blocker든 blocked든 상관없이)
+     */
+    @Modifying
+    @Query("DELETE FROM UserBlock ub WHERE ub.blockerUserId = :userId OR ub.blockedUserId = :userId")
+    int deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
@@ -281,15 +281,6 @@ public class UserServiceImpl implements UserService {
 
         UserEntity user = getCurrentUser();
 
-        // 특정 이메일인 경우 완전히 삭제 (캐스케이드 적용) // TODO : 기능 개발 마무리 후 삭제해야함
-        if ("kjkksu2@naver.com".equals(user.getEmail())) {
-            log.info("테스트 계정 감지: {} - 완전 삭제 수행", user.getEmail());
-            // CascadeType.ALL과 orphanRemoval=true로 인해 관련된 모든 데이터가 삭제됨
-            userRepository.delete(user);
-            log.info("테스트 계정 완전 삭제 완료: {}", user.getEmail());
-            return;
-        }
-
         user.softDelete();
         userRepository.save(user);
 

--- a/src/main/java/org/swyp/dessertbee/user/service/UserTestService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserTestService.java
@@ -1,0 +1,95 @@
+package org.swyp.dessertbee.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.store.saved.repository.UserStoreListRepository;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserRepository;
+import org.swyp.dessertbee.user.repository.UserBlockRepository;
+
+/**
+ * 사용자 테스트용 서비스
+ * 릴리즈 환경에서만 활성화되며, 사용자와 관련된 모든 데이터를 완전히 삭제하는 기능을 제공합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserTestService {
+
+    private final UserRepository userRepository;
+    private final UserBlockRepository userBlockRepository;
+    private final UserService userService;
+    private final UserStoreListRepository userStoreListRepository;
+
+    /**
+     * 현재 로그인한 사용자와 관련된 모든 데이터를 완전히 삭제합니다.
+     * JWT 토큰을 통해 현재 사용자를 식별합니다.
+     *
+     * @return 삭제된 사용자의 이메일
+     */
+    @Transactional
+    @PreAuthorize("hasRole('ADMIN')")
+    public String hardDeleteCurrentUserWithAllRelatedData() {
+        log.warn("현재 로그인 사용자 Hard Delete 시작");
+
+        // JWT 토큰에서 현재 사용자 조회
+        UserEntity currentUser = userService.getCurrentUser();
+        if (currentUser == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND,
+                    "현재 로그인한 사용자를 찾을 수 없습니다.");
+        }
+
+        String email = currentUser.getEmail();
+        performHardDeleteWithAllRelatedData(currentUser);
+
+        log.warn("현재 로그인 사용자 Hard Delete 완료 - email: {}", email);
+        return email;
+    }
+
+    /**
+     * 사용자와 관련된 모든 데이터를 순서대로 완전 삭제합니다.
+     *
+     * @param user 삭제할 사용자
+     */
+    private void performHardDeleteWithAllRelatedData(UserEntity user) {
+        Long userId = user.getId();
+        String email = user.getEmail();
+
+        try {
+            log.info("관련 데이터 정리 시작 - userId: {}, email: {}", userId, email);
+
+            // 사용자 차단 관련 데이터 삭제 (양방향 매핑이 아니라서 따로 삭제)
+            cleanupUserData(userId);
+
+            // 사용자 삭제 (CASCADE로 연관 데이터 자동 삭제)
+            userRepository.delete(user);
+
+            log.info("사용자 완전 삭제 완료 - userId: {}, email: {}", userId, email);
+
+        } catch (Exception e) {
+            log.error("사용자 완전 삭제 실패 - userId: {}, email: {}", userId, email, e);
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
+                    "사용자 삭제 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 사용자 차단 관련 데이터 정리
+     */
+    private void cleanupUserData(Long userId) {
+        try {
+            int deletedCount = userBlockRepository.deleteByUserId(userId);
+            deletedCount = deletedCount + userStoreListRepository.deleteByUserId(userId);
+            log.info("사용자 차단 데이터 정리 완료 - userId: {}, 삭제된 레코드: {} 개", userId, deletedCount);
+        } catch (Exception e) {
+            log.error("사용자 차단 데이터 정리 실패 - userId: {}", userId, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/org/swyp/dessertbee/user/service/UserTestService.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserTestService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.store.saved.repository.UserStoreListRepository;
+import org.swyp.dessertbee.store.saved.service.UserStoreService;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.user.repository.UserBlockRepository;
@@ -26,6 +27,7 @@ public class UserTestService {
     private final UserBlockRepository userBlockRepository;
     private final UserService userService;
     private final UserStoreListRepository userStoreListRepository;
+    private final UserStoreService userStoreService;
 
     /**
      * 현재 로그인한 사용자와 관련된 모든 데이터를 완전히 삭제합니다.
@@ -85,7 +87,7 @@ public class UserTestService {
     private void cleanupUserData(Long userId) {
         try {
             int deletedCount = userBlockRepository.deleteByUserId(userId);
-            deletedCount = deletedCount + userStoreListRepository.deleteByUserId(userId);
+            deletedCount = deletedCount + userStoreService.deleteAllUserStoreLists(userId);
             log.info("사용자 차단 데이터 정리 완료 - userId: {}, 삭제된 레코드: {} 개", userId, deletedCount);
         } catch (Exception e) {
             log.error("사용자 차단 데이터 정리 실패 - userId: {}", userId, e);


### PR DESCRIPTION
## :hash: 연관된 이슈
#471 

## :memo: 작업 내용

- 모든 사용자 계정을 Soft Delete로 통일
- 테스트용 Hard Delete는 별도 Admin API로 분리
- 외래키 참조 테이블 순차 정리 후 사용자 삭제
정리 순서:
1. user_block 테이블 정리
2. user_store_list 테이블 정리
3. 사용자 삭제 (CASCADE로 나머지 자동 정리)

### 스크린샷 (선택)
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/89df8f85-45fc-40d4-84e0-6545f568f553" />

## :speech_balloon: 리뷰 요구사항(선택)
예림님 특히 user_store_list 레코드 삭제 부분 자세히 봐주세요.
- user_id하고 단방향 매핑 관계라 이렇게 삭제하는 메서드 구현했습니다.
- 단일 레코드 삭제만 있어서 해당 user_id에 해당되는 레코드를 전체 삭제하는 레포지토리를 추가적으로 구현했습니다.