### PR TITLE
Feature/oauth auto account linking

### DIFF
--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -43,10 +43,10 @@ public class OAuthController {
             description = """
                     OAuth로 새로운 사용자 등록 및 로그인.
                     
-                    **웹 환경**: OAuth 인가 코드를 code 필드에 전송
-                    **앱 환경**: SDK에서 획득한 액세스 토큰을 code 필드에 전송하고 Platform-Type 헤더를 'app'으로 설정
+                    웹 환경: OAuth 인가 코드를 code 필드에 전송
+                    앱 환경: SDK에서 획득한 액세스 토큰을 code 필드에 전송하고 Platform-Type 헤더를 'app'으로 설정
                     
-                    **자동 계정 연결**: 동일한 이메일로 다른 OAuth 제공자에서 가입할 경우 자동으로 기존 계정에 연결됩니다.
+                    자동 계정 연결: 동일한 이메일로 다른 OAuth 제공자에서 가입할 경우 자동으로 기존 계정에 연결됩니다.
                     
                     앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.
                     """,

--- a/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
+++ b/src/main/java/org/swyp/dessertbee/auth/controller/OAuthController.java
@@ -18,6 +18,10 @@ import org.swyp.dessertbee.auth.service.OAuthService;
 import org.swyp.dessertbee.common.annotation.ApiErrorResponses;
 import org.swyp.dessertbee.common.exception.ErrorCode;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * OAuth 인증을 처리하는 컨트롤러
  * 프론트엔드에서 받은 인가 코드로 OAuth 인증 처리
@@ -41,6 +45,8 @@ public class OAuthController {
                     
                     **웹 환경**: OAuth 인가 코드를 code 필드에 전송
                     **앱 환경**: SDK에서 획득한 액세스 토큰을 code 필드에 전송하고 Platform-Type 헤더를 'app'으로 설정
+                    
+                    **자동 계정 연결**: 동일한 이메일로 다른 OAuth 제공자에서 가입할 경우 자동으로 기존 계정에 연결됩니다.
                     
                     앱에서는 X-Device-ID 헤더를, 웹에서는 deviceId 쿠키를 사용하여 디바이스를 식별합니다.
                     """,
@@ -132,5 +138,26 @@ public class OAuthController {
                 request.getUserInfo(), deviceId, isApp);
 
         return ResponseEntity.ok(loginResponse);
+    }
+
+    /**
+     * 사용자의 OAuth 제공자 정보 조회 (테스트용)
+     */
+    @Operation(
+            summary = "사용자 OAuth 제공자 정보 조회",
+            description = "특정 이메일로 가입된 OAuth 제공자 목록을 조회합니다. 자동 계정 연결로 인해 여러 제공자가 연결되어 있을 수 있습니다."
+    )
+    @ApiResponse(responseCode = "200", description = "OAuth 제공자 정보 조회 성공")
+    @GetMapping("/providers/{email}")
+    public ResponseEntity<Map<String, Object>> getOAuthProviders(@PathVariable String email) {
+        List<String> providers = oAuthService.getOAuthProvidersByEmail(email);
+        long providerCount = oAuthService.getOAuthProviderCount(email);
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("email", email);
+        response.put("providers", providers);
+        response.put("providerCount", providerCount);
+        
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/dto/response/LoginResponse.java
+++ b/src/main/java/org/swyp/dessertbee/auth/dto/response/LoginResponse.java
@@ -94,6 +94,22 @@ public class LoginResponse {
     private Boolean fromApp = false; // 앱에서 로그인 여부
 
     @Schema(
+            description = "OAuth 계정 자동 연결 발생 여부",
+            example = "true",
+            defaultValue = "false",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Builder.Default
+    private Boolean accountLinkingOccurred = false; // OAuth 계정 자동 연결 여부
+
+    @Schema(
+            description = "연결된 OAuth 제공자 목록",
+            example = "[\"apple\", \"kakao\"]",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private java.util.List<String> linkedProviders; // 연결된 OAuth 제공자 목록
+
+    @Schema(
             description = "이미지 관련 오류 메시지 (이미지 업로드 실패 시에만 존재)",
             implementation = ErrorResponse.class,
             nullable = true,
@@ -135,6 +151,41 @@ public class LoginResponse {
                 .deviceId(deviceId)
                 .isPreferenceSet(isPreferenceSet)
                 .fromApp(false)
+                .accountLinkingOccurred(false)
+                .build();
+    }
+
+    /**
+     * 로그인 성공 응답 생성 (계정 연결 정보 포함)
+     * @param accessToken JWT 액세스 토큰
+     * @param refreshToken JWT 리프레시 토큰
+     * @param expiresIn 액세스 토큰 만료 시간
+     * @param user 사용자 엔티티
+     * @param profileImageUrl 프로필 이미지 URL
+     * @param deviceId 디바이스 식별자
+     * @param isPreferenceSet 선호도 설정 여부
+     * @param accountLinkingOccurred 계정 연결 발생 여부
+     * @param linkedProviders 연결된 OAuth 제공자 목록
+     * @return 로그인 응답 객체
+     */
+    public static LoginResponse success(String accessToken, String refreshToken, long expiresIn, long refreshExpiresIn,
+                                        UserEntity user, String profileImageUrl, String deviceId, boolean isPreferenceSet,
+                                        boolean accountLinkingOccurred, java.util.List<String> linkedProviders) {
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .expiresIn(expiresIn)
+                .refreshExpiresIn(refreshExpiresIn)
+                .userUuid(user.getUserUuid())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .profileImageUrl(profileImageUrl)
+                .deviceId(deviceId)
+                .isPreferenceSet(isPreferenceSet)
+                .fromApp(false)
+                .accountLinkingOccurred(accountLinkingOccurred)
+                .linkedProviders(linkedProviders)
                 .build();
     }
 

--- a/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AppleOAuthService.java
@@ -31,7 +31,6 @@ import org.swyp.dessertbee.role.entity.RoleType;
 import org.swyp.dessertbee.role.repository.RoleRepository;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
-import org.swyp.dessertbee.auth.service.OAuthAccountLinkingService;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -95,7 +94,7 @@ public class AppleOAuthService {
      */
     @Transactional
     public LoginResponse processAppleLogin(String code, String idToken, String state, AppleUserInfo userInfo,
-                                           String deviceId, boolean isApp) {
+                                        String deviceId, boolean isApp) {
         try {
             log.info("애플 로그인 처리 시작 - 앱: {}, ID 토큰 존재 여부: {}, 코드 존재 여부: {}",
                     isApp, idToken != null, code != null);
@@ -398,15 +397,22 @@ public class AppleOAuthService {
             log.debug("새 디바이스 ID 생성: {}, 앱: {}", effectiveDeviceId, isApp);
         }
 
-        // OAuth 자동 계정 통합 서비스를 사용하여 사용자 조회 및 계정 연결
-        UserEntity user = oAuthAccountLinkingService.processOAuthUserLogin(oauth2Response, effectiveDeviceId, isApp);
+        // 1. OAuth 사용자 조회 (기존 사용자 또는 새로운 사용자)
+        UserEntity user = oAuthAccountLinkingService.findOrCreateUser(oauth2Response);
         
-        // 만약 새로운 사용자인 경우 회원가입 처리
+        // 2. 새로운 사용자인 경우 회원가입 처리
         if (user.getId() == null) {
             log.info("새로운 애플 사용자 회원가입 - 이메일: {}", oauth2Response.getEmail());
             user = registerNewUser(oauth2Response, isApp);
         } else {
-            log.info("기존 사용자 애플 로그인 성공 (자동 계정 연결 포함) - 사용자 ID: {}, 이메일: {}", user.getId(), user.getEmail());
+            // 3. 기존 사용자인 경우 계정 연결 필요 여부 확인 및 처리
+            log.info("기존 사용자 애플 로그인 - 사용자 ID: {}, 이메일: {}", user.getId(), user.getEmail());
+            
+            // 동일한 OAuth 제공자로 가입된 사용자가 아닌 경우 계정 연결 처리
+            if (!userRepository.findByEmailAndOAuthProvider(user.getEmail(), oauth2Response.getProvider()).isPresent()) {
+                log.info("기존 사용자에게 새로운 OAuth 제공자 연결 시작 - 이메일: {}, 제공자: {}", user.getEmail(), oauth2Response.getProvider());
+                user = oAuthAccountLinkingService.linkOAuthProviderToUser(user, oauth2Response, effectiveDeviceId, isApp);
+            }
         }
 
         List<String> roles = user.getUserRoles().stream()
@@ -436,12 +442,9 @@ public class AppleOAuthService {
 
         boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
 
-        // 계정 연결 정보 확인
-        boolean accountLinkingOccurred = oAuthAccountLinkingService.isAccountLinkingOccurred();
-        java.util.List<String> linkedProviders = oAuthAccountLinkingService.getUserOAuthProviders(user.getEmail());
-        
-        // 계정 연결 상태 초기화
-        oAuthAccountLinkingService.resetAccountLinkingStatus();
+        // 계정 연결 정보 확인 (Repository 직접 사용)
+        boolean accountLinkingOccurred = user.getAuthEntities().size() > 1; // 여러 OAuth 제공자 연결된 경우
+        java.util.List<String> linkedProviders = userRepository.findOAuthProvidersByEmail(user.getEmail());
 
         return LoginResponse.success(accessToken, refreshToken, expiresIn, refreshExpiresIn,
                 user, profileImageUrl, usedDeviceId, isPreferenceSet, accountLinkingOccurred, linkedProviders);

--- a/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/AuthServiceImpl.java
@@ -1,6 +1,5 @@
 package org.swyp.dessertbee.auth.service;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -25,7 +25,6 @@ import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.auth.exception.AuthExceptions.*;
 import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
-import org.swyp.dessertbee.auth.service.OAuthAccountLinkingService;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -156,15 +155,22 @@ public class KakaoOAuthService {
     private LoginResponse processUserLogin(OAuth2Response oauth2Response, String deviceId, boolean isApp) {
         log.info("카카오 OAuth 로그인 처리 시작 - 이메일: {}, 제공자: {}", oauth2Response.getEmail(), oauth2Response.getProvider());
         
-        // OAuth 자동 계정 통합 서비스를 사용하여 사용자 조회 및 계정 연결
-        UserEntity user = oAuthAccountLinkingService.processOAuthUserLogin(oauth2Response, deviceId, isApp);
+        // 1. OAuth 사용자 조회 (기존 사용자 또는 새로운 사용자)
+        UserEntity user = oAuthAccountLinkingService.findOrCreateUser(oauth2Response);
         
-        // 만약 새로운 사용자인 경우 회원가입 처리
+        // 2. 새로운 사용자인 경우 회원가입 처리
         if (user.getId() == null) {
             log.info("새로운 카카오 사용자 회원가입 - 이메일: {}", oauth2Response.getEmail());
             user = registerNewUser(oauth2Response);
         } else {
-            log.info("기존 사용자 카카오 로그인 성공 (자동 계정 연결 포함) - 사용자 ID: {}, 이메일: {}", user.getId(), user.getEmail());
+            // 3. 기존 사용자인 경우 계정 연결 필요 여부 확인 및 처리
+            log.info("기존 사용자 카카오 로그인 - 사용자 ID: {}, 이메일: {}", user.getId(), user.getEmail());
+            
+            // 동일한 OAuth 제공자로 가입된 사용자가 아닌 경우 계정 연결 처리
+            if (!userRepository.findByEmailAndOAuthProvider(user.getEmail(), oauth2Response.getProvider()).isPresent()) {
+                log.info("기존 사용자에게 새로운 OAuth 제공자 연결 시작 - 이메일: {}, 제공자: {}", user.getEmail(), oauth2Response.getProvider());
+                user = oAuthAccountLinkingService.linkOAuthProviderToUser(user, oauth2Response, deviceId, isApp);
+            }
         }
 
         // 정지 여부 확인
@@ -201,12 +207,9 @@ public class KakaoOAuthService {
 
         boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
         
-        // 계정 연결 정보 확인
-        boolean accountLinkingOccurred = oAuthAccountLinkingService.isAccountLinkingOccurred();
-        java.util.List<String> linkedProviders = oAuthAccountLinkingService.getUserOAuthProviders(user.getEmail());
-        
-        // 계정 연결 상태 초기화
-        oAuthAccountLinkingService.resetAccountLinkingStatus();
+        // 계정 연결 정보 확인 (Repository 직접 사용)
+        boolean accountLinkingOccurred = user.getAuthEntities().size() > 1; // 여러 OAuth 제공자 연결된 경우
+        java.util.List<String> linkedProviders = userRepository.findOAuthProvidersByEmail(user.getEmail());
         
         return LoginResponse.success(accessToken, refreshToken, expiresIn, refreshExpiresIn,
                 user, profileImageUrl, usedDeviceId, isPreferenceSet, accountLinkingOccurred, linkedProviders);

--- a/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/KakaoOAuthService.java
@@ -25,6 +25,7 @@ import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 import org.swyp.dessertbee.auth.exception.AuthExceptions.*;
 import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
+import org.swyp.dessertbee.auth.service.OAuthAccountLinkingService;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -44,6 +45,7 @@ public class KakaoOAuthService {
     private final ImageService imageService;
     private final RestTemplate restTemplate = new RestTemplate();
     private final PreferenceService preferenceService;
+    private final OAuthAccountLinkingService oAuthAccountLinkingService;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
@@ -149,12 +151,21 @@ public class KakaoOAuthService {
     }
 
     /**
-     * OAuth 사용자 정보로 로그인 처리 (회원가입 또는 로그인)
+     * OAuth 사용자 정보로 로그인 처리 (회원가입 또는 자동 계정 연결)
      */
     private LoginResponse processUserLogin(OAuth2Response oauth2Response, String deviceId, boolean isApp) {
-        // 이메일로 사용자 조회
-        UserEntity user = userRepository.findByEmail(oauth2Response.getEmail())
-                .orElseGet(() -> registerNewUser(oauth2Response));
+        log.info("카카오 OAuth 로그인 처리 시작 - 이메일: {}, 제공자: {}", oauth2Response.getEmail(), oauth2Response.getProvider());
+        
+        // OAuth 자동 계정 통합 서비스를 사용하여 사용자 조회 및 계정 연결
+        UserEntity user = oAuthAccountLinkingService.processOAuthUserLogin(oauth2Response, deviceId, isApp);
+        
+        // 만약 새로운 사용자인 경우 회원가입 처리
+        if (user.getId() == null) {
+            log.info("새로운 카카오 사용자 회원가입 - 이메일: {}", oauth2Response.getEmail());
+            user = registerNewUser(oauth2Response);
+        } else {
+            log.info("기존 사용자 카카오 로그인 성공 (자동 계정 연결 포함) - 사용자 ID: {}, 이메일: {}", user.getId(), user.getEmail());
+        }
 
         // 정지 여부 확인
         if (user.isSuspended()) {
@@ -189,8 +200,16 @@ public class KakaoOAuthService {
         String profileImageUrl = profileImages.isEmpty() ? null : profileImages.get(0);
 
         boolean isPreferenceSet = preferenceService.isUserPreferenceSet(user);
+        
+        // 계정 연결 정보 확인
+        boolean accountLinkingOccurred = oAuthAccountLinkingService.isAccountLinkingOccurred();
+        java.util.List<String> linkedProviders = oAuthAccountLinkingService.getUserOAuthProviders(user.getEmail());
+        
+        // 계정 연결 상태 초기화
+        oAuthAccountLinkingService.resetAccountLinkingStatus();
+        
         return LoginResponse.success(accessToken, refreshToken, expiresIn, refreshExpiresIn,
-                user, profileImageUrl, usedDeviceId, isPreferenceSet);
+                user, profileImageUrl, usedDeviceId, isPreferenceSet, accountLinkingOccurred, linkedProviders);
     }
 
     /**

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthAccountLinkingService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthAccountLinkingService.java
@@ -1,0 +1,177 @@
+package org.swyp.dessertbee.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.swyp.dessertbee.auth.entity.AuthEntity;
+import org.swyp.dessertbee.auth.oauth2.OAuth2Response;
+import org.swyp.dessertbee.auth.repository.AuthRepository;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.common.exception.ErrorCode;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.HashMap;
+
+/**
+ * OAuth 계정 통합을 처리하는 서비스
+ * 동일한 이메일로 다른 OAuth 제공자에서 가입할 때 계정을 연결하는 로직을 담당
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthAccountLinkingService {
+
+    private final UserRepository userRepository;
+    private final AuthRepository authRepository;
+
+    // 계정 연결 상태를 추적하기 위한 ThreadLocal 변수
+    private final ThreadLocal<Boolean> accountLinkingOccurred = ThreadLocal.withInitial(() -> false);
+
+    /**
+     * OAuth 로그인 시 기존 사용자 조회 및 자동 계정 통합 처리
+     *
+     * @param oauth2Response OAuth 응답 정보
+     * @param deviceId 디바이스 ID
+     * @param isApp 앱 환경 여부
+     * @return 기존 사용자 또는 새로 생성된 사용자
+     */
+    @Transactional
+    public UserEntity processOAuthUserLogin(OAuth2Response oauth2Response, String deviceId, boolean isApp) {
+        String email = oauth2Response.getEmail();
+        String provider = oauth2Response.getProvider();
+        String providerId = oauth2Response.getProviderId();
+
+        log.info("OAuth 자동 계정 통합 처리 시작 - 이메일: {}, 제공자: {}", email, provider);
+
+        // 1. 동일한 OAuth 제공자로 가입된 사용자 조회
+        Optional<UserEntity> existingUserWithSameProvider = userRepository.findByEmailAndOAuthProvider(email, provider);
+        if (existingUserWithSameProvider.isPresent()) {
+            log.info("동일한 OAuth 제공자로 가입된 사용자 발견 - 이메일: {}, 제공자: {}", email, provider);
+            return existingUserWithSameProvider.get();
+        }
+
+        // 2. 이메일로 기존 사용자 조회 (다른 OAuth 제공자 또는 일반 가입)
+        Optional<UserEntity> existingUser = userRepository.findByEmail(email);
+        if (existingUser.isPresent()) {
+            UserEntity user = existingUser.get();
+            List<String> existingProviders = userRepository.findOAuthProvidersByEmail(email);
+            
+            log.info("동일한 이메일로 가입된 기존 사용자 발견 - 자동 계정 연결 시작 - 이메일: {}, 기존 제공자들: {}, 새로운 제공자: {}", 
+                    email, existingProviders, provider);
+
+            // 3. 자동으로 기존 사용자에게 새로운 OAuth 제공자 연결
+            try {
+                UserEntity linkedUser = linkOAuthProviderToExistingUser(user, provider, providerId, deviceId, isApp);
+                log.info("OAuth 계정 자동 연결 완료 - 사용자 ID: {}, 이메일: {}, 연결된 제공자: {}", 
+                        linkedUser.getId(), email, provider);
+                
+                return linkedUser;
+            } catch (Exception e) {
+                log.error("OAuth 계정 자동 연결 실패 - 이메일: {}, 제공자: {}, 오류: {}", email, provider, e.getMessage());
+                throw new BusinessException(ErrorCode.OAUTH_ACCOUNT_LINKING_FAILED, 
+                        "동일한 이메일로 가입된 계정과 자동 연결에 실패했습니다.");
+            }
+        }
+
+        // 4. 새로운 사용자 생성이 필요한 경우 (ID가 null인 UserEntity 반환)
+        log.info("새로운 사용자 생성 필요 - 이메일: {}, 제공자: {}", email, provider);
+        return UserEntity.builder()
+                .email(email)
+                .nickname(oauth2Response.getNickname())
+                .build();
+    }
+
+    /**
+     * 기존 사용자에게 새로운 OAuth 제공자 자동 연결
+     */
+    private UserEntity linkOAuthProviderToExistingUser(UserEntity user, String provider, String providerId, 
+                                                      String deviceId, boolean isApp) {
+        log.info("기존 사용자에게 OAuth 제공자 자동 연결 시작 - 사용자 ID: {}, 제공자: {}", user.getId(), provider);
+
+        // 이미 해당 제공자로 연결되어 있는지 확인
+        Optional<AuthEntity> existingAuth = authRepository.findByProviderAndProviderId(provider, providerId);
+        if (existingAuth.isPresent()) {
+            log.info("이미 해당 OAuth 제공자로 연결된 계정 존재 - 제공자: {}, 제공자 ID: {}", provider, providerId);
+            return user;
+        }
+
+        // 사용자가 이미 해당 제공자로 가입되어 있는지 확인
+        boolean alreadyHasProvider = user.getAuthEntities().stream()
+                .anyMatch(auth -> auth.getProvider().equals(provider));
+        if (alreadyHasProvider) {
+            log.info("사용자가 이미 해당 OAuth 제공자로 가입되어 있음 - 사용자 ID: {}, 제공자: {}", user.getId(), provider);
+            return user;
+        }
+
+        // 기존 사용자에게 새로운 OAuth 제공자 자동 연결
+        AuthEntity newAuth = AuthEntity.builder()
+                .user(user)
+                .provider(provider)
+                .providerId(providerId)
+                .deviceId(deviceId)
+                .active(true)
+                .build();
+
+        authRepository.save(newAuth);
+        user.getAuthEntities().add(newAuth);
+
+        // 새로운 OAuth 제공자가 실제로 연결되었을 때만 계정 연결 상태를 true로 설정
+        accountLinkingOccurred.set(true);
+
+        log.info("OAuth 제공자 자동 연결 완료 - 사용자 ID: {}, 제공자: {}", user.getId(), provider);
+        return user;
+    }
+
+    /**
+     * 사용자의 OAuth 제공자 목록 조회
+     */
+    public List<String> getUserOAuthProviders(String email) {
+        return userRepository.findOAuthProvidersByEmail(email);
+    }
+
+    /**
+     * 사용자가 특정 OAuth 제공자로 가입했는지 확인
+     */
+    public boolean hasOAuthProvider(String email, String provider) {
+        return userRepository.findByEmailAndOAuthProvider(email, provider).isPresent();
+    }
+
+    /**
+     * 사용자의 OAuth 계정 수 조회
+     */
+    public long getOAuthProviderCount(String email) {
+        return userRepository.countOAuthProvidersByEmail(email);
+    }
+
+    /**
+     * 현재 요청에서 계정 연결이 발생했는지 확인
+     */
+    public boolean isAccountLinkingOccurred() {
+        return accountLinkingOccurred.get();
+    }
+
+    /**
+     * 계정 연결 상태 초기화 (요청 처리 완료 후 호출)
+     */
+    public void resetAccountLinkingStatus() {
+        accountLinkingOccurred.set(false);
+    }
+
+    /**
+     * 계정 연결 정보 조회
+     */
+    public Map<String, Object> getAccountLinkingInfo(String email) {
+        Map<String, Object> info = new HashMap<>();
+        info.put("email", email);
+        info.put("providers", getUserOAuthProviders(email));
+        info.put("providerCount", getOAuthProviderCount(email));
+        info.put("hasMultipleProviders", getOAuthProviderCount(email) > 1);
+        return info;
+    }
+} 

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthAccountLinkingService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthAccountLinkingService.java
@@ -12,42 +12,49 @@ import org.swyp.dessertbee.common.exception.ErrorCode;
 import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.HashMap;
 
 /**
  * OAuth 계정 통합을 처리하는 서비스
  * 동일한 이메일로 다른 OAuth 제공자에서 가입할 때 계정을 연결하는 로직을 담당
  */
+public interface OAuthAccountLinkingService {
+    
+    /**
+     * OAuth 로그인 시 기존 사용자 조회
+     *
+     * @param oauth2Response OAuth 응답 정보
+     * @return 사용자 엔티티 (새로운 사용자인 경우 ID가 null)
+     */
+    UserEntity findOrCreateUser(OAuth2Response oauth2Response);
+
+    /**
+     * 기존 사용자에게 새로운 OAuth 제공자 연결
+     *
+     * @param user 기존 사용자
+     * @param oauth2Response OAuth 응답 정보
+     * @param deviceId 디바이스 ID
+     * @param isApp 앱 환경 여부
+     * @return 연결된 사용자 엔티티
+     */
+    UserEntity linkOAuthProviderToUser(UserEntity user, OAuth2Response oauth2Response, String deviceId, boolean isApp);
+}
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class OAuthAccountLinkingService {
+class OAuthAccountLinkingServiceImpl implements OAuthAccountLinkingService {
 
     private final UserRepository userRepository;
     private final AuthRepository authRepository;
 
-    // 계정 연결 상태를 추적하기 위한 ThreadLocal 변수
-    private final ThreadLocal<Boolean> accountLinkingOccurred = ThreadLocal.withInitial(() -> false);
-
-    /**
-     * OAuth 로그인 시 기존 사용자 조회 및 자동 계정 통합 처리
-     *
-     * @param oauth2Response OAuth 응답 정보
-     * @param deviceId 디바이스 ID
-     * @param isApp 앱 환경 여부
-     * @return 기존 사용자 또는 새로 생성된 사용자
-     */
-    @Transactional
-    public UserEntity processOAuthUserLogin(OAuth2Response oauth2Response, String deviceId, boolean isApp) {
+    @Override
+    @Transactional(readOnly = true)
+    public UserEntity findOrCreateUser(OAuth2Response oauth2Response) {
         String email = oauth2Response.getEmail();
         String provider = oauth2Response.getProvider();
-        String providerId = oauth2Response.getProviderId();
 
-        log.info("OAuth 자동 계정 통합 처리 시작 - 이메일: {}, 제공자: {}", email, provider);
+        log.info("OAuth 사용자 조회 시작 - 이메일: {}, 제공자: {}", email, provider);
 
         // 1. 동일한 OAuth 제공자로 가입된 사용자 조회
         Optional<UserEntity> existingUserWithSameProvider = userRepository.findByEmailAndOAuthProvider(email, provider);
@@ -59,27 +66,11 @@ public class OAuthAccountLinkingService {
         // 2. 이메일로 기존 사용자 조회 (다른 OAuth 제공자 또는 일반 가입)
         Optional<UserEntity> existingUser = userRepository.findByEmail(email);
         if (existingUser.isPresent()) {
-            UserEntity user = existingUser.get();
-            List<String> existingProviders = userRepository.findOAuthProvidersByEmail(email);
-            
-            log.info("동일한 이메일로 가입된 기존 사용자 발견 - 자동 계정 연결 시작 - 이메일: {}, 기존 제공자들: {}, 새로운 제공자: {}", 
-                    email, existingProviders, provider);
-
-            // 3. 자동으로 기존 사용자에게 새로운 OAuth 제공자 연결
-            try {
-                UserEntity linkedUser = linkOAuthProviderToExistingUser(user, provider, providerId, deviceId, isApp);
-                log.info("OAuth 계정 자동 연결 완료 - 사용자 ID: {}, 이메일: {}, 연결된 제공자: {}", 
-                        linkedUser.getId(), email, provider);
-                
-                return linkedUser;
-            } catch (Exception e) {
-                log.error("OAuth 계정 자동 연결 실패 - 이메일: {}, 제공자: {}, 오류: {}", email, provider, e.getMessage());
-                throw new BusinessException(ErrorCode.OAUTH_ACCOUNT_LINKING_FAILED, 
-                        "동일한 이메일로 가입된 계정과 자동 연결에 실패했습니다.");
-            }
+            log.info("동일한 이메일로 가입된 기존 사용자 발견 - 이메일: {}, 제공자: {}", email, provider);
+            return existingUser.get();
         }
 
-        // 4. 새로운 사용자 생성이 필요한 경우 (ID가 null인 UserEntity 반환)
+        // 3. 새로운 사용자 생성이 필요한 경우
         log.info("새로운 사용자 생성 필요 - 이메일: {}, 제공자: {}", email, provider);
         return UserEntity.builder()
                 .email(email)
@@ -87,11 +78,12 @@ public class OAuthAccountLinkingService {
                 .build();
     }
 
-    /**
-     * 기존 사용자에게 새로운 OAuth 제공자 자동 연결
-     */
-    private UserEntity linkOAuthProviderToExistingUser(UserEntity user, String provider, String providerId, 
-                                                      String deviceId, boolean isApp) {
+    @Override
+    @Transactional
+    public UserEntity linkOAuthProviderToUser(UserEntity user, OAuth2Response oauth2Response, String deviceId, boolean isApp) {
+        String provider = oauth2Response.getProvider();
+        String providerId = oauth2Response.getProviderId();
+
         log.info("기존 사용자에게 OAuth 제공자 자동 연결 시작 - 사용자 ID: {}, 제공자: {}", user.getId(), provider);
 
         // 이미 해당 제공자로 연결되어 있는지 확인
@@ -121,57 +113,7 @@ public class OAuthAccountLinkingService {
         authRepository.save(newAuth);
         user.getAuthEntities().add(newAuth);
 
-        // 새로운 OAuth 제공자가 실제로 연결되었을 때만 계정 연결 상태를 true로 설정
-        accountLinkingOccurred.set(true);
-
         log.info("OAuth 제공자 자동 연결 완료 - 사용자 ID: {}, 제공자: {}", user.getId(), provider);
         return user;
-    }
-
-    /**
-     * 사용자의 OAuth 제공자 목록 조회
-     */
-    public List<String> getUserOAuthProviders(String email) {
-        return userRepository.findOAuthProvidersByEmail(email);
-    }
-
-    /**
-     * 사용자가 특정 OAuth 제공자로 가입했는지 확인
-     */
-    public boolean hasOAuthProvider(String email, String provider) {
-        return userRepository.findByEmailAndOAuthProvider(email, provider).isPresent();
-    }
-
-    /**
-     * 사용자의 OAuth 계정 수 조회
-     */
-    public long getOAuthProviderCount(String email) {
-        return userRepository.countOAuthProvidersByEmail(email);
-    }
-
-    /**
-     * 현재 요청에서 계정 연결이 발생했는지 확인
-     */
-    public boolean isAccountLinkingOccurred() {
-        return accountLinkingOccurred.get();
-    }
-
-    /**
-     * 계정 연결 상태 초기화 (요청 처리 완료 후 호출)
-     */
-    public void resetAccountLinkingStatus() {
-        accountLinkingOccurred.set(false);
-    }
-
-    /**
-     * 계정 연결 정보 조회
-     */
-    public Map<String, Object> getAccountLinkingInfo(String email) {
-        Map<String, Object> info = new HashMap<>();
-        info.put("email", email);
-        info.put("providers", getUserOAuthProviders(email));
-        info.put("providerCount", getOAuthProviderCount(email));
-        info.put("hasMultipleProviders", getOAuthProviderCount(email) > 1);
-        return info;
     }
 } 

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -9,6 +9,7 @@ import org.swyp.dessertbee.auth.dto.response.LoginResponse;
 import org.swyp.dessertbee.auth.enums.AuthProvider;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
+import java.util.List;
 
 /**
  * OAuth 인증 처리를 담당하는 공통 서비스
@@ -20,6 +21,7 @@ public class OAuthService {
 
     private final KakaoOAuthService kakaoOAuthService;
     private final AppleOAuthService appleOAuthService;
+    private final OAuthAccountLinkingService oAuthAccountLinkingService;
 
     /**
      * OAuth 로그인 처리 (웹: 인가 코드, 앱: 액세스 토큰)
@@ -110,5 +112,19 @@ public class OAuthService {
             log.error("Apple 로그인 처리 중 오류 발생 - 플랫폼: {}", isApp ? "APP" : "WEB", e);
             throw new OAuthAuthenticationException("Apple 로그인 처리 중 오류가 발생했습니다.");
         }
+    }
+
+    /**
+     * 사용자의 OAuth 제공자 목록 조회
+     */
+    public List<String> getOAuthProvidersByEmail(String email) {
+        return oAuthAccountLinkingService.getUserOAuthProviders(email);
+    }
+
+    /**
+     * 사용자의 OAuth 계정 수 조회
+     */
+    public long getOAuthProviderCount(String email) {
+        return oAuthAccountLinkingService.getOAuthProviderCount(email);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
+++ b/src/main/java/org/swyp/dessertbee/auth/service/OAuthService.java
@@ -9,6 +9,7 @@ import org.swyp.dessertbee.auth.dto.response.LoginResponse;
 import org.swyp.dessertbee.auth.enums.AuthProvider;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.auth.exception.OAuthExceptions.*;
+import org.swyp.dessertbee.user.repository.UserRepository;
 import java.util.List;
 
 /**
@@ -22,6 +23,7 @@ public class OAuthService {
     private final KakaoOAuthService kakaoOAuthService;
     private final AppleOAuthService appleOAuthService;
     private final OAuthAccountLinkingService oAuthAccountLinkingService;
+    private final UserRepository userRepository;
 
     /**
      * OAuth 로그인 처리 (웹: 인가 코드, 앱: 액세스 토큰)
@@ -118,13 +120,13 @@ public class OAuthService {
      * 사용자의 OAuth 제공자 목록 조회
      */
     public List<String> getOAuthProvidersByEmail(String email) {
-        return oAuthAccountLinkingService.getUserOAuthProviders(email);
+        return userRepository.findOAuthProvidersByEmail(email);
     }
 
     /**
      * 사용자의 OAuth 계정 수 조회
      */
     public long getOAuthProviderCount(String email) {
-        return oAuthAccountLinkingService.getOAuthProviderCount(email);
+        return userRepository.countOAuthProvidersByEmail(email);
     }
 }

--- a/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
+++ b/src/main/java/org/swyp/dessertbee/common/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
 
     // OAuth
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "O001", "지원되지 않는 OAuth 제공자입니다."),
-
+    OAUTH_ACCOUNT_LINKING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "O002", "OAuth 계정 연결에 실패했습니다."),
 
     // JWT
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "J001", "유효하지 않은 JWT 서명입니다."),

--- a/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
+++ b/src/main/java/org/swyp/dessertbee/user/entity/UserEntity.java
@@ -83,7 +83,7 @@ public class UserEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<AuthEntity> auths = new ArrayList<>();
+    private List<AuthEntity> authEntities = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
+++ b/src/main/java/org/swyp/dessertbee/user/repository/UserRepository.java
@@ -80,4 +80,41 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     @Query("SELECT u FROM UserEntity u WHERE u.id = :userId") // deletedAt 조건 없음
     Optional<UserEntity> findByIdIncludingDeleted(@Param("userId") Long userId);
+
+    /**
+     * 이메일과 OAuth 제공자로 사용자 조회 (auth 테이블과 조인)
+     * 특정 OAuth 제공자로 가입한 사용자를 찾을 때 사용
+     *
+     * @param email 사용자 이메일
+     * @param provider OAuth 제공자 (apple, kakao 등)
+     * @return UserEntity
+     */
+    @Query("SELECT u FROM UserEntity u " +
+           "JOIN u.authEntities a " +
+           "WHERE u.email = :email AND a.provider = :provider AND u.deletedAt IS NULL")
+    Optional<UserEntity> findByEmailAndOAuthProvider(@Param("email") String email, @Param("provider") String provider);
+
+    /**
+     * 이메일로 가입된 모든 OAuth 제공자 조회
+     * 사용자가 어떤 OAuth 제공자로 가입했는지 확인할 때 사용
+     *
+     * @param email 사용자 이메일
+     * @return OAuth 제공자 목록
+     */
+    @Query("SELECT DISTINCT a.provider FROM UserEntity u " +
+           "JOIN u.authEntities a " +
+           "WHERE u.email = :email AND u.deletedAt IS NULL")
+    List<String> findOAuthProvidersByEmail(@Param("email") String email);
+
+    /**
+     * 이메일로 가입된 OAuth 계정 수 조회
+     * 사용자가 여러 OAuth 제공자로 가입했는지 확인할 때 사용
+     *
+     * @param email 사용자 이메일
+     * @return OAuth 계정 수
+     */
+    @Query("SELECT COUNT(DISTINCT a.provider) FROM UserEntity u " +
+           "JOIN u.authEntities a " +
+           "WHERE u.email = :email AND u.deletedAt IS NULL")
+    long countOAuthProvidersByEmail(@Param("email") String email);
 }

--- a/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.swyp.dessertbee.auth.entity.AuthEntity;
-import org.swyp.dessertbee.auth.repository.AuthRepository;
 import org.swyp.dessertbee.common.entity.ImageType;
 import org.swyp.dessertbee.common.exception.BusinessException;
 import org.swyp.dessertbee.common.exception.ErrorCode;
@@ -25,7 +24,6 @@ import org.swyp.dessertbee.user.entity.UserEntity;
 import org.swyp.dessertbee.user.repository.MbtiRepository;
 import org.swyp.dessertbee.user.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.*;
 
 /**

--- a/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
+++ b/src/main/java/org/swyp/dessertbee/user/service/UserServiceImpl.java
@@ -285,7 +285,7 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
 
         // 연관된 인증 정보도 비활성화
-        user.getAuths().forEach(AuthEntity::deactivate);
+        user.getAuthEntities().forEach(AuthEntity::deactivate);
 
         log.info("해당 유저의 계정이 비활성화 처리 되었습니다 : {}", user.getEmail());
     }

--- a/src/test/java/org/swyp/dessertbee/auth/service/OAuthAccountLinkingServiceTest.java
+++ b/src/test/java/org/swyp/dessertbee/auth/service/OAuthAccountLinkingServiceTest.java
@@ -1,0 +1,337 @@
+package org.swyp.dessertbee.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.swyp.dessertbee.auth.entity.AuthEntity;
+import org.swyp.dessertbee.auth.oauth2.OAuth2Response;
+import org.swyp.dessertbee.auth.repository.AuthRepository;
+import org.swyp.dessertbee.common.exception.BusinessException;
+import org.swyp.dessertbee.user.entity.UserEntity;
+import org.swyp.dessertbee.user.repository.UserRepository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * OAuthAccountLinkingService 단위 테스트
+ * 자동 계정 연결 기능을 테스트합니다.
+ */
+@ExtendWith(MockitoExtension.class)
+class OAuthAccountLinkingServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AuthRepository authRepository;
+
+    @InjectMocks
+    private OAuthAccountLinkingService oAuthAccountLinkingService;
+
+    private UserEntity existingUser;
+    private OAuth2Response appleOAuthResponse;
+    private OAuth2Response kakaoOAuthResponse;
+    private AuthEntity appleAuth;
+
+    @BeforeEach
+    void setUp() {
+        // 기존 사용자 설정 (Apple로 가입된 사용자)
+        existingUser = UserEntity.builder()
+                .id(1L)
+                .userUuid(UUID.randomUUID())
+                .email("test@example.com")
+                .nickname("테스트사용자")
+                .build();
+
+        // Apple OAuth 응답
+        appleOAuthResponse = new OAuth2Response() {
+            @Override
+            public String getProvider() {
+                return "apple";
+            }
+
+            @Override
+            public String getProviderId() {
+                return "apple_123456";
+            }
+
+            @Override
+            public String getEmail() {
+                return "test@example.com";
+            }
+
+            @Override
+            public String getNickname() {
+                return "테스트사용자";
+            }
+
+            @Override
+            public String getImageUrl() {
+                return null;
+            }
+        };
+
+        // Kakao OAuth 응답
+        kakaoOAuthResponse = new OAuth2Response() {
+            @Override
+            public String getProvider() {
+                return "kakao";
+            }
+
+            @Override
+            public String getProviderId() {
+                return "kakao_789012";
+            }
+
+            @Override
+            public String getEmail() {
+                return "test@example.com";
+            }
+
+            @Override
+            public String getNickname() {
+                return "테스트사용자";
+            }
+
+            @Override
+            public String getImageUrl() {
+                return null;
+            }
+        };
+
+        // Apple Auth 엔티티
+        appleAuth = AuthEntity.builder()
+                .id(1)
+                .user(existingUser)
+                .provider("apple")
+                .providerId("apple_123456")
+                .deviceId("device_apple")
+                .active(true)
+                .build();
+
+        existingUser.getAuthEntities().add(appleAuth);
+    }
+
+    @Test
+    @DisplayName("동일한 OAuth 제공자로 가입된 사용자 발견 시 기존 사용자 반환")
+    void shouldReturnExistingUserWhenSameProviderExists() {
+        // given
+        when(userRepository.findByEmailAndOAuthProvider("test@example.com", "apple"))
+                .thenReturn(Optional.of(existingUser));
+
+        // when
+        UserEntity result = oAuthAccountLinkingService.processOAuthUserLogin(appleOAuthResponse, "device_apple", true);
+
+        // then
+        assertThat(result).isEqualTo(existingUser);
+        assertThat(result.getId()).isEqualTo(1L);
+        verify(userRepository, times(1)).findByEmailAndOAuthProvider("test@example.com", "apple");
+        verify(userRepository, never()).findByEmail(anyString());
+        verify(authRepository, never()).save(any(AuthEntity.class));
+    }
+
+    @Test
+    @DisplayName("동일한 이메일로 다른 OAuth 제공자 가입 시 자동 계정 연결")
+    void shouldAutomaticallyLinkAccountWhenDifferentProviderExists() {
+        // given
+        when(userRepository.findByEmailAndOAuthProvider("test@example.com", "kakao"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail("test@example.com"))
+                .thenReturn(Optional.of(existingUser));
+        when(userRepository.findOAuthProvidersByEmail("test@example.com"))
+                .thenReturn(Arrays.asList("apple"));
+        when(authRepository.findByProviderAndProviderId("kakao", "kakao_789012"))
+                .thenReturn(Optional.empty());
+        when(authRepository.save(any(AuthEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        UserEntity result = oAuthAccountLinkingService.processOAuthUserLogin(kakaoOAuthResponse, "device_kakao", true);
+
+        // then
+        assertThat(result).isEqualTo(existingUser);
+        assertThat(result.getAuthEntities()).hasSize(2);
+        assertThat(result.getAuthEntities()).anyMatch(auth -> 
+                auth.getProvider().equals("apple") && auth.getProviderId().equals("apple_123456"));
+        assertThat(result.getAuthEntities()).anyMatch(auth -> 
+                auth.getProvider().equals("kakao") && auth.getProviderId().equals("kakao_789012"));
+        
+        verify(authRepository, times(1)).save(any(AuthEntity.class));
+        assertThat(oAuthAccountLinkingService.isAccountLinkingOccurred()).isTrue();
+    }
+
+    @Test
+    @DisplayName("새로운 사용자 가입 시 ID가 null인 UserEntity 반환")
+    void shouldReturnNewUserWhenNoExistingUserFound() {
+        // given
+        when(userRepository.findByEmailAndOAuthProvider("new@example.com", "apple"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail("new@example.com"))
+                .thenReturn(Optional.empty());
+
+        OAuth2Response newUserOAuthResponse = new OAuth2Response() {
+            @Override
+            public String getProvider() {
+                return "apple";
+            }
+
+            @Override
+            public String getProviderId() {
+                return "apple_new";
+            }
+
+            @Override
+            public String getEmail() {
+                return "new@example.com";
+            }
+
+            @Override
+            public String getNickname() {
+                return "새사용자";
+            }
+
+            @Override
+            public String getImageUrl() {
+                return null;
+            }
+        };
+
+        // when
+        UserEntity result = oAuthAccountLinkingService.processOAuthUserLogin(newUserOAuthResponse, "device_new", true);
+
+        // then
+        assertThat(result.getId()).isNull();
+        assertThat(result.getEmail()).isEqualTo("new@example.com");
+        assertThat(result.getNickname()).isEqualTo("새사용자");
+        verify(authRepository, never()).save(any(AuthEntity.class));
+        assertThat(oAuthAccountLinkingService.isAccountLinkingOccurred()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미 연결된 OAuth 제공자인 경우 중복 연결 방지")
+    void shouldPreventDuplicateLinkingWhenProviderAlreadyExists() {
+        // given
+        when(userRepository.findByEmailAndOAuthProvider("test@example.com", "apple"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail("test@example.com"))
+                .thenReturn(Optional.of(existingUser));
+        when(userRepository.findOAuthProvidersByEmail("test@example.com"))
+                .thenReturn(Arrays.asList("apple"));
+
+        // when
+        UserEntity result = oAuthAccountLinkingService.processOAuthUserLogin(appleOAuthResponse, "device_apple", true);
+
+        // then
+        assertThat(result).isEqualTo(existingUser);
+        assertThat(result.getAuthEntities()).hasSize(1); // 기존 Apple 계정만 존재
+        verify(authRepository, never()).save(any(AuthEntity.class));
+        assertThat(oAuthAccountLinkingService.isAccountLinkingOccurred()).isFalse();
+    }
+
+    @Test
+    @DisplayName("계정 연결 실패 시 예외 발생")
+    void shouldThrowExceptionWhenAccountLinkingFails() {
+        // given
+        when(userRepository.findByEmailAndOAuthProvider("test@example.com", "kakao"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail("test@example.com"))
+                .thenReturn(Optional.of(existingUser));
+        when(userRepository.findOAuthProvidersByEmail("test@example.com"))
+                .thenReturn(Arrays.asList("apple"));
+        when(authRepository.findByProviderAndProviderId("kakao", "kakao_789012"))
+                .thenReturn(Optional.empty());
+        when(authRepository.save(any(AuthEntity.class)))
+                .thenThrow(new RuntimeException("Database error"));
+
+        // when & then
+        assertThatThrownBy(() -> 
+                oAuthAccountLinkingService.processOAuthUserLogin(kakaoOAuthResponse, "device_kakao", true))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", org.swyp.dessertbee.common.exception.ErrorCode.OAUTH_ACCOUNT_LINKING_FAILED);
+    }
+
+    @Test
+    @DisplayName("사용자의 OAuth 제공자 목록 조회")
+    void shouldGetUserOAuthProviders() {
+        // given
+        when(userRepository.findOAuthProvidersByEmail("test@example.com"))
+                .thenReturn(Arrays.asList("apple", "kakao"));
+
+        // when
+        List<String> providers = oAuthAccountLinkingService.getUserOAuthProviders("test@example.com");
+
+        // then
+        assertThat(providers).containsExactly("apple", "kakao");
+    }
+
+    @Test
+    @DisplayName("사용자의 OAuth 계정 수 조회")
+    void shouldGetOAuthProviderCount() {
+        // given
+        when(userRepository.countOAuthProvidersByEmail("test@example.com"))
+                .thenReturn(2L);
+
+        // when
+        long count = oAuthAccountLinkingService.getOAuthProviderCount("test@example.com");
+
+        // then
+        assertThat(count).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("계정 연결 상태 초기화")
+    void shouldResetAccountLinkingStatus() {
+        // given
+        when(userRepository.findByEmailAndOAuthProvider("test@example.com", "kakao"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail("test@example.com"))
+                .thenReturn(Optional.of(existingUser));
+        when(userRepository.findOAuthProvidersByEmail("test@example.com"))
+                .thenReturn(Arrays.asList("apple"));
+        when(authRepository.findByProviderAndProviderId("kakao", "kakao_789012"))
+                .thenReturn(Optional.empty());
+        when(authRepository.save(any(AuthEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        oAuthAccountLinkingService.processOAuthUserLogin(kakaoOAuthResponse, "device_kakao", true);
+        assertThat(oAuthAccountLinkingService.isAccountLinkingOccurred()).isTrue();
+        
+        oAuthAccountLinkingService.resetAccountLinkingStatus();
+        
+        // then
+        assertThat(oAuthAccountLinkingService.isAccountLinkingOccurred()).isFalse();
+    }
+
+    @Test
+    @DisplayName("계정 연결 정보 조회")
+    void shouldGetAccountLinkingInfo() {
+        // given
+        when(userRepository.findOAuthProvidersByEmail("test@example.com"))
+                .thenReturn(Arrays.asList("apple", "kakao"));
+        when(userRepository.countOAuthProvidersByEmail("test@example.com"))
+                .thenReturn(2L);
+
+        // when
+        var info = oAuthAccountLinkingService.getAccountLinkingInfo("test@example.com");
+
+        // then
+        assertThat(info.get("email")).isEqualTo("test@example.com");
+        assertThat((List<String>) info.get("providers")).containsExactly("apple", "kakao");
+        assertThat(info.get("providerCount")).isEqualTo(2L);
+        assertThat(info.get("hasMultipleProviders")).isEqualTo(true);
+    }
+} 


### PR DESCRIPTION
## :hash: 연관된 이슈
#482

## :memo: 작업 내용
동일한 이메일로 Apple과 Kakao 등 여러 OAuth 제공자에 가입할 때 발생하는 중복 이메일 제약조건 위반 문제를 해결하기 위해 자동 계정 연결 기능을 구현

동일 이메일로 여러 OAuth 제공자 가입 시 자동 계정 통합 처리합니다.
